### PR TITLE
Add C# BGInfo generator and cmdlets

### DIFF
--- a/Examples/Run.BGInfo1.ps1
+++ b/Examples/Run.BGInfo1.ps1
@@ -1,3 +1,5 @@
+# Example using compiled cmdlets
+
 Clear-Host
 
 Import-Module $PSScriptRoot\..\PowerBGInfo.psd1 -Force

--- a/Examples/Run.BGInfo2.ps1
+++ b/Examples/Run.BGInfo2.ps1
@@ -1,3 +1,5 @@
+# Example using compiled cmdlets
+
 ﻿Import-Module .\PowerBGInfo.psd1 -Force
 
 New-BGInfo -MonitorIndex 0 {

--- a/Examples/Run.BGInfo3.ps1
+++ b/Examples/Run.BGInfo3.ps1
@@ -1,3 +1,5 @@
+# Example using compiled cmdlets
+
 ﻿Import-Module .\PowerBGInfo.psd1 -Force
 
 New-BGInfo -MonitorIndex 0 {

--- a/Sources/PowerBGInfo.PowerShell/Class1.cs
+++ b/Sources/PowerBGInfo.PowerShell/Class1.cs
@@ -1,5 +1,0 @@
-﻿namespace PowerBGInfo.PowerShell {
-    public class Class1 {
-
-    }
-}

--- a/Sources/PowerBGInfo.PowerShell/NewBGInfoCmdlets.cs
+++ b/Sources/PowerBGInfo.PowerShell/NewBGInfoCmdlets.cs
@@ -1,0 +1,205 @@
+using System.Management.Automation;
+using DesktopManager;
+using ImagePlayground;
+using SixLabors.ImageSharp;
+using PowerBGInfo;
+
+namespace PowerBGInfo.PowerShell;
+
+[Cmdlet(VerbsCommon.New, "BGInfo")]
+[OutputType(typeof(string))]
+public class NewBGInfoCommand : PSCmdlet
+{
+    [Parameter(Mandatory = true)]
+    public ScriptBlock BGInfoContent { get; set; } = null!;
+
+    [Parameter]
+    public string FilePath { get; set; } = string.Empty;
+
+    [Parameter(Mandatory = true)]
+    public string ConfigurationDirectory { get; set; } = string.Empty;
+
+    [Parameter]
+    public string FontFamilyName { get; set; } = "Calibri";
+
+    [Parameter]
+    public Color Color { get; set; } = Color.Black;
+
+    [Parameter]
+    public int FontSize { get; set; } = 16;
+
+    [Parameter]
+    public Color ValueColor { get; set; } = Color.Black;
+
+    [Parameter]
+    public float ValueFontSize { get; set; } = 16;
+
+    [Parameter]
+    public string ValueFontFamilyName { get; set; } = "Calibri";
+
+    [Parameter]
+    public int SpaceBetweenLines { get; set; } = 10;
+
+    [Parameter]
+    public int SpaceBetweenColumns { get; set; } = 30;
+
+    [Parameter]
+    public float PositionX { get; set; } = 10;
+
+    [Parameter]
+    public float PositionY { get; set; } = 10;
+
+    [Parameter]
+    public int MonitorIndex { get; set; }
+
+    [Parameter]
+    public int SpaceX { get; set; } = 10;
+
+    [Parameter]
+    public int SpaceY { get; set; } = 10;
+
+    [Parameter]
+    public DesktopWallpaperPosition WallpaperFit { get; set; } = DesktopWallpaperPosition.Center;
+
+    [Parameter]
+    public string TextPosition { get; set; } = "TopLeft";
+
+    [Parameter]
+    public string Target { get; set; } = "Wallpaper";
+
+    protected override void ProcessRecord()
+    {
+        var config = new BgInfoConfiguration
+        {
+            FilePath = FilePath,
+            ConfigurationDirectory = ConfigurationDirectory,
+            FontFamilyName = FontFamilyName,
+            Color = Color,
+            FontSize = FontSize,
+            ValueColor = ValueColor,
+            ValueFontFamilyName = ValueFontFamilyName,
+            ValueFontSize = ValueFontSize,
+            SpaceBetweenLines = SpaceBetweenLines,
+            SpaceBetweenColumns = SpaceBetweenColumns,
+            PositionX = PositionX,
+            PositionY = PositionY,
+            MonitorIndex = MonitorIndex,
+            SpaceX = SpaceX,
+            SpaceY = SpaceY,
+            WallpaperFit = WallpaperFit,
+            TextPosition = TextPosition,
+            Target = Target
+        };
+
+        var results = BGInfoContent.Invoke();
+        foreach (var item in results)
+        {
+            if (item.BaseObject is BgInfoEntry entry)
+            {
+                config.Entries.Add(entry);
+            }
+        }
+
+        var generator = new BgInfoGenerator(new ImageService(), new WallpaperService());
+        var path = generator.Generate(config);
+        WriteObject(path);
+    }
+}
+
+[Cmdlet(VerbsCommon.New, "BGInfoLabel")]
+[OutputType(typeof(BgInfoEntry))]
+public class NewBGInfoLabelCommand : PSCmdlet
+{
+    [Parameter(Mandatory = true)]
+    public string Name { get; set; } = string.Empty;
+
+    [Parameter]
+    public Color Color { get; set; } = Color.Black;
+
+    [Parameter]
+    public float FontSize { get; set; } = 16;
+
+    [Parameter]
+    public string FontFamilyName { get; set; } = "Calibri";
+
+    protected override void EndProcessing()
+    {
+        var entry = new BgInfoEntry
+        {
+            Type = BgInfoEntryType.Label,
+            Name = Name,
+            Color = Color,
+            FontSize = FontSize,
+            FontFamilyName = FontFamilyName
+        };
+        WriteObject(entry);
+    }
+}
+
+[Cmdlet(VerbsCommon.New, "BGInfoValue")]
+[OutputType(typeof(BgInfoEntry))]
+public class NewBGInfoValueCommand : PSCmdlet
+{
+    [Parameter(ParameterSetName = "Values")]
+    [Parameter(ParameterSetName = "Builtin")]
+    public string Name { get; set; } = string.Empty;
+
+    [Parameter(ParameterSetName = "Values")]
+    public string Value { get; set; } = string.Empty;
+
+    [Parameter(ParameterSetName = "Builtin")]
+    public string BuiltinValue { get; set; } = string.Empty;
+
+    [Parameter]
+    public Color Color { get; set; } = Color.Black;
+
+    [Parameter]
+    public float FontSize { get; set; } = 16;
+
+    [Parameter]
+    public string FontFamilyName { get; set; } = "Calibri";
+
+    [Parameter]
+    public Color ValueColor { get; set; } = Color.Black;
+
+    [Parameter]
+    public float ValueFontSize { get; set; } = 16;
+
+    [Parameter]
+    public string ValueFontFamilyName { get; set; } = "Calibri";
+
+    protected override void EndProcessing()
+    {
+        string finalValue = string.IsNullOrEmpty(BuiltinValue) ? Value : SystemInfoProvider.GetValue(BuiltinValue);
+        var entry = new BgInfoEntry
+        {
+            Type = BgInfoEntryType.Value,
+            Name = string.IsNullOrEmpty(Name) ? BuiltinValue : Name,
+            Value = finalValue,
+            Color = Color,
+            FontSize = FontSize,
+            FontFamilyName = FontFamilyName,
+            ValueColor = ValueColor,
+            ValueFontSize = ValueFontSize,
+            ValueFontFamilyName = ValueFontFamilyName
+        };
+        WriteObject(entry);
+    }
+}
+
+[Cmdlet(VerbsCommon.Set, "LogonScreen")]
+public class SetLogonScreenCommand : PSCmdlet
+{
+    [Parameter(Mandatory = true)]
+    public string FilePath { get; set; } = string.Empty;
+
+    protected override void EndProcessing()
+    {
+        var path = System.IO.Path.GetFullPath(FilePath);
+        const string regPath = "HKLM:SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\PersonalizationCSP";
+        using var key = Microsoft.Win32.Registry.LocalMachine.CreateSubKey(regPath);
+        key.SetValue("LockScreenImagePath", path, Microsoft.Win32.RegistryValueKind.String);
+        key.SetValue("LockScreenImageUrl", path, Microsoft.Win32.RegistryValueKind.String);
+        key.SetValue("LockScreenImageStatus", 1, Microsoft.Win32.RegistryValueKind.DWord);
+    }
+}

--- a/Sources/PowerBGInfo.PowerShell/PowerBGInfo.PowerShell.csproj
+++ b/Sources/PowerBGInfo.PowerShell/PowerBGInfo.PowerShell.csproj
@@ -14,9 +14,17 @@
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
 
-    <ItemGroup>
+  <ItemGroup>
         <ProjectReference Include="..\PowerBGInfo\PowerBGInfo.csproj" />
-    </ItemGroup>
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">
+        <PackageReference Include="System.Management.Automation" Version="6.0.4" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' != 'net472' ">
+        <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.3.0" />
+  </ItemGroup>
 
     <PropertyGroup>
         <!-- This is needed for XmlDoc2CmdletDoc to generate a PowerShell documentation file. -->

--- a/Sources/PowerBGInfo.Tests/BgInfoGeneratorTests.cs
+++ b/Sources/PowerBGInfo.Tests/BgInfoGeneratorTests.cs
@@ -1,0 +1,38 @@
+using DesktopManager;
+using PowerBGInfo;
+using System.IO;
+using Xunit;
+
+namespace PowerBGInfo.Tests;
+
+public class BgInfoGeneratorTests
+{
+    [Fact]
+    public void GenerateCreatesFile()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            return;
+        }
+        var imageService = new ImageService();
+        var wallpaperService = new FakeWallpaperService();
+        var generator = new BgInfoGenerator(imageService, wallpaperService);
+        var config = new BgInfoConfiguration
+        {
+            FilePath = Path.Combine("Examples","Samples","TapC-Evotec-2560x1080.jpg"),
+            ConfigurationDirectory = Path.Combine(Path.GetTempPath(), "bginfo" + Path.GetRandomFileName())
+        };
+        config.Entries.Add(new BgInfoEntry{Type=BgInfoEntryType.Value, Name="Test", Value="1"});
+        var path = generator.Generate(config);
+        Assert.True(File.Exists(path));
+    }
+}
+
+internal class FakeWallpaperService : IWallpaperService
+{
+    public int Calls { get; private set; }
+    public void SetWallpaper(int monitorIndex, string filePath, DesktopManager.DesktopWallpaperPosition position)
+    {
+        Calls++;
+    }
+}

--- a/Sources/PowerBGInfo.Tests/Cmdlet.Tests.ps1
+++ b/Sources/PowerBGInfo.Tests/Cmdlet.Tests.ps1
@@ -1,0 +1,9 @@
+Import-Module "$PSScriptRoot/../PowerBGInfo.PowerShell/bin/Debug/net8.0/PowerBGInfo.PowerShell.dll" -Force
+
+Describe 'New-BGInfoValue cmdlet' {
+    It 'creates entry' {
+        $entry = New-BGInfoValue -Name Test -Value X
+        $entry.Name | Should -Be 'Test'
+        $entry.Value | Should -Be 'X'
+    }
+}

--- a/Sources/PowerBGInfo.Tests/PowerBGInfo.Tests.csproj
+++ b/Sources/PowerBGInfo.Tests/PowerBGInfo.Tests.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="xunit" Version="2.5.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+    <ProjectReference Include="..\PowerBGInfo\PowerBGInfo.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Sources/PowerBGInfo.Tests/SystemInfoProviderTests.cs
+++ b/Sources/PowerBGInfo.Tests/SystemInfoProviderTests.cs
@@ -1,0 +1,13 @@
+using Xunit;
+
+namespace PowerBGInfo.Tests;
+
+public class SystemInfoProviderTests
+{
+    [Fact]
+    public void ReturnsUserName()
+    {
+        var value = SystemInfoProvider.GetValue("UserName");
+        Assert.Equal(Environment.UserName, value);
+    }
+}

--- a/Sources/PowerBGInfo.Tests/UnitTest1.cs
+++ b/Sources/PowerBGInfo.Tests/UnitTest1.cs
@@ -1,8 +1,0 @@
-namespace PowerBGInfo.Tests {
-    public class UnitTest1 {
-        [Fact]
-        public void Test1() {
-
-        }
-    }
-}

--- a/Sources/PowerBGInfo/BgInfoConfiguration.cs
+++ b/Sources/PowerBGInfo/BgInfoConfiguration.cs
@@ -1,0 +1,29 @@
+using System.Collections.Generic;
+using SixLabors.ImageSharp;
+using DesktopManager;
+
+namespace PowerBGInfo;
+
+public class BgInfoConfiguration
+{
+    public string FilePath { get; set; } = string.Empty;
+    public string ConfigurationDirectory { get; set; } = string.Empty;
+    public string FontFamilyName { get; set; } = "Calibri";
+    public Color Color { get; set; } = Color.Black;
+    public float FontSize { get; set; } = 16f;
+    public Color ValueColor { get; set; } = Color.Black;
+    public float ValueFontSize { get; set; } = 16f;
+    public string ValueFontFamilyName { get; set; } = "Calibri";
+    public int SpaceBetweenLines { get; set; } = 10;
+    public int SpaceBetweenColumns { get; set; } = 30;
+    public float PositionX { get; set; } = 10;
+    public float PositionY { get; set; } = 10;
+    public int MonitorIndex { get; set; }
+    public int SpaceX { get; set; } = 10;
+    public int SpaceY { get; set; } = 10;
+    public DesktopWallpaperPosition WallpaperFit { get; set; } = DesktopWallpaperPosition.Center;
+    public string TextPosition { get; set; } = "TopLeft";
+    public string Target { get; set; } = "Wallpaper";
+    public bool UseScreenCoordinates { get; set; }
+    public List<BgInfoEntry> Entries { get; } = new();
+}

--- a/Sources/PowerBGInfo/BgInfoEntry.cs
+++ b/Sources/PowerBGInfo/BgInfoEntry.cs
@@ -1,0 +1,22 @@
+using SixLabors.ImageSharp;
+
+namespace PowerBGInfo;
+
+public enum BgInfoEntryType
+{
+    Label,
+    Value
+}
+
+public class BgInfoEntry
+{
+    public BgInfoEntryType Type { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public string? Value { get; set; }
+    public Color? Color { get; set; }
+    public float? FontSize { get; set; }
+    public string? FontFamilyName { get; set; }
+    public Color? ValueColor { get; set; }
+    public float? ValueFontSize { get; set; }
+    public string? ValueFontFamilyName { get; set; }
+}

--- a/Sources/PowerBGInfo/BgInfoGenerator.cs
+++ b/Sources/PowerBGInfo/BgInfoGenerator.cs
@@ -1,0 +1,86 @@
+using System.IO;
+using ImagePlayground;
+using SixLabors.ImageSharp;
+using DesktopManager;
+
+namespace PowerBGInfo;
+
+public class BgInfoGenerator
+{
+    private readonly ImageService _imageService;
+    private readonly IWallpaperService _wallpaperService;
+
+    public BgInfoGenerator(ImageService imageService, IWallpaperService wallpaperService)
+    {
+        _imageService = imageService;
+        _wallpaperService = wallpaperService;
+    }
+
+    public string Generate(BgInfoConfiguration config)
+    {
+        Directory.CreateDirectory(config.ConfigurationDirectory);
+
+        var monitors = new Monitors();
+        var imagePath = string.IsNullOrEmpty(config.FilePath)
+            ? monitors.GetWallpaper(config.MonitorIndex)
+            : config.FilePath;
+
+        if (string.IsNullOrEmpty(imagePath) || !File.Exists(imagePath))
+            throw new FileNotFoundException("Wallpaper not found", imagePath);
+
+        var fileName = Path.GetFileNameWithoutExtension(imagePath) + "_PowerBgInfo" + Path.GetExtension(imagePath);
+        var outputPath = Path.Combine(config.ConfigurationDirectory, fileName);
+        File.Copy(imagePath, outputPath, true);
+
+        using var image = _imageService.Load(outputPath);
+
+        float highestWidth = 0;
+        float highestHeight = 0;
+        float highestValueWidth = 0;
+        foreach (var entry in config.Entries)
+        {
+            entry.Color ??= config.Color;
+            entry.FontSize ??= config.FontSize;
+            entry.FontFamilyName ??= config.FontFamilyName;
+            if (entry.Type != BgInfoEntryType.Label)
+            {
+                entry.ValueColor ??= entry.Color ?? config.ValueColor;
+                entry.ValueFontSize ??= entry.FontSize ?? config.ValueFontSize;
+                entry.ValueFontFamilyName ??= entry.FontFamilyName ?? config.ValueFontFamilyName;
+            }
+            var size = image.GetTextSize(entry.Name, entry.FontSize!.Value, entry.FontFamilyName!);
+            if (size.Width > highestWidth) highestWidth = size.Width;
+            if (size.Height > highestHeight) highestHeight = size.Height;
+            if (entry.Type != BgInfoEntryType.Label && entry.Value != null)
+            {
+                var valSize = image.GetTextSize(entry.Value, entry.ValueFontSize!.Value, entry.ValueFontFamilyName!);
+                if (valSize.Width > highestValueWidth) highestValueWidth = valSize.Width;
+            }
+        }
+
+        float posX = config.PositionX;
+        float posY = config.PositionY;
+        foreach (var entry in config.Entries)
+        {
+            if (entry.Type == BgInfoEntryType.Label)
+            {
+                image.AddText(posX, posY, entry.Name, entry.Color!.Value, entry.FontSize!.Value, entry.FontFamilyName!);
+            }
+            else
+            {
+                image.AddText(posX, posY, entry.Name, entry.Color!.Value, entry.FontSize!.Value, entry.FontFamilyName!);
+                image.AddText(posX + highestWidth + config.SpaceBetweenColumns, posY, entry.Value!, entry.ValueColor!.Value, entry.ValueFontSize!.Value, entry.ValueFontFamilyName!);
+            }
+            posY += highestHeight + config.SpaceBetweenLines;
+        }
+
+        _imageService.Save(image, outputPath);
+
+        if (config.Target is "Wallpaper" or "Both")
+        {
+            _wallpaperService.SetWallpaper(config.MonitorIndex, outputPath, config.WallpaperFit);
+        }
+
+        return outputPath;
+    }
+}

--- a/Sources/PowerBGInfo/Class1.cs
+++ b/Sources/PowerBGInfo/Class1.cs
@@ -1,7 +1,0 @@
-﻿namespace PowerBGInfo
-{
-    public class Class1
-    {
-
-    }
-}

--- a/Sources/PowerBGInfo/ImageService.cs
+++ b/Sources/PowerBGInfo/ImageService.cs
@@ -1,0 +1,9 @@
+using ImagePlayground;
+
+namespace PowerBGInfo;
+
+public class ImageService
+{
+    public Image Load(string filePath) => Image.Load(filePath);
+    public void Save(Image image, string filePath) => image.Save(filePath);
+}

--- a/Sources/PowerBGInfo/PowerBGInfo.csproj
+++ b/Sources/PowerBGInfo/PowerBGInfo.csproj
@@ -1,10 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net472;netstandard2.0;net8.0</TargetFrameworks>
+        <TargetFrameworks>net472;netstandard2.0;net8.0;net9.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <LangVersion>Latest</LangVersion>
     </PropertyGroup>
+
+    <ItemGroup>
+      <PackageReference Include="DesktopManager" Version="2.0.1" />
+      <PackageReference Include="ImagePlayground" Version="0.0.8" />
+    </ItemGroup>
 
 </Project>

--- a/Sources/PowerBGInfo/SystemInfoProvider.cs
+++ b/Sources/PowerBGInfo/SystemInfoProvider.cs
@@ -1,0 +1,20 @@
+using System.Runtime.InteropServices;
+
+namespace PowerBGInfo;
+
+public static class SystemInfoProvider
+{
+    public static string GetValue(string builtin)
+    {
+        return builtin switch
+        {
+            "UserName" => Environment.UserName,
+            "HostName" => Environment.MachineName,
+            "FullUserName" => $"{Environment.UserDomainName}\\{Environment.UserName}",
+            "CpuLogicalCores" => Environment.ProcessorCount.ToString(),
+            "OSArchitecture" => RuntimeInformation.OSArchitecture.ToString(),
+            "OSVersion" => RuntimeInformation.OSDescription,
+            _ => string.Empty
+        };
+    }
+}

--- a/Sources/PowerBGInfo/WallpaperService.cs
+++ b/Sources/PowerBGInfo/WallpaperService.cs
@@ -1,0 +1,19 @@
+using DesktopManager;
+
+namespace PowerBGInfo;
+
+public interface IWallpaperService
+{
+    void SetWallpaper(int monitorIndex, string filePath, DesktopWallpaperPosition position);
+}
+
+public class WallpaperService : IWallpaperService
+{
+    private readonly Monitors _monitors = new();
+
+    public void SetWallpaper(int monitorIndex, string filePath, DesktopWallpaperPosition position)
+    {
+        _monitors.SetWallpaperPosition(position);
+        _monitors.SetWallpaper(monitorIndex, filePath);
+    }
+}


### PR DESCRIPTION
## Summary
- implement `BgInfoGenerator` with supporting classes
- expose PowerShell cmdlets in C#
- add xUnit and Pester tests
- update example scripts
- update project references for new packages and frameworks

## Testing
- `dotnet build Sources/PowerBGInfo.sln -c Debug`
- `dotnet test Sources/PowerBGInfo.sln -c Debug`
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Path Sources/PowerBGInfo.Tests/Cmdlet.Tests.ps1"`

------
https://chatgpt.com/codex/tasks/task_e_686c3c5bdfa0832e8114b7008024b199