### PR TITLE
Fix failing BgInfoGenerator test

### DIFF
--- a/Sources/PowerBGInfo.Tests/BgInfoGeneratorTests.cs
+++ b/Sources/PowerBGInfo.Tests/BgInfoGeneratorTests.cs
@@ -19,7 +19,7 @@ public class BgInfoGeneratorTests
         var generator = new BgInfoGenerator(imageService, wallpaperService);
         var config = new BgInfoConfiguration
         {
-            FilePath = Path.Combine("Examples","Samples","TapC-Evotec-2560x1080.jpg"),
+            FilePath = Path.Combine(AppContext.BaseDirectory, "TapC-Evotec-2560x1080.jpg"),
             ConfigurationDirectory = Path.Combine(Path.GetTempPath(), "bginfo" + Path.GetRandomFileName())
         };
         config.Entries.Add(new BgInfoEntry{Type=BgInfoEntryType.Value, Name="Test", Value="1"});

--- a/Sources/PowerBGInfo.Tests/PowerBGInfo.Tests.csproj
+++ b/Sources/PowerBGInfo.Tests/PowerBGInfo.Tests.csproj
@@ -27,4 +27,11 @@
     <Using Include="Xunit" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Include="..\..\Examples\Samples\TapC-Evotec-2560x1080.jpg">
+      <Link>TapC-Evotec-2560x1080.jpg</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
## Summary
- ensure test uses sample image copied to output
- include sample file in test project output

## Testing
- `dotnet test Sources/PowerBGInfo.Tests/PowerBGInfo.Tests.csproj -c Release -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_686ea2acc3fc832e9ded40816680af75