### PR TITLE
Add release validation playbook

### DIFF
--- a/Build/Validate-PowerBGInfo.ps1
+++ b/Build/Validate-PowerBGInfo.ps1
@@ -1,0 +1,150 @@
+[CmdletBinding()]
+param(
+    [ValidateSet('Debug', 'Release')]
+    [string] $Configuration = 'Debug',
+    [switch] $SkipPublishSingleFile,
+    [switch] $SkipPublishAot,
+    [switch] $KeepArtifacts
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Assert-PathExists {
+    param(
+        [string] $Path,
+        [string] $Description
+    )
+
+    if (-not (Test-Path -LiteralPath $Path)) {
+        throw "Expected $Description at $Path"
+    }
+}
+
+function Get-ImagePixelHash {
+    param(
+        [string] $Path
+    )
+
+    Add-Type -AssemblyName System.Drawing
+    $bitmap = [System.Drawing.Bitmap]::new($Path)
+    try {
+        $bytes = New-Object byte[] ($bitmap.Width * $bitmap.Height * 4)
+        $index = 0
+        for ($y = 0; $y -lt $bitmap.Height; $y++) {
+            for ($x = 0; $x -lt $bitmap.Width; $x++) {
+                $pixel = $bitmap.GetPixel($x, $y)
+                $bytes[$index++] = $pixel.A
+                $bytes[$index++] = $pixel.R
+                $bytes[$index++] = $pixel.G
+                $bytes[$index++] = $pixel.B
+            }
+        }
+
+        return ([System.BitConverter]::ToString(([System.Security.Cryptography.SHA256]::HashData($bytes)))).Replace('-', '')
+    } finally {
+        $bitmap.Dispose()
+    }
+}
+
+function Assert-ImageEquivalent {
+    param(
+        [string] $ReferencePath,
+        [string] $CandidatePath,
+        [string] $Description
+    )
+
+    $referenceHash = Get-ImagePixelHash -Path $ReferencePath
+    $candidateHash = Get-ImagePixelHash -Path $CandidatePath
+    if ($referenceHash -ne $candidateHash) {
+        throw "$Description mismatch. Reference: $ReferencePath Candidate: $CandidatePath"
+    }
+}
+
+$repositoryRoot = Split-Path -Path $PSScriptRoot -Parent
+$solutionPath = Join-Path -Path $repositoryRoot -ChildPath 'Sources\PowerBGInfo.sln'
+$cliProjectPath = Join-Path -Path $repositoryRoot -ChildPath 'Sources\PowerBGInfo.Cli\PowerBGInfo.Cli.csproj'
+$modulePath = Join-Path -Path $repositoryRoot -ChildPath "Sources\PowerBGInfo.PowerShell\bin\$Configuration\net8.0-windows\PowerBGInfo.PowerShell.dll"
+$cliPath = Join-Path -Path $repositoryRoot -ChildPath "Sources\PowerBGInfo.Cli\bin\$Configuration\net8.0-windows\PowerBGInfo.Cli.exe"
+$validationScriptPath = Join-Path -Path $repositoryRoot -ChildPath 'Examples\Scripts\PowerBGInfo.Validation.Sample.ps1'
+$validationRoot = Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath "PowerBGInfo.Validation.$([guid]::NewGuid().ToString('N'))"
+$renderDirectory = Join-Path -Path $validationRoot -ChildPath 'renders'
+$validationJsonPath = Join-Path -Path $validationRoot -ChildPath 'validation.json'
+$scriptOutputPath = Join-Path -Path $renderDirectory -ChildPath 'script.png'
+$jsonOutputPath = Join-Path -Path $renderDirectory -ChildPath 'json.png'
+$powerShellOutputPath = Join-Path -Path $renderDirectory -ChildPath 'powershell.png'
+$powerShellRunnerPath = Join-Path -Path $validationRoot -ChildPath 'invoke-bginfo.ps1'
+$singleFileOutputPath = Join-Path -Path $renderDirectory -ChildPath 'singlefile.png'
+$aotOutputPath = Join-Path -Path $renderDirectory -ChildPath 'aot.png'
+$singleFileDirectory = Join-Path -Path $validationRoot -ChildPath 'cli-singlefile'
+$aotDirectory = Join-Path -Path $validationRoot -ChildPath 'cli-aot'
+
+try {
+    New-Item -ItemType Directory -Path $renderDirectory -Force | Out-Null
+
+    dotnet build $solutionPath -c $Configuration | Out-Null
+    dotnet test $solutionPath -c $Configuration --no-build | Out-Null
+
+    Invoke-Pester -Path (Join-Path -Path $repositoryRoot -ChildPath 'Sources\PowerBGInfo.Tests\Cmdlet.Tests.ps1') -Output Detailed | Out-Null
+
+    Assert-PathExists -Path $modulePath -Description 'PowerBGInfo.PowerShell module'
+    Assert-PathExists -Path $cliPath -Description 'PowerBGInfo CLI'
+    Assert-PathExists -Path $validationScriptPath -Description 'validation script'
+
+    & $cliPath --script $validationScriptPath --module $modulePath --directory $renderDirectory --output (Split-Path -Path $scriptOutputPath -Leaf) --export-json $validationJsonPath --no-apply | Out-Null
+
+    Assert-PathExists -Path $scriptOutputPath -Description 'script-backed CLI output'
+    Assert-PathExists -Path $validationJsonPath -Description 'exported validation json'
+
+    & $cliPath --config $validationJsonPath --directory $renderDirectory --output (Split-Path -Path $jsonOutputPath -Leaf) --no-apply | Out-Null
+    Assert-PathExists -Path $jsonOutputPath -Description 'json-backed CLI output'
+
+    @"
+Import-Module -Name '$($modulePath.Replace("'", "''"))' -Force
+Invoke-BGInfo -Path '$($validationJsonPath.Replace("'", "''"))' -ConfigurationDirectory '$($renderDirectory.Replace("'", "''"))' -OutputFileName '$((Split-Path -Path $powerShellOutputPath -Leaf).Replace("'", "''"))' -NoApply | Out-Null
+"@ | Set-Content -LiteralPath $powerShellRunnerPath -Encoding UTF8
+
+    pwsh -NoLogo -NoProfile -File $powerShellRunnerPath | Out-Null
+    Assert-PathExists -Path $powerShellOutputPath -Description 'Invoke-BGInfo output'
+
+    Assert-ImageEquivalent -ReferencePath $scriptOutputPath -CandidatePath $jsonOutputPath -Description 'CLI script vs CLI json'
+    Assert-ImageEquivalent -ReferencePath $jsonOutputPath -CandidatePath $powerShellOutputPath -Description 'CLI json vs PowerShell json'
+
+    if (-not $SkipPublishSingleFile.IsPresent) {
+        dotnet publish $cliProjectPath -c $Configuration -f net8.0-windows -r win-x64 --self-contained false -p:PublishSingleFile=true -o $singleFileDirectory | Out-Null
+        $singleFileCliPath = Join-Path -Path $singleFileDirectory -ChildPath 'PowerBGInfo.Cli.exe'
+        Assert-PathExists -Path $singleFileCliPath -Description 'single-file CLI'
+        & $singleFileCliPath --config $validationJsonPath --directory $renderDirectory --output (Split-Path -Path $singleFileOutputPath -Leaf) --no-apply | Out-Null
+        Assert-PathExists -Path $singleFileOutputPath -Description 'single-file CLI output'
+        Assert-ImageEquivalent -ReferencePath $jsonOutputPath -CandidatePath $singleFileOutputPath -Description 'single-file CLI vs normal CLI'
+    }
+
+    if (-not $SkipPublishAot.IsPresent) {
+        dotnet publish $cliProjectPath -c $Configuration -f net8.0-windows -r win-x64 -p:PublishAot=true -o $aotDirectory | Out-Null
+        $aotCliPath = Join-Path -Path $aotDirectory -ChildPath 'PowerBGInfo.Cli.exe'
+        Assert-PathExists -Path $aotCliPath -Description 'NativeAOT CLI'
+        & $aotCliPath --config $validationJsonPath --directory $renderDirectory --output (Split-Path -Path $aotOutputPath -Leaf) --no-apply | Out-Null
+        Assert-PathExists -Path $aotOutputPath -Description 'NativeAOT CLI output'
+        if ((Get-ImagePixelHash -Path $jsonOutputPath) -ne (Get-ImagePixelHash -Path $aotOutputPath)) {
+            Write-Warning 'NativeAOT CLI output differs from the normal CLI output on this machine. NativeAOT remains a smoke-tested file-generation path rather than a strict parity path.'
+        }
+    }
+
+    Write-Host "Validated PowerBGInfo with configuration $Configuration"
+    Write-Host "Script-backed CLI : $scriptOutputPath"
+    Write-Host "JSON-backed CLI   : $jsonOutputPath"
+    Write-Host "PowerShell JSON   : $powerShellOutputPath"
+    if (-not $SkipPublishSingleFile.IsPresent) {
+        Write-Host "Single-file CLI   : $singleFileOutputPath"
+    }
+    if (-not $SkipPublishAot.IsPresent) {
+        Write-Host "NativeAOT CLI     : $aotOutputPath"
+    }
+
+    if ($KeepArtifacts.IsPresent) {
+        Write-Host "Artifacts kept at : $validationRoot"
+    }
+} finally {
+    if (-not $KeepArtifacts.IsPresent -and (Test-Path -LiteralPath $validationRoot)) {
+        Remove-Item -LiteralPath $validationRoot -Recurse -Force
+    }
+}

--- a/Examples/Scripts/PowerBGInfo.Validation.Sample.ps1
+++ b/Examples/Scripts/PowerBGInfo.Validation.Sample.ps1
@@ -1,0 +1,13 @@
+New-BGInfo {
+    New-BGInfoValue -BuiltinValue HostName -Name 'Host'
+    New-BGInfoValue -BuiltinValue FullUserName -Name 'User'
+    New-BGInfoLabel -Name 'System' -Color LemonChiffon -FontSize 14 -FontFamilyName 'Calibri'
+    New-BGInfoValue -BuiltinValue OSName -Name 'OS'
+    New-BGInfoValue -BuiltinValue OSBuild -Name 'Build'
+    New-BGInfoValue -BuiltinValue CpuLogicalCores -Name 'Logical Cores'
+} -FilePath '..\Samples\TapN-Evotec-1600x900.jpg' `
+    -ConfigurationDirectory '..\Output' `
+    -OutputFileName 'PowerBGInfo.Validation.Sample.png' `
+    -BackgroundColor Black `
+    -Target File `
+    -PassThru

--- a/README.MD
+++ b/README.MD
@@ -118,6 +118,39 @@ The last two commands validate both CLI modes:
 - PowerShell-authored JSON consumed by the CLI
 - PowerShell script consumed directly by the CLI
 
+For a fuller release-proof pass, use the reusable validation script:
+
+```powershell
+pwsh -NoLogo -NoProfile -File .\Build\Validate-PowerBGInfo.ps1 -Configuration Release
+```
+
+That script verifies:
+
+- solution build and .NET tests
+- PowerShell/Pester coverage
+- CLI `--script` output
+- CLI `--config` output from exported JSON
+- `Invoke-BGInfo` output from the same JSON
+- published single-file CLI output parity
+- NativeAOT CLI smoke output for `Target File` / `--no-apply`
+
+Use `-KeepArtifacts` if you want the rendered files and published executables left on disk for inspection.
+
+## Manual Validation
+
+These scenarios still deserve a real machine check because they change Windows state, may need elevation, or depend on shell behavior:
+
+1. Current-user wallpaper apply:
+   Run `New-BGInfo` or `PowerBGInfo.Cli --config ...` without `--no-apply` and confirm the wallpaper changes immediately.
+2. All users:
+   Run elevated with `-AllUsers`, then confirm both an existing secondary profile and a newly created profile receive the staged wallpaper.
+3. Logon screen:
+   Run elevated with `-Target LogonScreen` or `-Target Both`, lock/sign out, and confirm the generated image is used.
+4. Windows 11 24H2 refresh:
+   Run wallpaper apply, sign out/sign back in, and confirm the refresh workaround still prevents Windows from reusing the previous cached wallpaper.
+5. Terminal server / RDS:
+   Validate in a real user session that per-user values such as `FullUserName` still resolve correctly when run inside the session.
+
 ## Script-backed CLI
 
 When you want the EXE to keep full PowerShell flexibility, return a configuration object from your script:
@@ -396,6 +429,7 @@ dotnet publish .\Sources\PowerBGInfo.Cli\PowerBGInfo.Cli.csproj -c Release -f ne
 ```
 
 NativeAOT is currently best for `--no-apply` / `Target File` workflows with an explicit `FilePath`. Windows desktop APIs from `DesktopManager` and `System.Management` still emit AOT warnings for wallpaper and system-query paths.
+Treat NativeAOT as a file-generation smoke path, not yet as a strict pixel-for-pixel parity target for every machine/runtime combination.
 
 You can also use only builtin values
 


### PR DESCRIPTION
## Summary
- add a reusable release validation script for PowerBGInfo
- add a deterministic validation sample script for output parity checks
- document the automated vs manual validation matrix in the README

## Validation
- pwsh -NoLogo -NoProfile -File .\\Build\\Validate-PowerBGInfo.ps1 -Configuration Release -KeepArtifacts
