### PR TITLE
Add ChartForgeX topology overlays

### DIFF
--- a/Examples/Scripts/PowerBGInfo.TopologyOverlay.ps1
+++ b/Examples/Scripts/PowerBGInfo.TopologyOverlay.ps1
@@ -1,0 +1,19 @@
+$examplesPath = Split-Path -Path $PSScriptRoot -Parent
+$sampleImage = Join-Path -Path $examplesPath -ChildPath 'Samples\TapC-Evotec-2560x1080.jpg'
+
+New-BGInfo {
+    New-BGInfoValue -Name 'Topology' -Value 'ChartForgeX overlay' -Color White -ValueColor White -FontSize 22
+
+    New-BGInfoTopology -Title 'Lab topology' -Subtitle 'Gateway, API, SQL' -Width 560 -Height 310 -Anchor BottomRight -OffsetX 34 -OffsetY 34 -TopologyDefinition {
+        New-BGInfoTopologyGroup -Id 'lab' -Label 'Lab Site' -Status Healthy -Symbol region
+        New-BGInfoTopologyNode -Id 'gateway' -Label 'Gateway' -Kind Network -Status Healthy -GroupId 'lab' -Symbol GW
+        New-BGInfoTopologyNode -Id 'api' -Label 'API' -Kind Service -Status Healthy -GroupId 'lab' -Symbol API
+        New-BGInfoTopologyNode -Id 'sql' -Label 'SQL' -Kind Database -Status Warning -GroupId 'lab' -Symbol SQL
+        New-BGInfoTopologyEdge -SourceNodeId 'gateway' -TargetNodeId 'api' -Label 'HTTPS' -Kind Connectivity -Status Healthy -Direction Forward
+        New-BGInfoTopologyEdge -SourceNodeId 'api' -TargetNodeId 'sql' -Label '32 ms' -Kind Dependency -Status Warning -Direction Forward
+    }
+} -FilePath $sampleImage `
+    -ConfigurationDirectory (Join-Path -Path $examplesPath -ChildPath 'Output') `
+    -OutputFileName 'PowerBGInfo.TopologyOverlay.jpg' `
+    -Target File `
+    -WallpaperFit Fill

--- a/PowerBGInfo.psd1
+++ b/PowerBGInfo.psd1
@@ -1,7 +1,7 @@
 @{
     AliasesToExport        = @()
     Author                 = 'Przemyslaw Klys'
-    CmdletsToExport        = @('New-BGInfo', 'New-BGInfoLabel', 'New-BGInfoValue', 'New-BGInfoVariable', 'New-BGInfoChart', 'Invoke-BGInfo', 'Export-BGInfoConfiguration', 'New-BGInfoConfiguration')
+    CmdletsToExport        = @('New-BGInfo', 'New-BGInfoLabel', 'New-BGInfoValue', 'New-BGInfoVariable', 'New-BGInfoChart', 'New-BGInfoTopology', 'New-BGInfoTopologyEdge', 'New-BGInfoTopologyGroup', 'New-BGInfoTopologyNode', 'Invoke-BGInfo', 'Export-BGInfoConfiguration', 'New-BGInfoConfiguration')
     CompanyName            = 'Evotec'
     CompatiblePSEditions   = @('Desktop', 'Core')
     Copyright              = '(c) 2011 - 2025 Przemyslaw Klys @ Evotec. All rights reserved.'
@@ -16,7 +16,7 @@
             IconUri    = 'https://evotec.xyz/wp-content/uploads/2022/12/PowerBGInfo.png'
             LicenseUri = 'https://github.com/EvotecIT/PowerBGInfo/blob/master/License'
             ProjectUri = 'https://github.com/EvotecIT/PowerBGInfo'
-            Tags       = @('windows', 'image', 'monitor', 'bginfo')
+            Tags       = @('windows', 'image', 'monitor', 'bginfo', 'charts', 'topology', 'diagrams')
         }
     }
     RootModule             = 'PowerBGInfo.psm1'

--- a/README.MD
+++ b/README.MD
@@ -271,7 +271,7 @@ Here's how the wallpaper will look like:
 - Logon screen: use `-Target LogonScreen` or `-Target Both` (requires elevation).
 - Long values: use `-ValueWrapWidth` or JSON `ValueWrapWidth` to wrap value text such as long AD descriptions.
 - Stable output path: use `-OutputFileName` to control the output name and path.
-- Charts: use `New-BGInfoChart` to add ChartForgeX-backed transparent chart overlays with optional history.
+- Charts and topology diagrams: use `New-BGInfoChart` and `New-BGInfoTopology` to add ChartForgeX-backed transparent overlays with optional chart history.
 
 ## Deployment recipes
 
@@ -393,6 +393,25 @@ New-BGInfo -MonitorIndex 0 {
 ```
 
 Charts are rendered by ChartForgeX into transparent overlays before PowerBGInfo composites them into the wallpaper. Supported kinds are `Sparkline`, `Line`, `Area`, `Bar`, `HorizontalBar`, `Gauge`, `Circle`, `RadialBar`, `Bullet`, `Pie`, `Donut`, `ProgressBar`, and `Pictorial`.
+
+## Topology diagrams
+
+PowerBGInfo can also place ChartForgeX topology diagrams on the wallpaper. This is useful for lab machines, admin jump boxes, training kiosks, build agents, and shared operational desktops where a compact service or network map is more useful than another metric chart.
+
+```powershell
+New-BGInfo {
+    New-BGInfoTopology -Title 'Lab topology' -Subtitle 'Gateway, API, SQL' -Width 560 -Height 310 -Anchor BottomRight -OffsetX 34 -OffsetY 34 -TopologyDefinition {
+        New-BGInfoTopologyGroup -Id 'lab' -Label 'Lab Site' -Status Healthy -Symbol region
+        New-BGInfoTopologyNode -Id 'gateway' -Label 'Gateway' -Kind Network -Status Healthy -GroupId 'lab' -Symbol GW
+        New-BGInfoTopologyNode -Id 'api' -Label 'API' -Kind Service -Status Healthy -GroupId 'lab' -Symbol API
+        New-BGInfoTopologyNode -Id 'sql' -Label 'SQL' -Kind Database -Status Warning -GroupId 'lab' -Symbol SQL
+        New-BGInfoTopologyEdge -SourceNodeId 'gateway' -TargetNodeId 'api' -Label 'HTTPS' -Kind Connectivity -Status Healthy -Direction Forward
+        New-BGInfoTopologyEdge -SourceNodeId 'api' -TargetNodeId 'sql' -Label '32 ms' -Kind Dependency -Status Warning -Direction Forward
+    }
+} -FilePath $PSScriptRoot\Examples\Samples\TapC-Evotec-2560x1080.jpg -ConfigurationDirectory $PSScriptRoot\Examples\Output -OutputFileName 'PowerBGInfo.TopologyOverlay.jpg' -Target File -WallpaperFit Fill
+```
+
+Topology overlays default to a transparent canvas so they sit on top of the selected wallpaper instead of covering it with a heavy panel. Use `-Opaque` on `New-BGInfoTopology` when you want ChartForgeX to render its normal canvas background.
 
 Point-based charts can use `-Labels`, `-Palette`, `-ShowLegend`, `-ShowPointLegend`, `-LegendPosition`, and `-ShowDataLabels`. Gauge-like charts can use `-Minimum` and `-Maximum`; bullet charts add `-Target` and `-RangeEnds`; donut/progress/pictorial charts expose focused options such as `-DonutInnerRadiusRatio`, `-DonutCenterValue`, `-NoProgressHandles`, `-PictorialSymbol`, and `-PictorialColumns`.
 

--- a/Sources/PowerBGInfo.PowerShell/CmdletNewBGInfo.cs
+++ b/Sources/PowerBGInfo.PowerShell/CmdletNewBGInfo.cs
@@ -235,6 +235,12 @@ public class CmdletNewBGInfo : PSCmdlet {
                 continue;
             }
 
+            if (item?.BaseObject is BgInfoTopology topology)
+            {
+                config.Topologies.Add(topology);
+                continue;
+            }
+
             if (item != null && TryConvertLegacyEntry(item, out var legacyEntry))
             {
                 config.Entries.Add(legacyEntry);

--- a/Sources/PowerBGInfo.PowerShell/CmdletNewBGInfoConfiguration.cs
+++ b/Sources/PowerBGInfo.PowerShell/CmdletNewBGInfoConfiguration.cs
@@ -152,6 +152,10 @@ public sealed class CmdletNewBGInfoConfiguration : PSCmdlet {
     [Parameter]
     public BgInfoChart[] Charts { get; set; } = System.Array.Empty<BgInfoChart>();
 
+    /// <para>Topology diagrams to include in the configuration.</para>
+    [Parameter]
+    public BgInfoTopology[] Topologies { get; set; } = System.Array.Empty<BgInfoTopology>();
+
     /// <summary>Creates the configuration object.</summary>
     protected override void EndProcessing() {
         var config = new BgInfoConfiguration();
@@ -198,6 +202,9 @@ public sealed class CmdletNewBGInfoConfiguration : PSCmdlet {
         }
         if (IsParameterBound(nameof(Charts)) && Charts.Length > 0) {
             config.Charts.AddRange(Charts);
+        }
+        if (IsParameterBound(nameof(Topologies)) && Topologies.Length > 0) {
+            config.Topologies.AddRange(Topologies);
         }
 
         WriteObject(config);

--- a/Sources/PowerBGInfo.PowerShell/CmdletNewBGInfoTopology.cs
+++ b/Sources/PowerBGInfo.PowerShell/CmdletNewBGInfoTopology.cs
@@ -1,0 +1,128 @@
+using ChartForgeX.Topology;
+using PowerBGInfo;
+using System.Management.Automation;
+
+namespace PowerBGInfo.PowerShell;
+
+/// <summary>Creates a BGInfo topology overlay definition.</summary>
+[Cmdlet(VerbsCommon.New, "BGInfoTopology")]
+[OutputType(typeof(BgInfoTopology))]
+public sealed class CmdletNewBGInfoTopology : PSCmdlet {
+    /// <para>Script block that emits topology groups, nodes, and edges.</para>
+    [Parameter(Mandatory = true, Position = 0)]
+    public ScriptBlock TopologyDefinition { get; set; } = null!;
+
+    /// <para>Topology title.</para>
+    [Parameter]
+    public string Title { get; set; } = string.Empty;
+
+    /// <para>Topology subtitle.</para>
+    [Parameter]
+    public string Subtitle { get; set; } = string.Empty;
+
+    /// <para>Topology width in pixels.</para>
+    [Parameter]
+    public int Width { get; set; } = 520;
+
+    /// <para>Topology height in pixels.</para>
+    [Parameter]
+    public int Height { get; set; } = 300;
+
+    /// <para>Anchor position for placement.</para>
+    [Parameter]
+    public BgInfoTextPosition Anchor { get; set; } = BgInfoTextPosition.BottomRight;
+
+    /// <para>Horizontal offset from the anchor.</para>
+    [Parameter]
+    public int OffsetX { get; set; } = 32;
+
+    /// <para>Vertical offset from the anchor.</para>
+    [Parameter]
+    public int OffsetY { get; set; } = 32;
+
+    /// <para>Absolute X position.</para>
+    [Parameter]
+    public int PositionX { get; set; }
+
+    /// <para>Absolute Y position.</para>
+    [Parameter]
+    public int PositionY { get; set; }
+
+    /// <para>Topology layout mode.</para>
+    [Parameter]
+    public TopologyLayoutMode Layout { get; set; } = TopologyLayoutMode.Layered;
+
+    /// <para>Topology layout direction.</para>
+    [Parameter]
+    public TopologyLayoutDirection Direction { get; set; } = TopologyLayoutDirection.LeftToRight;
+
+    /// <para>Node presentation mode.</para>
+    [Parameter]
+    public TopologyNodeDisplayMode NodeDisplayMode { get; set; } = TopologyNodeDisplayMode.CompactCard;
+
+    /// <para>Theme name.</para>
+    [Parameter]
+    [ValidateSet("Light", "Dark")]
+    public string Theme { get; set; } = "Dark";
+
+    /// <para>Use an opaque topology canvas.</para>
+    [Parameter]
+    public SwitchParameter Opaque { get; set; }
+
+    /// <para>Hide the topology title.</para>
+    [Parameter]
+    public SwitchParameter NoTitle { get; set; }
+
+    /// <para>Show the topology legend.</para>
+    [Parameter]
+    public SwitchParameter ShowLegend { get; set; }
+
+    /// <para>Hide group containers.</para>
+    [Parameter]
+    public SwitchParameter NoGroups { get; set; }
+
+    /// <para>Hide edge labels.</para>
+    [Parameter]
+    public SwitchParameter NoEdgeLabels { get; set; }
+
+    /// <summary>Emits a BGInfo topology overlay definition.</summary>
+    protected override void EndProcessing() {
+        var topology = new BgInfoTopology {
+            Title = Title,
+            Subtitle = Subtitle,
+            Width = Width,
+            Height = Height,
+            Anchor = Anchor,
+            OffsetX = OffsetX,
+            OffsetY = OffsetY,
+            Layout = Layout,
+            Direction = Direction,
+            NodeDisplayMode = NodeDisplayMode,
+            Theme = Theme,
+            Transparent = !Opaque.IsPresent,
+            ShowTitle = !NoTitle.IsPresent,
+            ShowLegend = ShowLegend.IsPresent,
+            ShowGroups = !NoGroups.IsPresent,
+            ShowEdgeLabels = !NoEdgeLabels.IsPresent
+        };
+
+        if (MyInvocation.BoundParameters.ContainsKey(nameof(PositionX)) &&
+            MyInvocation.BoundParameters.ContainsKey(nameof(PositionY))) {
+            topology.PositionX = PositionX;
+            topology.PositionY = PositionY;
+        }
+
+        foreach (var item in TopologyDefinition.Invoke()) {
+            var value = item is PSObject psObject ? psObject.BaseObject : item;
+            if (value is TopologyGroup group) {
+                topology.Groups.Add(group);
+            } else if (value is TopologyNode node) {
+                topology.Nodes.Add(node);
+            } else if (value is TopologyEdge edge) {
+                topology.Edges.Add(edge);
+            }
+        }
+
+        WriteObject(topology);
+    }
+}

--- a/Sources/PowerBGInfo.PowerShell/CmdletNewBGInfoTopologyEdge.cs
+++ b/Sources/PowerBGInfo.PowerShell/CmdletNewBGInfoTopologyEdge.cs
@@ -1,0 +1,73 @@
+using ChartForgeX.Topology;
+using PowerBGInfo;
+using System.Management.Automation;
+
+namespace PowerBGInfo.PowerShell;
+
+/// <summary>Creates a BGInfo topology edge definition.</summary>
+[Cmdlet(VerbsCommon.New, "BGInfoTopologyEdge")]
+[OutputType(typeof(TopologyEdge))]
+public sealed class CmdletNewBGInfoTopologyEdge : PSCmdlet {
+    /// <para>Stable edge identifier. When omitted, one is derived from source and target ids.</para>
+    [Parameter]
+    public string Id { get; set; } = string.Empty;
+
+    /// <para>Source node identifier.</para>
+    [Parameter(Mandatory = true, Position = 0)]
+    public string SourceNodeId { get; set; } = string.Empty;
+
+    /// <para>Target node identifier.</para>
+    [Parameter(Mandatory = true, Position = 1)]
+    public string TargetNodeId { get; set; } = string.Empty;
+
+    /// <para>Primary edge label.</para>
+    [Parameter(Position = 2)]
+    public string Label { get; set; } = string.Empty;
+
+    /// <para>Relationship kind.</para>
+    [Parameter]
+    public TopologyEdgeKind Kind { get; set; } = TopologyEdgeKind.Generic;
+
+    /// <para>Relationship health or state.</para>
+    [Parameter]
+    public TopologyHealthStatus Status { get; set; } = TopologyHealthStatus.Unknown;
+
+    /// <para>Direction marker behavior.</para>
+    [Parameter]
+    public TopologyDirection Direction { get; set; } = TopologyDirection.None;
+
+    /// <para>Edge routing mode.</para>
+    [Parameter]
+    public TopologyEdgeRouting Routing { get; set; } = TopologyEdgeRouting.Orthogonal;
+
+    /// <para>Optional edge color as CSS hex.</para>
+    [Parameter]
+    public string Color { get; set; } = string.Empty;
+
+    /// <para>Render the edge as a quiet structural relationship.</para>
+    [Parameter]
+    public SwitchParameter Muted { get; set; }
+
+    /// <summary>Emits a topology edge definition.</summary>
+    protected override void EndProcessing() {
+        var edge = new TopologyEdge {
+            Id = string.IsNullOrWhiteSpace(Id) ? SourceNodeId + "-" + TargetNodeId : Id,
+            SourceNodeId = SourceNodeId,
+            TargetNodeId = TargetNodeId,
+            Kind = Kind,
+            Status = Status,
+            Direction = Direction,
+            Routing = Routing,
+            IsMuted = Muted.IsPresent
+        };
+
+        if (!string.IsNullOrWhiteSpace(Label)) {
+            edge.Label = Label;
+        }
+        if (!string.IsNullOrWhiteSpace(Color)) {
+            edge.Color = Color;
+        }
+
+        WriteObject(edge);
+    }
+}

--- a/Sources/PowerBGInfo.PowerShell/CmdletNewBGInfoTopologyGroup.cs
+++ b/Sources/PowerBGInfo.PowerShell/CmdletNewBGInfoTopologyGroup.cs
@@ -1,0 +1,57 @@
+using ChartForgeX.Topology;
+using PowerBGInfo;
+using System.Management.Automation;
+
+namespace PowerBGInfo.PowerShell;
+
+/// <summary>Creates a BGInfo topology group definition.</summary>
+[Cmdlet(VerbsCommon.New, "BGInfoTopologyGroup")]
+[OutputType(typeof(TopologyGroup))]
+public sealed class CmdletNewBGInfoTopologyGroup : PSCmdlet {
+    /// <para>Stable group identifier.</para>
+    [Parameter(Mandatory = true, Position = 0)]
+    public string Id { get; set; } = string.Empty;
+
+    /// <para>Group label rendered in the topology.</para>
+    [Parameter(Mandatory = true, Position = 1)]
+    public string Label { get; set; } = string.Empty;
+
+    /// <para>Optional group subtitle.</para>
+    [Parameter]
+    public string Subtitle { get; set; } = string.Empty;
+
+    /// <para>Group health or state.</para>
+    [Parameter]
+    public TopologyHealthStatus Status { get; set; } = TopologyHealthStatus.Unknown;
+
+    /// <para>Short symbol rendered near the group header.</para>
+    [Parameter]
+    public string Symbol { get; set; } = string.Empty;
+
+    /// <para>Optional group accent color as CSS hex.</para>
+    [Parameter]
+    public string Color { get; set; } = string.Empty;
+
+    /// <summary>Emits a topology group definition.</summary>
+    protected override void EndProcessing() {
+        var group = new TopologyGroup {
+            Id = Id,
+            Label = Label,
+            Status = Status,
+            Width = 320,
+            Height = 220
+        };
+
+        if (!string.IsNullOrWhiteSpace(Subtitle)) {
+            group.Subtitle = Subtitle;
+        }
+        if (!string.IsNullOrWhiteSpace(Symbol)) {
+            group.Symbol = Symbol;
+        }
+        if (!string.IsNullOrWhiteSpace(Color)) {
+            group.Color = Color;
+        }
+
+        WriteObject(group);
+    }
+}

--- a/Sources/PowerBGInfo.PowerShell/CmdletNewBGInfoTopologyNode.cs
+++ b/Sources/PowerBGInfo.PowerShell/CmdletNewBGInfoTopologyNode.cs
@@ -1,0 +1,81 @@
+using ChartForgeX.Topology;
+using PowerBGInfo;
+using System.Management.Automation;
+
+namespace PowerBGInfo.PowerShell;
+
+/// <summary>Creates a BGInfo topology node definition.</summary>
+[Cmdlet(VerbsCommon.New, "BGInfoTopologyNode")]
+[OutputType(typeof(TopologyNode))]
+public sealed class CmdletNewBGInfoTopologyNode : PSCmdlet {
+    /// <para>Stable node identifier used by topology edges.</para>
+    [Parameter(Mandatory = true, Position = 0)]
+    public string Id { get; set; } = string.Empty;
+
+    /// <para>Node label rendered in the topology.</para>
+    [Parameter(Mandatory = true, Position = 1)]
+    public string Label { get; set; } = string.Empty;
+
+    /// <para>Optional node subtitle.</para>
+    [Parameter]
+    public string Subtitle { get; set; } = string.Empty;
+
+    /// <para>Node kind used for icon and legend selection.</para>
+    [Parameter]
+    public TopologyNodeKind Kind { get; set; } = TopologyNodeKind.Generic;
+
+    /// <para>Node health or state.</para>
+    [Parameter]
+    public TopologyHealthStatus Status { get; set; } = TopologyHealthStatus.Unknown;
+
+    /// <para>Optional parent group identifier.</para>
+    [Parameter]
+    public string GroupId { get; set; } = string.Empty;
+
+    /// <para>Short symbol rendered inside or near the node icon.</para>
+    [Parameter]
+    public string Symbol { get; set; } = string.Empty;
+
+    /// <para>Optional badge text.</para>
+    [Parameter]
+    public string Badge { get; set; } = string.Empty;
+
+    /// <para>Optional node accent color as CSS hex.</para>
+    [Parameter]
+    public string Color { get; set; } = string.Empty;
+
+    /// <para>Optional node display mode override.</para>
+    [Parameter]
+    public TopologyNodeDisplayMode DisplayMode { get; set; } = TopologyNodeDisplayMode.CompactCard;
+
+    /// <summary>Emits a topology node definition.</summary>
+    protected override void EndProcessing() {
+        var node = new TopologyNode {
+            Id = Id,
+            Label = Label,
+            Kind = Kind,
+            Status = Status
+        };
+
+        if (!string.IsNullOrWhiteSpace(Subtitle)) {
+            node.Subtitle = Subtitle;
+        }
+        if (!string.IsNullOrWhiteSpace(GroupId)) {
+            node.GroupId = GroupId;
+        }
+        if (!string.IsNullOrWhiteSpace(Symbol)) {
+            node.Symbol = Symbol;
+        }
+        if (!string.IsNullOrWhiteSpace(Badge)) {
+            node.Badge = Badge;
+        }
+        if (!string.IsNullOrWhiteSpace(Color)) {
+            node.Color = Color;
+        }
+        if (MyInvocation.BoundParameters.ContainsKey(nameof(DisplayMode))) {
+            node.DisplayMode = DisplayMode;
+        }
+
+        WriteObject(node);
+    }
+}

--- a/Sources/PowerBGInfo.Tests/BgInfoConfigurationJsonTests.cs
+++ b/Sources/PowerBGInfo.Tests/BgInfoConfigurationJsonTests.cs
@@ -1,5 +1,6 @@
 using System.IO;
 using System.Drawing;
+using ChartForgeX.Topology;
 using Xunit;
 
 namespace PowerBGInfo.Tests;
@@ -145,5 +146,85 @@ public class BgInfoConfigurationJsonTests
         Assert.Equal(0.4, chart.ProgressBarThicknessRatio);
         Assert.Equal(BgInfoChartPictorialSymbol.Person, chart.PictorialSymbol);
         Assert.Equal(8, chart.PictorialColumns);
+    }
+
+    [Fact]
+    public void SaveAndLoadPreservesTopologyOptions() {
+        var tempDirectory = Path.Combine(Path.GetTempPath(), "bginfo-json-" + Path.GetRandomFileName());
+        Directory.CreateDirectory(tempDirectory);
+        var path = Path.Combine(tempDirectory, "config.json");
+
+        var configuration = new BgInfoConfiguration {
+            ConfigurationDirectory = tempDirectory
+        };
+        var topology = new BgInfoTopology {
+            Title = "Lab topology",
+            Subtitle = "Gateway, API, SQL",
+            Width = 560,
+            Height = 310,
+            Anchor = BgInfoTextPosition.BottomRight,
+            OffsetX = 34,
+            OffsetY = 42,
+            Layout = TopologyLayoutMode.Layered,
+            Direction = TopologyLayoutDirection.LeftToRight,
+            NodeDisplayMode = TopologyNodeDisplayMode.CompactCard,
+            Theme = "Dark",
+            Transparent = true,
+            ShowLegend = true
+        };
+        topology.Groups.Add(new TopologyGroup {
+            Id = "lab",
+            Label = "Lab Site",
+            Status = TopologyHealthStatus.Healthy,
+            Symbol = "region"
+        });
+        topology.Nodes.Add(new TopologyNode {
+            Id = "gateway",
+            Label = "Gateway",
+            Kind = TopologyNodeKind.Network,
+            Status = TopologyHealthStatus.Healthy,
+            GroupId = "lab",
+            Symbol = "GW"
+        });
+        topology.Nodes.Add(new TopologyNode {
+            Id = "api",
+            Label = "API",
+            Kind = TopologyNodeKind.Service,
+            Status = TopologyHealthStatus.Warning,
+            GroupId = "lab",
+            Symbol = "API"
+        });
+        topology.Edges.Add(new TopologyEdge {
+            Id = "gateway-api",
+            SourceNodeId = "gateway",
+            TargetNodeId = "api",
+            Label = "HTTPS",
+            Kind = TopologyEdgeKind.Connectivity,
+            Status = TopologyHealthStatus.Healthy,
+            Direction = TopologyDirection.Forward
+        });
+        configuration.Topologies.Add(topology);
+
+        BgInfoConfigurationJson.Save(configuration, path);
+
+        var roundTripped = BgInfoConfigurationJson.Load(path);
+        var loaded = Assert.Single(roundTripped.Topologies);
+        Assert.Equal("Lab topology", loaded.Title);
+        Assert.Equal("Gateway, API, SQL", loaded.Subtitle);
+        Assert.Equal(560, loaded.Width);
+        Assert.Equal(310, loaded.Height);
+        Assert.Equal(BgInfoTextPosition.BottomRight, loaded.Anchor);
+        Assert.Equal(34, loaded.OffsetX);
+        Assert.Equal(42, loaded.OffsetY);
+        Assert.Equal(TopologyLayoutMode.Layered, loaded.Layout);
+        Assert.Equal(TopologyLayoutDirection.LeftToRight, loaded.Direction);
+        Assert.Equal(TopologyNodeDisplayMode.CompactCard, loaded.NodeDisplayMode);
+        Assert.True(loaded.Transparent);
+        Assert.True(loaded.ShowLegend);
+        Assert.Single(loaded.Groups);
+        Assert.Equal(2, loaded.Nodes.Count);
+        Assert.Single(loaded.Edges);
+        Assert.Equal("gateway-api", loaded.Edges[0].Id);
+        Assert.Equal(TopologyEdgeKind.Connectivity, loaded.Edges[0].Kind);
     }
 }

--- a/Sources/PowerBGInfo/BgInfoConfiguration.cs
+++ b/Sources/PowerBGInfo/BgInfoConfiguration.cs
@@ -152,4 +152,8 @@ public class BgInfoConfiguration {
     /// Gets the collection of charts to render.
     /// </summary>
     public List<BgInfoChart> Charts { get; } = new();
+    /// <summary>
+    /// Gets the collection of topology diagrams to render.
+    /// </summary>
+    public List<BgInfoTopology> Topologies { get; } = new();
 }

--- a/Sources/PowerBGInfo/BgInfoConfigurationJson.cs
+++ b/Sources/PowerBGInfo/BgInfoConfigurationJson.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using ChartForgeX.Topology;
 
 #if NET472
 using System.Web.Script.Serialization;
@@ -189,6 +190,15 @@ public static class BgInfoConfigurationJson {
             }
         }
 
+        if (model.Topologies != null) {
+            foreach (var topologyModel in model.Topologies) {
+                var topology = MapTopology(topologyModel);
+                if (topology != null) {
+                    configuration.Topologies.Add(topology);
+                }
+            }
+        }
+
         return configuration;
     }
 
@@ -315,6 +325,39 @@ public static class BgInfoConfigurationJson {
                     PictorialColumns = chart.PictorialColumns,
                     Metric = chart.Metric.ToString(),
                     MetricArgument = chart.MetricArgument
+                });
+            }
+        }
+
+        if (configuration.Topologies.Count > 0) {
+            model.Topologies = new List<BgInfoTopologyFile>();
+            foreach (var topology in configuration.Topologies) {
+                model.Topologies.Add(new BgInfoTopologyFile {
+                    Title = topology.Title,
+                    Subtitle = topology.Subtitle,
+                    Width = topology.Width,
+                    Height = topology.Height,
+                    Anchor = topology.Anchor.ToString(),
+                    OffsetX = topology.OffsetX,
+                    OffsetY = topology.OffsetY,
+                    PositionX = topology.PositionX,
+                    PositionY = topology.PositionY,
+                    Layout = topology.Layout.ToString(),
+                    Direction = topology.Direction.ToString(),
+                    NodeDisplayMode = topology.NodeDisplayMode.ToString(),
+                    VisualStyle = topology.VisualStyle.ToString(),
+                    CanvasSurfaceStyle = topology.CanvasSurfaceStyle.ToString(),
+                    Theme = topology.Theme,
+                    Transparent = topology.Transparent,
+                    ShowTitle = topology.ShowTitle,
+                    ShowLegend = topology.ShowLegend,
+                    ShowGroups = topology.ShowGroups,
+                    ShowEdgeLabels = topology.ShowEdgeLabels,
+                    ShowStatusBadges = topology.ShowStatusBadges,
+                    FitContentToViewport = topology.FitContentToViewport,
+                    Groups = topology.Groups.Select(MapGroupFile).ToList(),
+                    Nodes = topology.Nodes.Select(MapNodeFile).ToList(),
+                    Edges = topology.Edges.Select(MapEdgeFile).ToList()
                 });
             }
         }
@@ -476,6 +519,210 @@ public static class BgInfoConfigurationJson {
         return chart;
     }
 
+    private static BgInfoTopology? MapTopology(BgInfoTopologyFile model) {
+        if (model == null) {
+            return null;
+        }
+
+        var topology = new BgInfoTopology {
+            Title = model.Title ?? string.Empty,
+            Subtitle = model.Subtitle ?? string.Empty
+        };
+
+        if (model.Width.HasValue) {
+            topology.Width = model.Width.Value;
+        }
+        if (model.Height.HasValue) {
+            topology.Height = model.Height.Value;
+        }
+        if (!string.IsNullOrWhiteSpace(model.Anchor) && Enum.TryParse(model.Anchor, true, out BgInfoTextPosition anchor)) {
+            topology.Anchor = anchor;
+        }
+        if (model.OffsetX.HasValue) {
+            topology.OffsetX = model.OffsetX.Value;
+        }
+        if (model.OffsetY.HasValue) {
+            topology.OffsetY = model.OffsetY.Value;
+        }
+        if (model.PositionX.HasValue && model.PositionY.HasValue) {
+            topology.PositionX = model.PositionX.Value;
+            topology.PositionY = model.PositionY.Value;
+        }
+        if (!string.IsNullOrWhiteSpace(model.Layout) && Enum.TryParse(model.Layout, true, out TopologyLayoutMode layout)) {
+            topology.Layout = layout;
+        }
+        if (!string.IsNullOrWhiteSpace(model.Direction) && Enum.TryParse(model.Direction, true, out TopologyLayoutDirection direction)) {
+            topology.Direction = direction;
+        }
+        if (!string.IsNullOrWhiteSpace(model.NodeDisplayMode) && Enum.TryParse(model.NodeDisplayMode, true, out TopologyNodeDisplayMode nodeDisplayMode)) {
+            topology.NodeDisplayMode = nodeDisplayMode;
+        }
+        if (!string.IsNullOrWhiteSpace(model.VisualStyle) && Enum.TryParse(model.VisualStyle, true, out TopologyVisualStyle visualStyle)) {
+            topology.VisualStyle = visualStyle;
+        }
+        if (!string.IsNullOrWhiteSpace(model.CanvasSurfaceStyle) && Enum.TryParse(model.CanvasSurfaceStyle, true, out TopologyCanvasSurfaceStyle canvasStyle)) {
+            topology.CanvasSurfaceStyle = canvasStyle;
+        }
+        if (!string.IsNullOrWhiteSpace(model.Theme)) {
+            topology.Theme = model.Theme!;
+        }
+        if (model.Transparent.HasValue) {
+            topology.Transparent = model.Transparent.Value;
+        }
+        if (model.ShowTitle.HasValue) {
+            topology.ShowTitle = model.ShowTitle.Value;
+        }
+        if (model.ShowLegend.HasValue) {
+            topology.ShowLegend = model.ShowLegend.Value;
+        }
+        if (model.ShowGroups.HasValue) {
+            topology.ShowGroups = model.ShowGroups.Value;
+        }
+        if (model.ShowEdgeLabels.HasValue) {
+            topology.ShowEdgeLabels = model.ShowEdgeLabels.Value;
+        }
+        if (model.ShowStatusBadges.HasValue) {
+            topology.ShowStatusBadges = model.ShowStatusBadges.Value;
+        }
+        if (model.FitContentToViewport.HasValue) {
+            topology.FitContentToViewport = model.FitContentToViewport.Value;
+        }
+
+        if (model.Groups != null) {
+            foreach (var item in model.Groups) {
+                topology.Groups.Add(MapGroup(item));
+            }
+        }
+        if (model.Nodes != null) {
+            foreach (var item in model.Nodes) {
+                topology.Nodes.Add(MapNode(item));
+            }
+        }
+        if (model.Edges != null) {
+            foreach (var item in model.Edges) {
+                topology.Edges.Add(MapEdge(item));
+            }
+        }
+
+        return topology;
+    }
+
+    private static TopologyGroup MapGroup(BgInfoTopologyGroupFile model) {
+        var group = new TopologyGroup {
+            Id = model.Id ?? string.Empty,
+            Label = model.Label ?? string.Empty,
+            Width = model.Width ?? 320,
+            Height = model.Height ?? 220
+        };
+        if (!string.IsNullOrWhiteSpace(model.Status) && Enum.TryParse(model.Status, true, out TopologyHealthStatus status)) {
+            group.Status = status;
+        }
+        if (!string.IsNullOrWhiteSpace(model.Subtitle)) {
+            group.Subtitle = model.Subtitle;
+        }
+        if (!string.IsNullOrWhiteSpace(model.Symbol)) {
+            group.Symbol = model.Symbol;
+        }
+        if (!string.IsNullOrWhiteSpace(model.Color)) {
+            group.Color = model.Color;
+        }
+        return group;
+    }
+
+    private static TopologyNode MapNode(BgInfoTopologyNodeFile model) {
+        var node = new TopologyNode { Id = model.Id ?? string.Empty, Label = model.Label ?? string.Empty };
+        if (!string.IsNullOrWhiteSpace(model.Kind) && Enum.TryParse(model.Kind, true, out TopologyNodeKind kind)) {
+            node.Kind = kind;
+        }
+        if (!string.IsNullOrWhiteSpace(model.Status) && Enum.TryParse(model.Status, true, out TopologyHealthStatus status)) {
+            node.Status = status;
+        }
+        if (!string.IsNullOrWhiteSpace(model.DisplayMode) && Enum.TryParse(model.DisplayMode, true, out TopologyNodeDisplayMode displayMode)) {
+            node.DisplayMode = displayMode;
+        }
+        if (!string.IsNullOrWhiteSpace(model.Subtitle)) {
+            node.Subtitle = model.Subtitle;
+        }
+        if (!string.IsNullOrWhiteSpace(model.GroupId)) {
+            node.GroupId = model.GroupId;
+        }
+        if (!string.IsNullOrWhiteSpace(model.Symbol)) {
+            node.Symbol = model.Symbol;
+        }
+        if (!string.IsNullOrWhiteSpace(model.Badge)) {
+            node.Badge = model.Badge;
+        }
+        if (!string.IsNullOrWhiteSpace(model.Color)) {
+            node.Color = model.Color;
+        }
+        return node;
+    }
+
+    private static TopologyEdge MapEdge(BgInfoTopologyEdgeFile model) {
+        var edge = new TopologyEdge {
+            Id = model.Id ?? ((model.SourceNodeId ?? string.Empty) + "-" + (model.TargetNodeId ?? string.Empty)),
+            SourceNodeId = model.SourceNodeId ?? string.Empty,
+            TargetNodeId = model.TargetNodeId ?? string.Empty,
+            IsMuted = model.Muted ?? false
+        };
+        if (!string.IsNullOrWhiteSpace(model.Kind) && Enum.TryParse(model.Kind, true, out TopologyEdgeKind kind)) {
+            edge.Kind = kind;
+        }
+        if (!string.IsNullOrWhiteSpace(model.Status) && Enum.TryParse(model.Status, true, out TopologyHealthStatus status)) {
+            edge.Status = status;
+        }
+        if (!string.IsNullOrWhiteSpace(model.Direction) && Enum.TryParse(model.Direction, true, out TopologyDirection direction)) {
+            edge.Direction = direction;
+        }
+        if (!string.IsNullOrWhiteSpace(model.Routing) && Enum.TryParse(model.Routing, true, out TopologyEdgeRouting routing)) {
+            edge.Routing = routing;
+        }
+        if (!string.IsNullOrWhiteSpace(model.Label)) {
+            edge.Label = model.Label;
+        }
+        if (!string.IsNullOrWhiteSpace(model.Color)) {
+            edge.Color = model.Color;
+        }
+        return edge;
+    }
+
+    private static BgInfoTopologyGroupFile MapGroupFile(TopologyGroup group) => new() {
+        Id = group.Id,
+        Label = group.Label,
+        Subtitle = group.Subtitle,
+        Status = group.Status.ToString(),
+        Width = group.Width,
+        Height = group.Height,
+        Symbol = group.Symbol,
+        Color = group.Color
+    };
+
+    private static BgInfoTopologyNodeFile MapNodeFile(TopologyNode node) => new() {
+        Id = node.Id,
+        Label = node.Label,
+        Subtitle = node.Subtitle,
+        Kind = node.Kind.ToString(),
+        Status = node.Status.ToString(),
+        GroupId = node.GroupId,
+        Symbol = node.Symbol,
+        DisplayMode = node.DisplayMode?.ToString(),
+        Badge = node.Badge,
+        Color = node.Color
+    };
+
+    private static BgInfoTopologyEdgeFile MapEdgeFile(TopologyEdge edge) => new() {
+        Id = edge.Id,
+        SourceNodeId = edge.SourceNodeId,
+        TargetNodeId = edge.TargetNodeId,
+        Label = edge.Label,
+        Kind = edge.Kind.ToString(),
+        Status = edge.Status.ToString(),
+        Direction = edge.Direction.ToString(),
+        Routing = edge.Routing.ToString(),
+        Color = edge.Color,
+        Muted = edge.IsMuted
+    };
+
     private static void ApplyColor(string? text, Action<System.Drawing.Color> setter) {
         if (string.IsNullOrWhiteSpace(text)) {
             return;
@@ -540,6 +787,7 @@ public static class BgInfoConfigurationJson {
         public List<BgInfoVariableFile>? Variables { get; set; }
         public List<BgInfoEntryFile>? Entries { get; set; }
         public List<BgInfoChartFile>? Charts { get; set; }
+        public List<BgInfoTopologyFile>? Topologies { get; set; }
     }
 
     internal sealed class BgInfoVariableFile {
@@ -615,6 +863,71 @@ public static class BgInfoConfigurationJson {
         public int? PictorialColumns { get; set; }
         public string? Metric { get; set; }
         public string? MetricArgument { get; set; }
+    }
+
+    internal sealed class BgInfoTopologyFile {
+        public string? Title { get; set; }
+        public string? Subtitle { get; set; }
+        public int? Width { get; set; }
+        public int? Height { get; set; }
+        public string? Anchor { get; set; }
+        public int? OffsetX { get; set; }
+        public int? OffsetY { get; set; }
+        public float? PositionX { get; set; }
+        public float? PositionY { get; set; }
+        public string? Layout { get; set; }
+        public string? Direction { get; set; }
+        public string? NodeDisplayMode { get; set; }
+        public string? VisualStyle { get; set; }
+        public string? CanvasSurfaceStyle { get; set; }
+        public string? Theme { get; set; }
+        public bool? Transparent { get; set; }
+        public bool? ShowTitle { get; set; }
+        public bool? ShowLegend { get; set; }
+        public bool? ShowGroups { get; set; }
+        public bool? ShowEdgeLabels { get; set; }
+        public bool? ShowStatusBadges { get; set; }
+        public bool? FitContentToViewport { get; set; }
+        public List<BgInfoTopologyGroupFile>? Groups { get; set; }
+        public List<BgInfoTopologyNodeFile>? Nodes { get; set; }
+        public List<BgInfoTopologyEdgeFile>? Edges { get; set; }
+    }
+
+    internal sealed class BgInfoTopologyGroupFile {
+        public string? Id { get; set; }
+        public string? Label { get; set; }
+        public string? Subtitle { get; set; }
+        public string? Status { get; set; }
+        public double? Width { get; set; }
+        public double? Height { get; set; }
+        public string? Symbol { get; set; }
+        public string? Color { get; set; }
+    }
+
+    internal sealed class BgInfoTopologyNodeFile {
+        public string? Id { get; set; }
+        public string? Label { get; set; }
+        public string? Subtitle { get; set; }
+        public string? Kind { get; set; }
+        public string? Status { get; set; }
+        public string? GroupId { get; set; }
+        public string? Symbol { get; set; }
+        public string? DisplayMode { get; set; }
+        public string? Badge { get; set; }
+        public string? Color { get; set; }
+    }
+
+    internal sealed class BgInfoTopologyEdgeFile {
+        public string? Id { get; set; }
+        public string? SourceNodeId { get; set; }
+        public string? TargetNodeId { get; set; }
+        public string? Label { get; set; }
+        public string? Kind { get; set; }
+        public string? Status { get; set; }
+        public string? Direction { get; set; }
+        public string? Routing { get; set; }
+        public string? Color { get; set; }
+        public bool? Muted { get; set; }
     }
 }
 

--- a/Sources/PowerBGInfo/BgInfoGenerator.cs
+++ b/Sources/PowerBGInfo/BgInfoGenerator.cs
@@ -198,6 +198,7 @@ public class BgInfoGenerator
         var textBlock = new System.Drawing.RectangleF(textStartX, textStartY, totalWidth, Math.Max(0f, textBlockHeight));
 
         RenderCharts(image, config, textBlock);
+        RenderTopologies(image, config);
 
         _imageService.Save(image, outputPath);
 
@@ -428,6 +429,27 @@ public class BgInfoGenerator
             using var chartImage = BgInfoChartRenderer.Render(chart, values, config);
             var position = ResolveChartPosition(image, chart);
             image.DrawImage(chartImage, position.X, position.Y);
+        }
+    }
+
+    private static void RenderTopologies(Image image, BgInfoConfiguration config)
+    {
+        if (config.Topologies.Count == 0)
+        {
+            return;
+        }
+
+        for (int i = 0; i < config.Topologies.Count; i++)
+        {
+            var topology = config.Topologies[i];
+            if (topology.Nodes.Count == 0)
+            {
+                continue;
+            }
+
+            using var topologyImage = BgInfoTopologyRenderer.Render(topology, config);
+            var position = ResolveTopologyPosition(image, topology);
+            image.DrawImage(topologyImage, position.X, position.Y);
         }
     }
 
@@ -701,6 +723,17 @@ public class BgInfoGenerator
         float chartHeight = Math.Max(1, chart.Height);
         return ResolveChartPosition(new System.Drawing.RectangleF(0, 0, image.Width, image.Height),
             (int)chartWidth, (int)chartHeight, chart.Anchor, chart.OffsetX, chart.OffsetY);
+    }
+
+    private static System.Drawing.PointF ResolveTopologyPosition(Image image, BgInfoTopology topology)
+    {
+        if (topology.PositionX.HasValue && topology.PositionY.HasValue)
+        {
+            return new System.Drawing.PointF(topology.PositionX.Value, topology.PositionY.Value);
+        }
+
+        return ResolveChartPosition(new System.Drawing.RectangleF(0, 0, image.Width, image.Height),
+            Math.Max(1, topology.Width), Math.Max(1, topology.Height), topology.Anchor, topology.OffsetX, topology.OffsetY);
     }
 
     internal static System.Drawing.PointF ResolveChartPosition(System.Drawing.RectangleF area, int chartWidth, int chartHeight, BgInfoTextPosition anchor, int offsetX, int offsetY)

--- a/Sources/PowerBGInfo/BgInfoTopology.cs
+++ b/Sources/PowerBGInfo/BgInfoTopology.cs
@@ -1,0 +1,58 @@
+using System.Collections.Generic;
+using ChartForgeX.Topology;
+
+namespace PowerBGInfo;
+
+/// <summary>Defines a topology diagram block rendered onto the BGInfo output.</summary>
+public sealed class BgInfoTopology {
+    /// <summary>Topology title.</summary>
+    public string Title { get; set; } = string.Empty;
+    /// <summary>Optional topology subtitle.</summary>
+    public string Subtitle { get; set; } = string.Empty;
+    /// <summary>Topology width in pixels.</summary>
+    public int Width { get; set; } = 520;
+    /// <summary>Topology height in pixels.</summary>
+    public int Height { get; set; } = 300;
+    /// <summary>Anchor position used for placement.</summary>
+    public BgInfoTextPosition Anchor { get; set; } = BgInfoTextPosition.BottomRight;
+    /// <summary>Horizontal offset from the anchor.</summary>
+    public int OffsetX { get; set; } = 32;
+    /// <summary>Vertical offset from the anchor.</summary>
+    public int OffsetY { get; set; } = 32;
+    /// <summary>Explicit X position override.</summary>
+    public float? PositionX { get; set; }
+    /// <summary>Explicit Y position override.</summary>
+    public float? PositionY { get; set; }
+    /// <summary>Topology layout mode.</summary>
+    public TopologyLayoutMode Layout { get; set; } = TopologyLayoutMode.Layered;
+    /// <summary>Topology layout direction.</summary>
+    public TopologyLayoutDirection Direction { get; set; } = TopologyLayoutDirection.LeftToRight;
+    /// <summary>Node presentation mode.</summary>
+    public TopologyNodeDisplayMode NodeDisplayMode { get; set; } = TopologyNodeDisplayMode.CompactCard;
+    /// <summary>Reusable visual style.</summary>
+    public TopologyVisualStyle VisualStyle { get; set; } = TopologyVisualStyle.MonitoringDashboard;
+    /// <summary>Canvas surface style.</summary>
+    public TopologyCanvasSurfaceStyle CanvasSurfaceStyle { get; set; } = TopologyCanvasSurfaceStyle.Plain;
+    /// <summary>Theme name.</summary>
+    public string Theme { get; set; } = "Dark";
+    /// <summary>Whether to render a transparent canvas.</summary>
+    public bool Transparent { get; set; } = true;
+    /// <summary>Whether to show the topology title.</summary>
+    public bool ShowTitle { get; set; } = true;
+    /// <summary>Whether to show the topology legend.</summary>
+    public bool ShowLegend { get; set; }
+    /// <summary>Whether to show group containers.</summary>
+    public bool ShowGroups { get; set; } = true;
+    /// <summary>Whether to show edge labels.</summary>
+    public bool ShowEdgeLabels { get; set; } = true;
+    /// <summary>Whether to show status badges.</summary>
+    public bool ShowStatusBadges { get; set; } = true;
+    /// <summary>Whether to fit content into the requested viewport.</summary>
+    public bool FitContentToViewport { get; set; } = true;
+    /// <summary>Topology groups.</summary>
+    public List<TopologyGroup> Groups { get; } = new();
+    /// <summary>Topology nodes.</summary>
+    public List<TopologyNode> Nodes { get; } = new();
+    /// <summary>Topology edges.</summary>
+    public List<TopologyEdge> Edges { get; } = new();
+}

--- a/Sources/PowerBGInfo/BgInfoTopologyRenderer.cs
+++ b/Sources/PowerBGInfo/BgInfoTopologyRenderer.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Drawing;
+using System.IO;
+using ChartForgeX.Topology;
+using ImagePlayground.Gdi;
+using GdiImage = ImagePlayground.Gdi.Image;
+
+namespace PowerBGInfo;
+
+internal static class BgInfoTopologyRenderer {
+    public static GdiImage Render(BgInfoTopology topology, BgInfoConfiguration config) {
+        if (topology == null) {
+            throw new ArgumentNullException(nameof(topology));
+        }
+        if (config == null) {
+            throw new ArgumentNullException(nameof(config));
+        }
+
+        var width = Math.Max(1, topology.Width);
+        var height = Math.Max(1, topology.Height);
+        var chart = BuildTopology(topology, width, height);
+        var options = BuildRenderOptions(topology);
+
+        var image = new GdiImage();
+        image.Create(string.Empty, width, height, Color.Transparent);
+        DrawPng(image, chart.ToPng(options), 0, 0, width, height);
+        return image;
+    }
+
+    private static TopologyChart BuildTopology(BgInfoTopology topology, int width, int height) {
+        var chart = TopologyChart.Create()
+            .WithViewport(width, height, 18)
+            .WithLayout(topology.Layout, topology.Direction)
+            .WithTheme(CreateTheme(topology));
+
+        if (!string.IsNullOrWhiteSpace(topology.Title)) {
+            chart.Title = topology.Title;
+        }
+        if (!string.IsNullOrWhiteSpace(topology.Subtitle)) {
+            chart.Subtitle = topology.Subtitle;
+        }
+
+        chart.Groups.AddRange(topology.Groups);
+        chart.Nodes.AddRange(topology.Nodes);
+        chart.Edges.AddRange(topology.Edges);
+        return chart;
+    }
+
+    private static TopologyRenderOptions BuildRenderOptions(BgInfoTopology topology) {
+        return new TopologyRenderOptions {
+            IncludeTitle = topology.ShowTitle,
+            IncludeLegend = topology.ShowLegend,
+            IncludeGroups = topology.ShowGroups,
+            IncludeEdgeLabels = topology.ShowEdgeLabels,
+            IncludeStatusBadges = topology.ShowStatusBadges,
+            FitContentToViewport = topology.FitContentToViewport,
+            NodeDisplayMode = topology.NodeDisplayMode,
+            VisualStyle = topology.VisualStyle,
+            CanvasSurfaceStyle = topology.Transparent ? TopologyCanvasSurfaceStyle.Plain : topology.CanvasSurfaceStyle,
+            IncludeGroupStatusDots = true,
+            EdgeCornerStyle = TopologyEdgeCornerStyle.Rounded,
+            EdgeCornerRadius = 10
+        };
+    }
+
+    private static TopologyTheme CreateTheme(BgInfoTopology topology) {
+        var theme = topology.Theme.Equals("Light", StringComparison.OrdinalIgnoreCase)
+            ? TopologyTheme.Light()
+            : TopologyTheme.Dark();
+
+        if (topology.Transparent) {
+            theme.Background = topology.Theme.Equals("Light", StringComparison.OrdinalIgnoreCase) ? "#FFFFFF00" : "#0B112000";
+        }
+
+        return theme;
+    }
+
+    private static void DrawPng(GdiImage image, byte[] png, float x, float y, float width, float height) {
+        image.WithGraphics(graphics => {
+            using var stream = new MemoryStream(png);
+            using var bitmap = new Bitmap(stream);
+            graphics.DrawImage(bitmap, x, y, width, height);
+        });
+    }
+}

--- a/Sources/PowerBGInfo/PowerBGInfo.csproj
+++ b/Sources/PowerBGInfo/PowerBGInfo.csproj
@@ -25,7 +25,7 @@
         <ProjectReference Include="$(ChartForgeXProjectPath)" />
     </ItemGroup>
     <ItemGroup Condition="'$(ChartForgeXProjectPath)' == ''">
-        <PackageReference Include="ChartForgeX" Version="0.1.0" />
+        <PackageReference Include="ChartForgeX" Version="0.1.1" />
     </ItemGroup>
     <ItemGroup>
         <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">


### PR DESCRIPTION
## Summary
- Add first-class topology overlays alongside ChartForgeX chart overlays.
- Add topology model, JSON persistence, renderer, PowerShell DSL cmdlets, and a practical topology overlay example.
- Preserve transparent-by-default rendering so topology diagrams melt into wallpaper backgrounds cleanly.

## Validation
- dotnet test Sources\PowerBGInfo.Tests\PowerBGInfo.Tests.csproj -c Debug --no-restore
- dotnet build Sources\PowerBGInfo.PowerShell\PowerBGInfo.PowerShell.csproj -c Debug -f net8.0-windows --no-restore -m:1
- dotnet build Sources\PowerBGInfo.PowerShell\PowerBGInfo.PowerShell.csproj -c Debug -f net472 --no-restore -m:1
- git diff --check