### PR TITLE
Enable isolated PowerBGInfo packaging

### DIFF
--- a/Build/Build-Module.ps1
+++ b/Build/Build-Module.ps1
@@ -20,7 +20,7 @@ Build-Module -ModuleName 'PowerBGInfo' {
         # Description of the functionality provided by this module
         Description            = 'PowerBGInfo is a module that allows you to create background images with information about your environment.'
         # Tags applied to this module. These help with module discovery in online galleries.
-        Tags                   = @('windows', 'image', 'monitor', 'bginfo')
+        Tags                   = @('windows', 'image', 'monitor', 'bginfo', 'charts', 'topology', 'diagrams')
         # A URL to the main website for this project.
         ProjectUri             = 'https://github.com/EvotecIT/PowerBGInfo'
         IconUri                = 'https://evotec.xyz/wp-content/uploads/2022/12/PowerBGInfo.png'
@@ -86,11 +86,12 @@ Build-Module -ModuleName 'PowerBGInfo' {
         NETConfiguration                  = 'Release'
         NETFramework                      = 'net8.0-windows', 'net472'
         NETHandleAssemblyWithSameName     = $true
+        NETAssemblyLoadContext            = $true
         #NETMergeLibraryDebugging          = $true
         DotSourceLibraries                = $true
         DotSourceClasses                  = $true
         DeleteTargetModuleBeforeBuild     = $true
-        NETBinaryModuleDocumenation       = $true
+        NETBinaryModuleDocumentation      = $true
         RefreshPSD1Only                   = $true
     }
 

--- a/PowerBGInfo.psd1
+++ b/PowerBGInfo.psd1
@@ -4,7 +4,7 @@
     CmdletsToExport        = @('New-BGInfo', 'New-BGInfoLabel', 'New-BGInfoValue', 'New-BGInfoVariable', 'New-BGInfoChart', 'New-BGInfoTopology', 'New-BGInfoTopologyEdge', 'New-BGInfoTopologyGroup', 'New-BGInfoTopologyNode', 'Invoke-BGInfo', 'Export-BGInfoConfiguration', 'New-BGInfoConfiguration')
     CompanyName            = 'Evotec'
     CompatiblePSEditions   = @('Desktop', 'Core')
-    Copyright              = '(c) 2011 - 2025 Przemyslaw Klys @ Evotec. All rights reserved.'
+    Copyright              = '(c) 2011 - 2026 Przemyslaw Klys @ Evotec. All rights reserved.'
     Description            = 'PowerBGInfo is a module that allows you to create background images with information about your environment.'
     DotNetFrameworkVersion = '4.7.2'
     FunctionsToExport      = @()
@@ -13,11 +13,15 @@
     PowerShellVersion      = '5.1'
     PrivateData            = @{
         PSData = @{
-            IconUri    = 'https://evotec.xyz/wp-content/uploads/2022/12/PowerBGInfo.png'
-            LicenseUri = 'https://github.com/EvotecIT/PowerBGInfo/blob/master/License'
-            ProjectUri = 'https://github.com/EvotecIT/PowerBGInfo'
-            Tags       = @('windows', 'image', 'monitor', 'bginfo', 'charts', 'topology', 'diagrams')
+            IconUri                    = 'https://evotec.xyz/wp-content/uploads/2022/12/PowerBGInfo.png'
+            LicenseUri                 = 'https://github.com/EvotecIT/PowerBGInfo/blob/master/License'
+            ProjectUri                 = 'https://github.com/EvotecIT/PowerBGInfo'
+            Tags                       = @('windows', 'image', 'monitor', 'bginfo', 'charts', 'topology', 'diagrams')
+            RequireLicenseAcceptance   = $false
+            ExternalModuleDependencies = @()
         }
     }
     RootModule             = 'PowerBGInfo.psm1'
+    RequiredModules        = @()
+    ScriptsToProcess       = @()
 }


### PR DESCRIPTION
## Summary
- enable PSPublishModule assembly-load-context packaging for PowerBGInfo
- use the current NETBinaryModuleDocumentation key
- keep chart/topology/diagram package tags in the generated manifest

## Validation
- dotnet restore Sources/PowerBGInfo.sln
- dotnet build Sources/PowerBGInfo.Tests/PowerBGInfo.Tests.csproj --configuration Debug --no-restore /nr:false
- dotnet build Sources/PowerBGInfo.PowerShell/PowerBGInfo.PowerShell.csproj --configuration Release --framework net8.0-windows --no-restore /nr:false
- dotnet test Sources/PowerBGInfo.Tests/PowerBGInfo.Tests.csproj --configuration Debug --no-build --verbosity normal
- ./Build/Build-Module.ps1
- Test-ModuleManifest ./PowerBGInfo.psd1
- git diff --check