### PR TITLE
Add packaged ALC validation

### DIFF
--- a/.github/workflows/test-powershell.yml
+++ b/.github/workflows/test-powershell.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup PowerShell modules
         shell: pwsh
         run: |
-          Install-Module PSPublishModule -Force -Scope CurrentUser -AllowClobber
+          Install-Module PSPublishModule -MinimumVersion 3.0.4 -Force -Scope CurrentUser -AllowClobber
 
       - name: Refresh module manifest
         shell: pwsh
@@ -116,3 +116,52 @@ jobs:
       - name: Run PowerShell tests
         shell: pwsh
         run: ./PowerBGInfo.Tests.ps1
+
+  test-windows-packaged-alc:
+    needs: refresh-psd1
+    name: 'Windows Packaged ALC'
+    runs-on: windows-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Download manifest
+        uses: actions/download-artifact@v4
+        with:
+          name: psd1
+          path: .
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            9.0.x
+            ${{ env.DOTNET_VERSION }}
+
+      - name: Install PowerShell modules
+        shell: pwsh
+        run: |
+          Write-Host "PowerShell Version: $($PSVersionTable.PSVersion)"
+          Install-Module -Name PSPublishModule -Repository PSGallery -MinimumVersion 3.0.4 -Force -Scope CurrentUser -AllowClobber
+          Install-Module -Name Pester -Repository PSGallery -Force -SkipPublisherCheck -AllowClobber
+          Install-Module -Name PSWriteColor -Repository PSGallery -Force -SkipPublisherCheck -AllowClobber
+
+      - name: Build packaged module
+        shell: pwsh
+        env:
+          RefreshPSD1Only: 'false'
+        run: ./Build/Build-Module.ps1
+        timeout-minutes: 15
+
+      - name: Run packaged ALC smoke test
+        shell: pwsh
+        env:
+          PowerBGInfoPackagedAlcRequired: 'true'
+        run: |
+          Import-Module Pester -Force
+          $config = [PesterConfiguration]::Default
+          $config.Run.Path = 'Tests/AssemblyLoadContext.Conflict.Tests.ps1'
+          $config.Run.Exit = $true
+          $config.Output.Verbosity = 'Detailed'
+          Invoke-Pester -Configuration $config
+        timeout-minutes: 5

--- a/Build/Build-Module.ps1
+++ b/Build/Build-Module.ps1
@@ -1,6 +1,26 @@
 Import-Module PSPublishModule -Force -ErrorAction Stop
 
 Build-Module -ModuleName 'PowerBGInfo' {
+    function ConvertTo-BuildBoolean {
+        param(
+            [string] $Value,
+            [bool] $Default
+        )
+
+        if ([string]::IsNullOrWhiteSpace($Value)) {
+            return $Default
+        }
+
+        switch ($Value.Trim().ToLowerInvariant()) {
+            { $_ -in '1', 'true', 'yes', 'on' } { return $true }
+            { $_ -in '0', 'false', 'no', 'off' } { return $false }
+            default { throw "Unsupported boolean value '$Value'. Use true/false, 1/0, yes/no, or on/off." }
+        }
+    }
+
+    $certificateThumbprint = '483292C9E317AA13B07BB7A96AE9D1A5ED9E7703'
+    $signModule = -not (ConvertTo-BuildBoolean -Value $Env:CI -Default:$false)
+
     # Usual defaults as per standard module
     $Manifest = [ordered] @{
         # Minimum version of the Windows PowerShell engine required by this module
@@ -76,23 +96,43 @@ Build-Module -ModuleName 'PowerBGInfo' {
 
     $newConfigurationBuildSplat = @{
         Enable                            = $true
-        SignModule                        = $true
+        SignModule                        = $signModule
         MergeModuleOnBuild                = $true
         MergeFunctionsFromApprovedModules = $true
-        CertificateThumbprint             = '483292C9E317AA13B07BB7A96AE9D1A5ED9E7703'
+        CertificateThumbprint             = $certificateThumbprint
         ResolveBinaryConflicts            = $true
         ResolveBinaryConflictsName        = 'PowerBGInfo.PowerShell'
         NETProjectName                    = 'PowerBGInfo.PowerShell'
+        NETProjectPath                    = (Resolve-Path -LiteralPath (Join-Path $PSScriptRoot '..\Sources\PowerBGInfo.PowerShell\PowerBGInfo.PowerShell.csproj')).Path
         NETConfiguration                  = 'Release'
         NETFramework                      = 'net8.0-windows', 'net472'
         NETHandleAssemblyWithSameName     = $true
         NETAssemblyLoadContext            = $true
+        NETAssemblyTypeAcceleratorMode    = 'AllowList'
+        NETAssemblyTypeAccelerators       = @(
+            'PowerBGInfo.BgInfoConfiguration'
+            'PowerBGInfo.BgInfoConfigurationJson'
+            'PowerBGInfo.BgInfoEntry'
+            'PowerBGInfo.BgInfoEntryType'
+            'PowerBGInfo.BgInfoVariable'
+            'PowerBGInfo.BgInfoVariableProvider'
+            'PowerBGInfo.BgInfoChart'
+            'PowerBGInfo.BgInfoChartKind'
+            'PowerBGInfo.BgInfoChartLegendPosition'
+            'PowerBGInfo.BgInfoChartMetric'
+            'PowerBGInfo.BgInfoChartPictorialSymbol'
+            'PowerBGInfo.BgInfoChartLayoutMode'
+            'PowerBGInfo.BgInfoChartStackDirection'
+            'PowerBGInfo.BgInfoTarget'
+            'PowerBGInfo.BgInfoTextPosition'
+            'PowerBGInfo.BgInfoTopology'
+        )
         #NETMergeLibraryDebugging          = $true
         DotSourceLibraries                = $true
         DotSourceClasses                  = $true
         DeleteTargetModuleBeforeBuild     = $true
         NETBinaryModuleDocumentation      = $true
-        RefreshPSD1Only                   = $true
+        RefreshPSD1Only                   = ConvertTo-BuildBoolean -Value $Env:RefreshPSD1Only -Default:$true
     }
 
     New-ConfigurationBuild @newConfigurationBuildSplat

--- a/Tests/AssemblyLoadContext.Conflict.Tests.ps1
+++ b/Tests/AssemblyLoadContext.Conflict.Tests.ps1
@@ -1,0 +1,91 @@
+Describe 'Packaged AssemblyLoadContext isolation' {
+    It 'loads the packaged binary module through the PowerBGInfo ALC' {
+        $packagedAlcRequired = $Env:PowerBGInfoPackagedAlcRequired -eq 'true'
+        $packagedModuleRoot = Join-Path $PSScriptRoot '..\Artefacts\Unpacked\Modules'
+        $packagedModule = Join-Path $packagedModuleRoot 'PowerBGInfo'
+        $packagedLoader = Join-Path $packagedModule 'Lib\Core\PowerBGInfo.ModuleLoadContext.dll'
+        if ($PSVersionTable.PSEdition -ne 'Core') {
+            Set-ItResult -Skipped -Because 'AssemblyLoadContext validation requires PowerShell Core'
+            return
+        }
+
+        if (-not $packagedAlcRequired) {
+            Set-ItResult -Skipped -Because 'packaged AssemblyLoadContext validation runs in the packaged ALC job'
+            return
+        }
+
+        Test-Path -LiteralPath $packagedLoader | Should -BeTrue -Because 'the packaged build must produce the module-scoped ALC loader'
+
+        $moduleRootLiteral = $packagedModuleRoot.Replace("'", "''")
+        $script = @"
+`$ErrorActionPreference = 'Stop'
+`$WarningPreference = 'SilentlyContinue'
+`$moduleRoot = '$moduleRootLiteral'
+`$env:PSModulePath = `$moduleRoot + [IO.Path]::PathSeparator + `$env:PSModulePath
+
+Import-Module PowerBGInfo -Force
+
+`$outputDir = Join-Path ([IO.Path]::GetTempPath()) ('powerbginfo-alc-' + [Guid]::NewGuid().ToString('N'))
+`$result = New-BGInfo -Target File -ConfigurationDirectory `$outputDir -OutputFileName 'alc.png' -BackgroundColor Black {
+    New-BGInfoValue -Name 'ALC' -Value 'PowerBGInfo'
+}
+
+`$command = Get-Command New-BGInfo -ErrorAction Stop
+`$commandAssembly = `$command.ImplementingType.Assembly
+`$commandAlc = [System.Runtime.Loader.AssemblyLoadContext]::GetLoadContext(`$commandAssembly)
+`$loadedAssemblies = [System.Runtime.Loader.AssemblyLoadContext]::All |
+    ForEach-Object {
+        `$alc = `$_
+        foreach (`$assembly in `$alc.Assemblies) {
+            if (`$assembly.GetName().Name -in @('PowerBGInfo.PowerShell', 'PowerBGInfo', 'DesktopManager', 'ImagePlayground.Gdi')) {
+                [pscustomobject]@{
+                    Assembly = `$assembly.GetName().Name
+                    Version = `$assembly.GetName().Version.ToString()
+                    ALC = `$alc.Name
+                    IsDefault = [object]::ReferenceEquals(`$alc, [System.Runtime.Loader.AssemblyLoadContext]::Default)
+                }
+            }
+        }
+    }
+
+[pscustomobject]@{
+    OutputExists = Test-Path -LiteralPath `$result
+    NewBGInfoAssembly = `$commandAssembly.Location
+    NewBGInfoALC = `$commandAlc.Name
+    NewBGInfoALCIsDefault = [object]::ReferenceEquals(`$commandAlc, [System.Runtime.Loader.AssemblyLoadContext]::Default)
+    ConfigurationAccelerator = [PowerBGInfo.BgInfoConfiguration].FullName
+    ConfigurationJsonAccelerator = [PowerBGInfo.BgInfoConfigurationJson].FullName
+    ChartLegendAccelerator = [PowerBGInfo.BgInfoChartLegendPosition].FullName
+    ChartPictorialAccelerator = [PowerBGInfo.BgInfoChartPictorialSymbol].FullName
+    TargetAccelerator = [PowerBGInfo.BgInfoTarget].FullName
+    LoadedAssemblies = @(`$loadedAssemblies)
+} | ConvertTo-Json -Depth 6 -Compress
+"@
+        $encoded = [Convert]::ToBase64String([Text.Encoding]::Unicode.GetBytes($script))
+        $output = pwsh -NoProfile -ExecutionPolicy Bypass -EncodedCommand $encoded 2>&1
+        $LASTEXITCODE | Should -Be 0 -Because ($output -join [Environment]::NewLine)
+
+        $json = $output | Where-Object { $_ -is [string] -and $_.TrimStart().StartsWith('{') } | Select-Object -Last 1
+        $json | Should -Not -BeNullOrEmpty -Because ($output -join [Environment]::NewLine)
+        $result = $json | ConvertFrom-Json
+
+        $result.OutputExists | Should -BeTrue
+        $result.NewBGInfoAssembly | Should -BeLike '*\Artefacts\Unpacked\Modules\PowerBGInfo\Lib\Core\PowerBGInfo.PowerShell.dll'
+        $result.NewBGInfoALC | Should -Be 'PowerBGInfo'
+        $result.NewBGInfoALCIsDefault | Should -BeFalse
+        $result.ConfigurationAccelerator | Should -Be 'PowerBGInfo.BgInfoConfiguration'
+        $result.ConfigurationJsonAccelerator | Should -Be 'PowerBGInfo.BgInfoConfigurationJson'
+        $result.ChartLegendAccelerator | Should -Be 'PowerBGInfo.BgInfoChartLegendPosition'
+        $result.ChartPictorialAccelerator | Should -Be 'PowerBGInfo.BgInfoChartPictorialSymbol'
+        $result.TargetAccelerator | Should -Be 'PowerBGInfo.BgInfoTarget'
+
+        $loadedAssemblies = @($result.LoadedAssemblies)
+        $powerShellAssembly = $loadedAssemblies | Where-Object Assembly -eq 'PowerBGInfo.PowerShell' | Select-Object -First 1
+        $coreAssembly = $loadedAssemblies | Where-Object Assembly -eq 'PowerBGInfo' | Select-Object -First 1
+
+        $powerShellAssembly.ALC | Should -Be 'PowerBGInfo'
+        $powerShellAssembly.IsDefault | Should -BeFalse
+        $coreAssembly.ALC | Should -Be 'PowerBGInfo'
+        $coreAssembly.IsDefault | Should -BeFalse
+    }
+}


### PR DESCRIPTION
## Summary
- enable full PSPublishModule ALC packaging for PowerBGInfo by making `RefreshPSD1Only` env-driven
- add allowlisted type accelerators for public PowerBGInfo configuration/model types loaded through the module ALC
- add a packaged ALC CI job and smoke test that imports the built artifact and proves the binary module loads outside the default ALC

## Validation
- `RefreshPSD1Only=false ./Build/Build-Module.ps1`
- packaged ALC Pester test: 1 passed
- `pwsh -NoLogo -NoProfile -File ./PowerBGInfo.Tests.ps1`
- `dotnet test ./Sources/PowerBGInfo.sln -c Release`
- `git diff --cached --check`
