### PR TITLE
Add ChartForgeX visual canvas overlay support

### DIFF
--- a/.github/workflows/test-dotnet.yml
+++ b/.github/workflows/test-dotnet.yml
@@ -26,11 +26,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Checkout ChartForgeX visual canvas dependency
+      - name: Checkout ChartForgeX dependency
         uses: actions/checkout@v4
         with:
           repository: EvotecIT/ChartForgeX
-          ref: codex/visual-canvas
+          ref: main
           path: external/ChartForgeX
 
       - name: Setup .NET

--- a/.github/workflows/test-dotnet.yml
+++ b/.github/workflows/test-dotnet.yml
@@ -16,6 +16,7 @@ on:
 env:
   DOTNET_VERSION: '8.x'
   BUILD_CONFIGURATION: 'Release'
+  ChartForgeXProjectPath: '${{ github.workspace }}\external\ChartForgeX\ChartForgeX\ChartForgeX.csproj'
 
 jobs:
   test-windows:
@@ -25,6 +26,13 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Checkout ChartForgeX visual canvas dependency
+        uses: actions/checkout@v4
+        with:
+          repository: EvotecIT/ChartForgeX
+          ref: codex/visual-canvas
+          path: external/ChartForgeX
+
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
@@ -33,13 +41,13 @@ jobs:
             ${{ env.DOTNET_VERSION }}
 
       - name: Restore dependencies
-        run: dotnet restore Sources/PowerBGInfo.sln
+        run: dotnet restore Sources/PowerBGInfo.sln -p:ChartForgeXProjectPath="$env:ChartForgeXProjectPath"
 
       - name: Build solution
-        run: dotnet build Sources/PowerBGInfo.sln --configuration ${{ env.BUILD_CONFIGURATION }} --no-restore
+        run: dotnet build Sources/PowerBGInfo.sln --configuration ${{ env.BUILD_CONFIGURATION }} --no-restore -p:ChartForgeXProjectPath="$env:ChartForgeXProjectPath"
 
       - name: Run tests
-        run: dotnet test Sources/PowerBGInfo.Tests/PowerBGInfo.Tests.csproj --configuration ${{ env.BUILD_CONFIGURATION }} --framework net8.0-windows --no-build --verbosity normal --logger trx --collect:"XPlat Code Coverage"
+        run: dotnet test Sources/PowerBGInfo.Tests/PowerBGInfo.Tests.csproj --configuration ${{ env.BUILD_CONFIGURATION }} --framework net8.0-windows --no-build --verbosity normal --logger trx --collect:"XPlat Code Coverage" -p:ChartForgeXProjectPath="$env:ChartForgeXProjectPath"
 
       - name: Export config from PowerShell
         shell: pwsh
@@ -59,7 +67,7 @@ jobs:
           }
 
       - name: Publish CLI single-file
-        run: dotnet publish Sources/PowerBGInfo.Cli/PowerBGInfo.Cli.csproj --configuration ${{ env.BUILD_CONFIGURATION }} --framework net8.0-windows --runtime win-x64 --self-contained false -p:PublishSingleFile=true -o artifacts/cli-singlefile
+        run: dotnet publish Sources/PowerBGInfo.Cli/PowerBGInfo.Cli.csproj --configuration ${{ env.BUILD_CONFIGURATION }} --framework net8.0-windows --runtime win-x64 --self-contained false -p:PublishSingleFile=true -p:ChartForgeXProjectPath="$env:ChartForgeXProjectPath" -o artifacts/cli-singlefile
 
       - name: Run published CLI with PowerShell-generated config
         shell: pwsh
@@ -96,7 +104,7 @@ jobs:
           }
 
       - name: Publish CLI NativeAOT smoke build
-        run: dotnet publish Sources/PowerBGInfo.Cli/PowerBGInfo.Cli.csproj --configuration ${{ env.BUILD_CONFIGURATION }} --framework net8.0-windows --runtime win-x64 -p:PublishAot=true -o artifacts/cli-aot
+        run: dotnet publish Sources/PowerBGInfo.Cli/PowerBGInfo.Cli.csproj --configuration ${{ env.BUILD_CONFIGURATION }} --framework net8.0-windows --runtime win-x64 -p:PublishAot=true -p:ChartForgeXProjectPath="$env:ChartForgeXProjectPath" -o artifacts/cli-aot
 
       - name: Run NativeAOT CLI with PowerShell-generated config
         shell: pwsh

--- a/.github/workflows/test-powershell.yml
+++ b/.github/workflows/test-powershell.yml
@@ -16,6 +16,7 @@ on:
 env:
   DOTNET_VERSION: '8.x'
   BUILD_CONFIGURATION: 'Debug'
+  ChartForgeXProjectPath: '${{ github.workspace }}\external\ChartForgeX\ChartForgeX\ChartForgeX.csproj'
 
 jobs:
   refresh-psd1:
@@ -24,6 +25,13 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Checkout ChartForgeX visual canvas dependency
+        uses: actions/checkout@v4
+        with:
+          repository: EvotecIT/ChartForgeX
+          ref: codex/visual-canvas
+          path: external/ChartForgeX
 
       - name: Setup PowerShell modules
         shell: pwsh
@@ -51,6 +59,13 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Checkout ChartForgeX visual canvas dependency
+        uses: actions/checkout@v4
+        with:
+          repository: EvotecIT/ChartForgeX
+          ref: codex/visual-canvas
+          path: external/ChartForgeX
+
       - name: Download manifest
         uses: actions/download-artifact@v4
         with:
@@ -73,8 +88,8 @@ jobs:
 
       - name: Build .NET solution
         run: |
-          dotnet restore Sources/PowerBGInfo.sln
-          dotnet build Sources/PowerBGInfo.sln --configuration ${{ env.BUILD_CONFIGURATION }} --no-restore
+          dotnet restore Sources/PowerBGInfo.sln -p:ChartForgeXProjectPath="$env:ChartForgeXProjectPath"
+          dotnet build Sources/PowerBGInfo.sln --configuration ${{ env.BUILD_CONFIGURATION }} --no-restore -p:ChartForgeXProjectPath="$env:ChartForgeXProjectPath"
 
       - name: Run PowerShell tests
         shell: powershell
@@ -88,6 +103,13 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Checkout ChartForgeX visual canvas dependency
+        uses: actions/checkout@v4
+        with:
+          repository: EvotecIT/ChartForgeX
+          ref: codex/visual-canvas
+          path: external/ChartForgeX
+
       - name: Download manifest
         uses: actions/download-artifact@v4
         with:
@@ -110,8 +132,8 @@ jobs:
 
       - name: Build .NET solution
         run: |
-          dotnet restore Sources/PowerBGInfo.sln
-          dotnet build Sources/PowerBGInfo.sln --configuration ${{ env.BUILD_CONFIGURATION }} --no-restore
+          dotnet restore Sources/PowerBGInfo.sln -p:ChartForgeXProjectPath="$env:ChartForgeXProjectPath"
+          dotnet build Sources/PowerBGInfo.sln --configuration ${{ env.BUILD_CONFIGURATION }} --no-restore -p:ChartForgeXProjectPath="$env:ChartForgeXProjectPath"
 
       - name: Run PowerShell tests
         shell: pwsh
@@ -124,6 +146,13 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Checkout ChartForgeX visual canvas dependency
+        uses: actions/checkout@v4
+        with:
+          repository: EvotecIT/ChartForgeX
+          ref: codex/visual-canvas
+          path: external/ChartForgeX
 
       - name: Download manifest
         uses: actions/download-artifact@v4

--- a/.github/workflows/test-powershell.yml
+++ b/.github/workflows/test-powershell.yml
@@ -26,11 +26,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Checkout ChartForgeX visual canvas dependency
+      - name: Checkout ChartForgeX dependency
         uses: actions/checkout@v4
         with:
           repository: EvotecIT/ChartForgeX
-          ref: codex/visual-canvas
+          ref: main
           path: external/ChartForgeX
 
       - name: Setup PowerShell modules
@@ -59,11 +59,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Checkout ChartForgeX visual canvas dependency
+      - name: Checkout ChartForgeX dependency
         uses: actions/checkout@v4
         with:
           repository: EvotecIT/ChartForgeX
-          ref: codex/visual-canvas
+          ref: main
           path: external/ChartForgeX
 
       - name: Download manifest
@@ -103,11 +103,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Checkout ChartForgeX visual canvas dependency
+      - name: Checkout ChartForgeX dependency
         uses: actions/checkout@v4
         with:
           repository: EvotecIT/ChartForgeX
-          ref: codex/visual-canvas
+          ref: main
           path: external/ChartForgeX
 
       - name: Download manifest
@@ -147,11 +147,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Checkout ChartForgeX visual canvas dependency
+      - name: Checkout ChartForgeX dependency
         uses: actions/checkout@v4
         with:
           repository: EvotecIT/ChartForgeX
-          ref: codex/visual-canvas
+          ref: main
           path: external/ChartForgeX
 
       - name: Download manifest

--- a/Examples/Scripts/PowerBGInfo.VisualCanvas.MiniCharts.ps1
+++ b/Examples/Scripts/PowerBGInfo.VisualCanvas.MiniCharts.ps1
@@ -1,0 +1,76 @@
+Import-Module (Join-Path -Path $PSScriptRoot -ChildPath '..\..\PowerBGInfo.psd1') -Force
+
+$examplesPath = (Resolve-Path (Join-Path -Path $PSScriptRoot -ChildPath '..')).Path
+$sampleImage = Join-Path -Path $examplesPath -ChildPath 'Samples\TapC-Evotec-2560x1080.jpg'
+$logoImage = Join-Path -Path $examplesPath -ChildPath 'Samples\LogoEvotec.png'
+$outputDirectory = Join-Path -Path $examplesPath -ChildPath 'Output'
+
+$palette = @{
+    Accent                 = '#38BDF8'
+    SecondaryAccent        = '#60A5FA'
+    TitleColor             = '#F8FAFC'
+    TitleAccentColor       = '#38BDF8'
+    SubtitleColor          = '#E2E8F0'
+    TileLabelColor         = '#C7D2FE'
+    TileValueColor         = '#FFFFFF'
+    TileDetailColor        = '#B6C4DA'
+    TileGlassTop           = '#EE132444'
+    TileGlassBottom        = '#D9040A18'
+    TileProgressTrackColor = '#F0263A5E'
+    HeroBadgeTop           = '#13284C'
+    HeroBadgeBottom        = '#061225'
+    HeroBadgeTextColor     = '#F8FBFF'
+}
+
+$chart = @{
+    Background = '#A6081224'
+    Text       = '#F8FAFC'
+    Grid       = '#342F80FF'
+    Cpu        = '#38BDF8'
+    Memory     = '#60A5FA'
+    Disk       = '#34D399'
+    Patch      = '#FBBF24'
+}
+
+$tiles = @(
+    New-BGInfoVisualCanvasTile -Side Left -IconKind Computer -SurfaceStyle Glass -Label HOSTNAME -Value '{{HostName}}'
+    New-BGInfoVisualCanvasTile -Side Left -IconKind Network -SurfaceStyle Glass -Label 'IP ADDRESS' -Value '{{IPv4Address}}'
+    New-BGInfoVisualCanvasTile -Side Left -IconKind OperatingSystem -SurfaceStyle Glass -Label 'OPERATING SYSTEM' -Value '{{OSName}}' -Detail '{{OSVersion}}'
+    New-BGInfoVisualCanvasTile -Side Left -IconKind Shield -SurfaceStyle Glass -Label PATCHING -Value '89% compliant' -Progress 0.89
+    New-BGInfoVisualCanvasTile -Side Right -IconKind Cpu -SurfaceStyle Glass -Label CPU -Value '{{CpuCores}} cores / {{CpuLogicalCores}} threads' -Progress 0.28
+    New-BGInfoVisualCanvasTile -Side Right -IconKind Memory -SurfaceStyle Glass -Label RAM -Value '{{RAMSize}}' -Progress 0.41
+    New-BGInfoVisualCanvasTile -Side Right -IconKind Storage -SurfaceStyle Glass -Label 'SYSTEM DRIVE' -Value '62% free' -Progress 0.62
+    New-BGInfoVisualCanvasTile -Side Right -IconKind Domain -SurfaceStyle Glass -Label DOMAIN -Value '{{UserDNSDomain}}'
+)
+
+New-BGInfo -MonitorIndex 0 -Target File {
+    New-BGInfoVisualCanvas `
+        -Title 'PowerBGInfo' `
+        -Subtitle 'Mini charts stay below the hero and away from the side rails' `
+        -Accent $palette.Accent `
+        -SecondaryAccent $palette.SecondaryAccent `
+        -TitleColor $palette.TitleColor `
+        -TitleAccentColor $palette.TitleAccentColor `
+        -SubtitleColor $palette.SubtitleColor `
+        -TileLabelColor $palette.TileLabelColor `
+        -TileValueColor $palette.TileValueColor `
+        -TileDetailColor $palette.TileDetailColor `
+        -TileGlassTop $palette.TileGlassTop `
+        -TileGlassBottom $palette.TileGlassBottom `
+        -TileProgressTrackColor $palette.TileProgressTrackColor `
+        -HeroBadgeTop $palette.HeroBadgeTop `
+        -HeroBadgeBottom $palette.HeroBadgeBottom `
+        -HeroBadgeTextColor $palette.HeroBadgeTextColor `
+        -Tile $tiles
+
+    New-BGInfoChart -Id 'visual-cpu-spark' -Title 'CPU burst' -Kind Area -Values 18,26,22,37,48,43,51,35,29,41,33 -ValueSuffix '%' -Width 260 -Height 112 -Anchor BottomCenter -OffsetX -450 -OffsetY 210 -LineColor $chart.Cpu -FillColor $chart.Cpu -TextColor $chart.Text -BackgroundColor $chart.Background -GridColor $chart.Grid -ShowGrid -GridLineCount 3 -NoHistory
+    New-BGInfoChart -Id 'visual-ram-ring' -Title 'Memory load' -Kind RadialBar -Values 41 -ValueSuffix '%' -Width 230 -Height 112 -Anchor BottomCenter -OffsetX -150 -OffsetY 210 -LineColor $chart.Memory -TextColor $chart.Text -BackgroundColor $chart.Background -Maximum 100 -NoHistory
+    New-BGInfoChart -Id 'visual-disk-progress' -Title 'Disk free' -Kind ProgressBar -Values 62 -Labels 'C:' -ValueSuffix '%' -Width 260 -Height 112 -Anchor BottomCenter -OffsetX 145 -OffsetY 210 -LineColor $chart.Disk -TextColor $chart.Text -BackgroundColor $chart.Background -Maximum 100 -ProgressBarThicknessRatio 0.22 -NoProgressHandles -NoHistory
+    New-BGInfoChart -Id 'visual-patch-target' -Title 'Patch target' -Kind Bullet -Values 89 -Target 95 -RangeEnds 70,85 -ValueSuffix '%' -Width 280 -Height 112 -Anchor BottomCenter -OffsetX 455 -OffsetY 210 -LineColor $chart.Patch -TextColor $chart.Text -BackgroundColor $chart.Background -Maximum 100 -ShowLatestValue:$false -NoHistory
+
+    New-BGInfoImage -Path $logoImage -Width 210 -Anchor BottomRight -OffsetX 72 -OffsetY 54 -Opacity 0.92
+} -FilePath $sampleImage `
+    -ConfigurationDirectory $outputDirectory `
+    -OutputFileName 'PowerBGInfo.VisualCanvas.MiniCharts.jpg' `
+    -WallpaperFit Fill `
+    -BackgroundColor Black

--- a/Examples/Scripts/PowerBGInfo.VisualCanvas.MiniCharts.ps1
+++ b/Examples/Scripts/PowerBGInfo.VisualCanvas.MiniCharts.ps1
@@ -22,31 +22,21 @@ $palette = @{
     HeroBadgeTextColor     = '#F8FBFF'
 }
 
-$chart = @{
-    Background = '#A6081224'
-    Text       = '#F8FAFC'
-    Grid       = '#342F80FF'
-    Cpu        = '#38BDF8'
-    Memory     = '#60A5FA'
-    Disk       = '#34D399'
-    Patch      = '#FBBF24'
-}
-
 $tiles = @(
     New-BGInfoVisualCanvasTile -Side Left -IconKind Computer -SurfaceStyle Glass -Label HOSTNAME -Value '{{HostName}}'
     New-BGInfoVisualCanvasTile -Side Left -IconKind Network -SurfaceStyle Glass -Label 'IP ADDRESS' -Value '{{IPv4Address}}'
     New-BGInfoVisualCanvasTile -Side Left -IconKind OperatingSystem -SurfaceStyle Glass -Label 'OPERATING SYSTEM' -Value '{{OSName}}' -Detail '{{OSVersion}}'
-    New-BGInfoVisualCanvasTile -Side Left -IconKind Shield -SurfaceStyle Glass -Label PATCHING -Value '89% compliant' -Progress 0.89
-    New-BGInfoVisualCanvasTile -Side Right -IconKind Cpu -SurfaceStyle Glass -Label CPU -Value '{{CpuCores}} cores / {{CpuLogicalCores}} threads' -Progress 0.28
-    New-BGInfoVisualCanvasTile -Side Right -IconKind Memory -SurfaceStyle Glass -Label RAM -Value '{{RAMSize}}' -Progress 0.41
-    New-BGInfoVisualCanvasTile -Side Right -IconKind Storage -SurfaceStyle Glass -Label 'SYSTEM DRIVE' -Value '62% free' -Progress 0.62
+    New-BGInfoVisualCanvasTile -Side Left -IconKind Shield -SurfaceStyle Glass -Label PATCHING -Value '89% compliant' -Progress 0.89 -MiniChartKind Bars -MiniChartValues 70,75,79,83,86,89 -MiniChartMaximum 100
+    New-BGInfoVisualCanvasTile -Side Right -IconKind Cpu -SurfaceStyle Glass -Label CPU -Value '{{CpuCores}} cores / {{CpuLogicalCores}} threads' -Progress 0.28 -MiniChartKind Area -MiniChartValues 18,26,22,37,48,43,51,35,29,41,33 -MiniChartMaximum 100
+    New-BGInfoVisualCanvasTile -Side Right -IconKind Memory -SurfaceStyle Glass -Label RAM -Value '{{RAMSize}}' -Progress 0.41 -MiniChartKind Bars -MiniChartValues 36,39,41,42,44,43,41 -MiniChartMaximum 100
+    New-BGInfoVisualCanvasTile -Side Right -IconKind Storage -SurfaceStyle Glass -Label 'SYSTEM DRIVE' -Value '62% free' -Progress 0.62 -MiniChartKind Sparkline -MiniChartValues 66,65,64,64,63,62,62 -MiniChartMaximum 100
     New-BGInfoVisualCanvasTile -Side Right -IconKind Domain -SurfaceStyle Glass -Label DOMAIN -Value '{{UserDNSDomain}}'
 )
 
 New-BGInfo -MonitorIndex 0 -Target File {
     New-BGInfoVisualCanvas `
         -Title 'PowerBGInfo' `
-        -Subtitle 'Mini charts stay below the hero and away from the side rails' `
+        -Subtitle 'Mini charts live inside the matching desktop sections' `
         -Accent $palette.Accent `
         -SecondaryAccent $palette.SecondaryAccent `
         -TitleColor $palette.TitleColor `
@@ -62,11 +52,6 @@ New-BGInfo -MonitorIndex 0 -Target File {
         -HeroBadgeBottom $palette.HeroBadgeBottom `
         -HeroBadgeTextColor $palette.HeroBadgeTextColor `
         -Tile $tiles
-
-    New-BGInfoChart -Id 'visual-cpu-spark' -Title 'CPU burst' -Kind Area -Values 18,26,22,37,48,43,51,35,29,41,33 -ValueSuffix '%' -Width 260 -Height 112 -Anchor BottomCenter -OffsetX -450 -OffsetY 210 -LineColor $chart.Cpu -FillColor $chart.Cpu -TextColor $chart.Text -BackgroundColor $chart.Background -GridColor $chart.Grid -ShowGrid -GridLineCount 3 -NoHistory
-    New-BGInfoChart -Id 'visual-ram-ring' -Title 'Memory load' -Kind RadialBar -Values 41 -ValueSuffix '%' -Width 230 -Height 112 -Anchor BottomCenter -OffsetX -150 -OffsetY 210 -LineColor $chart.Memory -TextColor $chart.Text -BackgroundColor $chart.Background -Maximum 100 -NoHistory
-    New-BGInfoChart -Id 'visual-disk-progress' -Title 'Disk free' -Kind ProgressBar -Values 62 -Labels 'C:' -ValueSuffix '%' -Width 260 -Height 112 -Anchor BottomCenter -OffsetX 145 -OffsetY 210 -LineColor $chart.Disk -TextColor $chart.Text -BackgroundColor $chart.Background -Maximum 100 -ProgressBarThicknessRatio 0.22 -NoProgressHandles -NoHistory
-    New-BGInfoChart -Id 'visual-patch-target' -Title 'Patch target' -Kind Bullet -Values 89 -Target 95 -RangeEnds 70,85 -ValueSuffix '%' -Width 280 -Height 112 -Anchor BottomCenter -OffsetX 455 -OffsetY 210 -LineColor $chart.Patch -TextColor $chart.Text -BackgroundColor $chart.Background -Maximum 100 -ShowLatestValue:$false -NoHistory
 
     New-BGInfoImage -Path $logoImage -Width 210 -Anchor BottomRight -OffsetX 72 -OffsetY 54 -Opacity 0.92
 } -FilePath $sampleImage `

--- a/Examples/Scripts/PowerBGInfo.VisualCanvas.MiniCharts.ps1
+++ b/Examples/Scripts/PowerBGInfo.VisualCanvas.MiniCharts.ps1
@@ -26,17 +26,17 @@ $tiles = @(
     New-BGInfoVisualCanvasTile -Side Left -IconKind Computer -SurfaceStyle Glass -Label HOSTNAME -Value '{{HostName}}'
     New-BGInfoVisualCanvasTile -Side Left -IconKind Network -SurfaceStyle Glass -Label 'IP ADDRESS' -Value '{{IPv4Address}}'
     New-BGInfoVisualCanvasTile -Side Left -IconKind OperatingSystem -SurfaceStyle Glass -Label 'OPERATING SYSTEM' -Value '{{OSName}}' -Detail '{{OSVersion}}'
-    New-BGInfoVisualCanvasTile -Side Left -IconKind Shield -SurfaceStyle Glass -Label PATCHING -Value '89% compliant' -Progress 0.89 -MiniChartKind Bars -MiniChartValues 70,75,79,83,86,89 -MiniChartMaximum 100
-    New-BGInfoVisualCanvasTile -Side Right -IconKind Cpu -SurfaceStyle Glass -Label CPU -Value '{{CpuCores}} cores / {{CpuLogicalCores}} threads' -Progress 0.28 -MiniChartKind Area -MiniChartValues 18,26,22,37,48,43,51,35,29,41,33 -MiniChartMaximum 100
-    New-BGInfoVisualCanvasTile -Side Right -IconKind Memory -SurfaceStyle Glass -Label RAM -Value '{{RAMSize}}' -Progress 0.41 -MiniChartKind Bars -MiniChartValues 36,39,41,42,44,43,41 -MiniChartMaximum 100
-    New-BGInfoVisualCanvasTile -Side Right -IconKind Storage -SurfaceStyle Glass -Label 'SYSTEM DRIVE' -Value '62% free' -Progress 0.62 -MiniChartKind Sparkline -MiniChartValues 66,65,64,64,63,62,62 -MiniChartMaximum 100
+    New-BGInfoVisualCanvasTile -Side Left -IconKind Shield -SurfaceStyle Glass -Label PATCHING -Value '89% compliant' -Detail '6 devices pending' -Progress 0.89 -MiniChartKind Bars -MiniChartValues 70,75,79,83,86,89 -MiniChartMaximum 100
+    New-BGInfoVisualCanvasTile -Side Right -IconKind Cpu -SurfaceStyle Glass -Label 'CPU LOAD' -Value '33% active' -Detail '{{CpuCores}} cores / {{CpuLogicalCores}} threads' -Progress 0.33 -MiniChartKind Area -MiniChartValues 18,26,22,37,48,43,51,35,29,41,33 -MiniChartMaximum 100
+    New-BGInfoVisualCanvasTile -Side Right -IconKind Memory -SurfaceStyle Glass -Label 'MEMORY USE' -Value '13.2 GB used' -Detail '32 GB installed' -Progress 0.41 -MiniChartKind Bars -MiniChartValues 36,39,41,42,44,43,41 -MiniChartMaximum 100
+    New-BGInfoVisualCanvasTile -Side Right -IconKind Storage -SurfaceStyle Glass -Label 'SYSTEM DRIVE' -Value '62% free' -Detail 'C: 238 GB available' -Progress 0.62 -MiniChartKind Sparkline -MiniChartValues 66,65,64,64,63,62,62 -MiniChartMaximum 100
     New-BGInfoVisualCanvasTile -Side Right -IconKind Domain -SurfaceStyle Glass -Label DOMAIN -Value '{{UserDNSDomain}}'
 )
 
 New-BGInfo -MonitorIndex 0 -Target File {
     New-BGInfoVisualCanvas `
         -Title 'PowerBGInfo' `
-        -Subtitle 'Mini charts live inside the matching desktop sections' `
+        -Subtitle 'Each section pairs the current value with a matching recent trend' `
         -Accent $palette.Accent `
         -SecondaryAccent $palette.SecondaryAccent `
         -TitleColor $palette.TitleColor `

--- a/Examples/Scripts/PowerBGInfo.VisualCanvas.MiniCharts.ps1
+++ b/Examples/Scripts/PowerBGInfo.VisualCanvas.MiniCharts.ps1
@@ -26,10 +26,10 @@ $tiles = @(
     New-BGInfoVisualCanvasTile -Side Left -IconKind Computer -SurfaceStyle Glass -Label HOSTNAME -Value '{{HostName}}'
     New-BGInfoVisualCanvasTile -Side Left -IconKind Network -SurfaceStyle Glass -Label 'IP ADDRESS' -Value '{{IPv4Address}}'
     New-BGInfoVisualCanvasTile -Side Left -IconKind OperatingSystem -SurfaceStyle Glass -Label 'OPERATING SYSTEM' -Value '{{OSName}}' -Detail '{{OSVersion}}'
-    New-BGInfoVisualCanvasTile -Side Left -IconKind Shield -SurfaceStyle Glass -Label PATCHING -Value '89% compliant' -Detail '6 devices pending' -Progress 0.89 -MiniChartKind Bars -MiniChartValues 70,75,79,83,86,89 -MiniChartMaximum 100
-    New-BGInfoVisualCanvasTile -Side Right -IconKind Cpu -SurfaceStyle Glass -Label 'CPU LOAD' -Value '33% active' -Detail '{{CpuCores}} cores / {{CpuLogicalCores}} threads' -Progress 0.33 -MiniChartKind Area -MiniChartValues 18,26,22,37,48,43,51,35,29,41,33 -MiniChartMaximum 100
-    New-BGInfoVisualCanvasTile -Side Right -IconKind Memory -SurfaceStyle Glass -Label 'MEMORY USE' -Value '13.2 GB used' -Detail '32 GB installed' -Progress 0.41 -MiniChartKind Bars -MiniChartValues 36,39,41,42,44,43,41 -MiniChartMaximum 100
-    New-BGInfoVisualCanvasTile -Side Right -IconKind Storage -SurfaceStyle Glass -Label 'SYSTEM DRIVE' -Value '62% free' -Detail 'C: 238 GB available' -Progress 0.62 -MiniChartKind Sparkline -MiniChartValues 66,65,64,64,63,62,62 -MiniChartMaximum 100
+    New-BGInfoVisualCanvasTile -Side Left -IconKind Shield -SurfaceStyle Glass -Label PATCHING -Value '89% compliant' -Detail '6 devices pending' -MiniChartKind Bars -MiniChartValues 70,75,79,83,86,89 -MiniChartMaximum 100
+    New-BGInfoVisualCanvasTile -Side Right -IconKind Cpu -SurfaceStyle Glass -Label 'CPU LOAD' -Value '33% active' -Detail '{{CpuCores}} cores / {{CpuLogicalCores}} threads' -MiniChartKind Area -MiniChartValues 18,26,22,37,48,43,51,35,29,41,33 -MiniChartMaximum 100
+    New-BGInfoVisualCanvasTile -Side Right -IconKind Memory -SurfaceStyle Glass -Label 'MEMORY USE' -Value '13.2 GB used' -Detail '32 GB installed' -MiniChartKind Bars -MiniChartValues 36,39,41,42,44,43,41 -MiniChartMaximum 100
+    New-BGInfoVisualCanvasTile -Side Right -IconKind Storage -SurfaceStyle Glass -Label 'SYSTEM DRIVE' -Value '62% free' -Detail 'C: 238 GB available' -MiniChartKind Sparkline -MiniChartValues 66,65,64,64,63,62,62 -MiniChartMaximum 100
     New-BGInfoVisualCanvasTile -Side Right -IconKind Domain -SurfaceStyle Glass -Label DOMAIN -Value '{{UserDNSDomain}}'
 )
 

--- a/Examples/Scripts/PowerBGInfo.VisualCanvas.Raised3D.ps1
+++ b/Examples/Scripts/PowerBGInfo.VisualCanvas.Raised3D.ps1
@@ -1,0 +1,64 @@
+Import-Module (Join-Path -Path $PSScriptRoot -ChildPath '..\..\PowerBGInfo.psd1') -Force
+
+$examplesPath = (Resolve-Path (Join-Path -Path $PSScriptRoot -ChildPath '..')).Path
+$sampleImage = Join-Path -Path $examplesPath -ChildPath 'Samples\TapC-Evotec-2560x1080.jpg'
+$outputDirectory = Join-Path -Path $examplesPath -ChildPath 'Output'
+
+$palette = @{
+    Accent                 = '#38BDF8'
+    SecondaryAccent        = '#7DD3FC'
+    BackgroundTop          = '#02040A'
+    BackgroundBottom       = '#050B16'
+    TitleColor             = '#F8FAFC'
+    TitleAccentColor       = '#38BDF8'
+    SubtitleColor          = '#CBD5E1'
+    TileLabelColor         = '#BFD7FF'
+    TileValueColor         = '#FFFFFF'
+    TileDetailColor        = '#9FB6D8'
+    TileGlassTop           = '#F30E2448'
+    TileGlassBottom        = '#EB020816'
+    TileProgressTrackColor = '#7A14213D'
+    HeroBadgeTop           = '#102A4B'
+    HeroBadgeBottom        = '#030A17'
+    HeroBadgeTextColor     = '#F8FBFF'
+}
+
+$tiles = @(
+    New-BGInfoVisualCanvasTile -Side Left -IconKind Computer -SurfaceStyle Raised -Label HOSTNAME -Value '{{HostName}}'
+    New-BGInfoVisualCanvasTile -Side Left -IconKind Network -SurfaceStyle Raised -Label 'IP ADDRESS' -Value '{{IPv4Address}}'
+    New-BGInfoVisualCanvasTile -Side Left -IconKind OperatingSystem -SurfaceStyle Raised -Label 'OPERATING SYSTEM' -Value '{{OSName}}' -Detail '{{OSVersion}}'
+    New-BGInfoVisualCanvasTile -Side Left -IconKind Shield -SurfaceStyle Raised -Label PATCHING -Value '89% compliant' -Detail '6 devices pending' -MiniChartKind Bars -MiniChartValues 70,75,79,83,86,89 -MiniChartMaximum 100
+    New-BGInfoVisualCanvasTile -Side Right -IconKind Cpu -SurfaceStyle Raised -Label 'CPU LOAD' -Value '33% active' -Detail '{{CpuCores}} cores / {{CpuLogicalCores}} threads' -MiniChartKind Area -MiniChartValues 18,26,22,37,48,43,51,35,29,41,33 -MiniChartMaximum 100
+    New-BGInfoVisualCanvasTile -Side Right -IconKind Memory -SurfaceStyle Raised -Label 'MEMORY USE' -Value '13.2 GB used' -Detail '32 GB installed' -MiniChartKind Bars -MiniChartValues 36,39,41,42,44,43,41 -MiniChartMaximum 100
+    New-BGInfoVisualCanvasTile -Side Right -IconKind Storage -SurfaceStyle Raised -Label 'SYSTEM DRIVE' -Value '62% free' -Detail 'C: 238 GB available' -MiniChartKind Sparkline -MiniChartValues 66,65,64,64,63,62,62 -MiniChartMaximum 100
+    New-BGInfoVisualCanvasTile -Side Right -IconKind Domain -SurfaceStyle Raised -Label DOMAIN -Value '{{UserDNSDomain}}'
+)
+
+New-BGInfo -MonitorIndex 0 -Target File {
+    New-BGInfoVisualCanvas `
+        -Title 'PowerBGInfo' `
+        -Subtitle 'Raised sections on black background' `
+        -Opaque `
+        -NoTechBackdrop `
+        -Accent $palette.Accent `
+        -SecondaryAccent $palette.SecondaryAccent `
+        -BackgroundTop $palette.BackgroundTop `
+        -BackgroundBottom $palette.BackgroundBottom `
+        -TitleColor $palette.TitleColor `
+        -TitleAccentColor $palette.TitleAccentColor `
+        -SubtitleColor $palette.SubtitleColor `
+        -TileLabelColor $palette.TileLabelColor `
+        -TileValueColor $palette.TileValueColor `
+        -TileDetailColor $palette.TileDetailColor `
+        -TileGlassTop $palette.TileGlassTop `
+        -TileGlassBottom $palette.TileGlassBottom `
+        -TileProgressTrackColor $palette.TileProgressTrackColor `
+        -HeroBadgeTop $palette.HeroBadgeTop `
+        -HeroBadgeBottom $palette.HeroBadgeBottom `
+        -HeroBadgeTextColor $palette.HeroBadgeTextColor `
+        -Tile $tiles
+} -FilePath $sampleImage `
+    -ConfigurationDirectory $outputDirectory `
+    -OutputFileName 'PowerBGInfo.VisualCanvas.Raised3D.jpg' `
+    -WallpaperFit Fill `
+    -BackgroundColor Black

--- a/Examples/Scripts/PowerBGInfo.VisualCanvas.RaisedSections.ps1
+++ b/Examples/Scripts/PowerBGInfo.VisualCanvas.RaisedSections.ps1
@@ -1,0 +1,58 @@
+Import-Module (Join-Path -Path $PSScriptRoot -ChildPath '..\..\PowerBGInfo.psd1') -Force
+
+$examplesPath = (Resolve-Path (Join-Path -Path $PSScriptRoot -ChildPath '..')).Path
+$sampleImage = Join-Path -Path $examplesPath -ChildPath 'Samples\TapC-Evotec-2560x1080.jpg'
+$outputDirectory = Join-Path -Path $examplesPath -ChildPath 'Output'
+
+$palette = @{
+    Accent                 = '#38BDF8'
+    SecondaryAccent        = '#60A5FA'
+    TitleColor             = '#F8FAFC'
+    TitleAccentColor       = '#38BDF8'
+    SubtitleColor          = '#E2E8F0'
+    TileLabelColor         = '#C7D2FE'
+    TileValueColor         = '#FFFFFF'
+    TileDetailColor        = '#B6C4DA'
+    TileGlassTop           = '#F3132444'
+    TileGlassBottom        = '#D9040A18'
+    TileProgressTrackColor = '#F0263A5E'
+    HeroBadgeTop           = '#13284C'
+    HeroBadgeBottom        = '#061225'
+    HeroBadgeTextColor     = '#F8FBFF'
+}
+
+$tiles = @(
+    New-BGInfoVisualCanvasTile -Side Left -IconKind Computer -SurfaceStyle Glass -Label HOSTNAME -Value '{{HostName}}'
+    New-BGInfoVisualCanvasTile -Side Left -IconKind Network -SurfaceStyle Glass -Label 'IP ADDRESS' -Value '{{IPv4Address}}'
+    New-BGInfoVisualCanvasTile -Side Left -IconKind OperatingSystem -SurfaceStyle Glass -Label 'OPERATING SYSTEM' -Value '{{OSName}}' -Detail '{{OSVersion}}'
+    New-BGInfoVisualCanvasTile -Side Left -IconKind Storage -SurfaceStyle Glass -Label 'SYSTEM DRIVE' -Value '62% free' -Progress 0.62
+    New-BGInfoVisualCanvasTile -Side Right -IconKind Cpu -SurfaceStyle Glass -Label CPU -Value '{{CpuCores}} cores / {{CpuLogicalCores}} threads' -Progress 0.28
+    New-BGInfoVisualCanvasTile -Side Right -IconKind Memory -SurfaceStyle Glass -Label RAM -Value '{{RAMSize}}' -Progress 0.41
+    New-BGInfoVisualCanvasTile -Side Right -IconKind User -SurfaceStyle Glass -Label USER -Value '{{UserName}}'
+    New-BGInfoVisualCanvasTile -Side Right -IconKind Domain -SurfaceStyle Glass -Label DOMAIN -Value '{{UserDNSDomain}}'
+)
+
+New-BGInfo -MonitorIndex 0 -Target File {
+    New-BGInfoVisualCanvas `
+        -Title 'PowerBGInfo' `
+        -Subtitle 'Raised glass desktop sections over an existing wallpaper' `
+        -Accent $palette.Accent `
+        -SecondaryAccent $palette.SecondaryAccent `
+        -TitleColor $palette.TitleColor `
+        -TitleAccentColor $palette.TitleAccentColor `
+        -SubtitleColor $palette.SubtitleColor `
+        -TileLabelColor $palette.TileLabelColor `
+        -TileValueColor $palette.TileValueColor `
+        -TileDetailColor $palette.TileDetailColor `
+        -TileGlassTop $palette.TileGlassTop `
+        -TileGlassBottom $palette.TileGlassBottom `
+        -TileProgressTrackColor $palette.TileProgressTrackColor `
+        -HeroBadgeTop $palette.HeroBadgeTop `
+        -HeroBadgeBottom $palette.HeroBadgeBottom `
+        -HeroBadgeTextColor $palette.HeroBadgeTextColor `
+        -Tile $tiles
+} -FilePath $sampleImage `
+    -ConfigurationDirectory $outputDirectory `
+    -OutputFileName 'PowerBGInfo.VisualCanvas.RaisedSections.jpg' `
+    -WallpaperFit Fill `
+    -BackgroundColor Black

--- a/Examples/Scripts/PowerBGInfo.VisualCanvas.ps1
+++ b/Examples/Scripts/PowerBGInfo.VisualCanvas.ps1
@@ -1,0 +1,80 @@
+Import-Module (Join-Path -Path $PSScriptRoot -ChildPath '..\..\PowerBGInfo.psd1') -Force
+
+$examplesPath = (Resolve-Path (Join-Path -Path $PSScriptRoot -ChildPath '..')).Path
+$sampleImage = Join-Path -Path $examplesPath -ChildPath 'Samples\TapC-Evotec-2560x1080.jpg'
+$outputDirectory = Join-Path -Path $examplesPath -ChildPath 'Output'
+
+$palette = @{
+    Accent                 = '#2F80FF'
+    SecondaryAccent        = '#22A7FF'
+    TitleColor             = '#F8FAFC'
+    TitleAccentColor       = '#2F80FF'
+    SubtitleColor          = '#D8E3F4'
+    TileLabelColor         = '#C4D4EC'
+    TileValueColor         = '#F8FAFC'
+    TileDetailColor        = '#A8BAD4'
+    TileGlassTop           = '#E807152C'
+    TileGlassBottom        = '#DC030A17'
+    TileProgressTrackColor = '#EA18345D'
+    HeroBadgeTop           = '#0B1C3A'
+    HeroBadgeBottom        = '#051021'
+    HeroBadgeTextColor     = '#E8F1FF'
+}
+
+function New-VisualCanvasTiles {
+    param(
+        [PowerBGInfo.BgInfoVisualCanvasTileSurfaceStyle] $SurfaceStyle,
+        [switch] $UseIcons
+    )
+
+    $computerIcon = if ($UseIcons) { 'Computer' } else { 'Text' }
+    $networkIcon = if ($UseIcons) { 'Network' } else { 'Text' }
+    $osIcon = if ($UseIcons) { 'OperatingSystem' } else { 'Text' }
+    $cpuIcon = if ($UseIcons) { 'Cpu' } else { 'Text' }
+    $memoryIcon = if ($UseIcons) { 'Memory' } else { 'Text' }
+    $userIcon = if ($UseIcons) { 'User' } else { 'Text' }
+    $domainIcon = if ($UseIcons) { 'Domain' } else { 'Text' }
+
+    @(
+        New-BGInfoVisualCanvasTile -Side Left -Icon PC -IconKind $computerIcon -SurfaceStyle $SurfaceStyle -Label HOSTNAME -Value '{{HostName}}'
+        New-BGInfoVisualCanvasTile -Side Left -Icon NET -IconKind $networkIcon -SurfaceStyle $SurfaceStyle -Label 'IP ADDRESS' -Value '{{IPv4Address}}'
+        New-BGInfoVisualCanvasTile -Side Left -Icon OS -IconKind $osIcon -SurfaceStyle $SurfaceStyle -Label 'OPERATING SYSTEM' -Value '{{OSName}}' -Detail '{{OSVersion}}'
+        New-BGInfoVisualCanvasTile -Side Right -Icon CPU -IconKind $cpuIcon -SurfaceStyle $SurfaceStyle -Label CPU -Value '{{CpuCores}} cores / {{CpuLogicalCores}} threads'
+        New-BGInfoVisualCanvasTile -Side Right -Icon RAM -IconKind $memoryIcon -SurfaceStyle $SurfaceStyle -Label RAM -Value '{{RAMSize}}'
+        New-BGInfoVisualCanvasTile -Side Right -Icon USER -IconKind $userIcon -SurfaceStyle $SurfaceStyle -Label USER -Value '{{UserName}}'
+        New-BGInfoVisualCanvasTile -Side Right -Icon DNS -IconKind $domainIcon -SurfaceStyle $SurfaceStyle -Label DOMAIN -Value '{{UserDNSDomain}}'
+    )
+}
+
+$variants = @(
+    [pscustomobject]@{ Name = 'GlassText'; Tiles = New-VisualCanvasTiles -SurfaceStyle Glass; Output = 'PowerBGInfo.VisualCanvas.GlassText.jpg' }
+    [pscustomobject]@{ Name = 'OutlineText'; Tiles = New-VisualCanvasTiles -SurfaceStyle Outline; Output = 'PowerBGInfo.VisualCanvas.OutlineText.jpg' }
+    [pscustomobject]@{ Name = 'OutlineIcons'; Tiles = New-VisualCanvasTiles -SurfaceStyle Outline -UseIcons; Output = 'PowerBGInfo.VisualCanvas.OutlineIcons.jpg' }
+)
+
+foreach ($variant in $variants) {
+    New-BGInfo -MonitorIndex 0 -Target File {
+        New-BGInfoVisualCanvas `
+            -Title 'PowerBGInfo' `
+            -Subtitle 'Desktop background insights for Windows and PowerShell' `
+            -Accent $palette.Accent `
+            -SecondaryAccent $palette.SecondaryAccent `
+            -TitleColor $palette.TitleColor `
+            -TitleAccentColor $palette.TitleAccentColor `
+            -SubtitleColor $palette.SubtitleColor `
+            -TileLabelColor $palette.TileLabelColor `
+            -TileValueColor $palette.TileValueColor `
+            -TileDetailColor $palette.TileDetailColor `
+            -TileGlassTop $palette.TileGlassTop `
+            -TileGlassBottom $palette.TileGlassBottom `
+            -TileProgressTrackColor $palette.TileProgressTrackColor `
+            -HeroBadgeTop $palette.HeroBadgeTop `
+            -HeroBadgeBottom $palette.HeroBadgeBottom `
+            -HeroBadgeTextColor $palette.HeroBadgeTextColor `
+            -Tile $variant.Tiles
+    } -FilePath $sampleImage `
+        -ConfigurationDirectory $outputDirectory `
+        -OutputFileName $variant.Output `
+        -WallpaperFit Fill `
+        -BackgroundColor Black
+}

--- a/PowerBGInfo.psd1
+++ b/PowerBGInfo.psd1
@@ -1,7 +1,7 @@
 ﻿@{
     AliasesToExport        = @()
     Author                 = 'Przemyslaw Klys'
-    CmdletsToExport        = @('New-BGInfo', 'New-BGInfoLabel', 'New-BGInfoValue', 'New-BGInfoVariable', 'New-BGInfoChart', 'New-BGInfoTopology', 'New-BGInfoTopologyEdge', 'New-BGInfoTopologyGroup', 'New-BGInfoTopologyNode', 'New-BGInfoVisualCanvas', 'New-BGInfoVisualCanvasTile', 'New-BGInfoVisualCanvasFeature', 'Invoke-BGInfo', 'Export-BGInfoConfiguration', 'New-BGInfoConfiguration')
+    CmdletsToExport        = @('New-BGInfo', 'New-BGInfoLabel', 'New-BGInfoValue', 'New-BGInfoVariable', 'New-BGInfoChart', 'New-BGInfoTopology', 'New-BGInfoTopologyEdge', 'New-BGInfoTopologyGroup', 'New-BGInfoTopologyNode', 'New-BGInfoVisualCanvas', 'New-BGInfoVisualCanvasTile', 'New-BGInfoVisualCanvasFeature', 'New-BGInfoImage', 'Invoke-BGInfo', 'Export-BGInfoConfiguration', 'New-BGInfoConfiguration')
     CompanyName            = 'Evotec'
     CompatiblePSEditions   = @('Desktop', 'Core')
     Copyright              = '(c) 2011 - 2026 Przemyslaw Klys @ Evotec. All rights reserved.'

--- a/PowerBGInfo.psd1
+++ b/PowerBGInfo.psd1
@@ -1,7 +1,7 @@
 ﻿@{
     AliasesToExport        = @()
     Author                 = 'Przemyslaw Klys'
-    CmdletsToExport        = @('New-BGInfo', 'New-BGInfoLabel', 'New-BGInfoValue', 'New-BGInfoVariable', 'New-BGInfoChart', 'New-BGInfoTopology', 'New-BGInfoTopologyEdge', 'New-BGInfoTopologyGroup', 'New-BGInfoTopologyNode', 'Invoke-BGInfo', 'Export-BGInfoConfiguration', 'New-BGInfoConfiguration')
+    CmdletsToExport        = @('New-BGInfo', 'New-BGInfoLabel', 'New-BGInfoValue', 'New-BGInfoVariable', 'New-BGInfoChart', 'New-BGInfoTopology', 'New-BGInfoTopologyEdge', 'New-BGInfoTopologyGroup', 'New-BGInfoTopologyNode', 'New-BGInfoVisualCanvas', 'New-BGInfoVisualCanvasTile', 'New-BGInfoVisualCanvasFeature', 'Invoke-BGInfo', 'Export-BGInfoConfiguration', 'New-BGInfoConfiguration')
     CompanyName            = 'Evotec'
     CompatiblePSEditions   = @('Desktop', 'Core')
     Copyright              = '(c) 2011 - 2026 Przemyslaw Klys @ Evotec. All rights reserved.'

--- a/README.MD
+++ b/README.MD
@@ -314,7 +314,7 @@ New-BGInfo -Target File {
 } -FilePath $PSScriptRoot\Examples\Samples\TapC-Evotec-2560x1080.jpg -ConfigurationDirectory $PSScriptRoot\Examples\Output -OutputFileName 'PowerBGInfo.VisualCanvas.jpg' -WallpaperFit Fill
 ```
 
-`Examples\Scripts\PowerBGInfo.VisualCanvas.ps1` renders three variants: glass panels with text badges, outline-only panels with text badges, and outline-only panels with built-in icons. `Examples\Scripts\PowerBGInfo.VisualCanvas.RaisedSections.ps1` shows a stronger glass treatment with icon tiles and progress rails for a more raised section look over the same wallpaper. `Examples\Scripts\PowerBGInfo.VisualCanvas.MiniCharts.ps1` combines the same visual canvas with purpose-matched mini charts inside the CPU, RAM, disk, and patching sections plus a bottom-right logo image. Tile `-SurfaceStyle` supports `Glass` and `Outline`; tile `-IconKind` can render built-in icons such as `Computer`, `Network`, `OperatingSystem`, `Cpu`, `Memory`, `User`, `Domain`, `Terminal`, `Storage`, and `Shield`.
+`Examples\Scripts\PowerBGInfo.VisualCanvas.ps1` renders three variants: glass panels with text badges, outline-only panels with text badges, and outline-only panels with built-in icons. `Examples\Scripts\PowerBGInfo.VisualCanvas.RaisedSections.ps1` shows a stronger glass treatment with icon tiles and progress rails for a more raised section look over the same wallpaper. `Examples\Scripts\PowerBGInfo.VisualCanvas.Raised3D.ps1` uses the reusable `Raised` surface style on a black operational background. `Examples\Scripts\PowerBGInfo.VisualCanvas.MiniCharts.ps1` combines the same visual canvas with purpose-matched mini charts inside the CPU, RAM, disk, and patching sections plus a bottom-right logo image. Tile `-SurfaceStyle` supports `Glass`, `Outline`, and `Raised`; tile `-IconKind` can render built-in icons such as `Computer`, `Network`, `OperatingSystem`, `Cpu`, `Memory`, `User`, `Domain`, `Terminal`, `Storage`, and `Shield`.
 
 The visual canvas palette is data-driven. `New-BGInfoVisualCanvas` accepts color parameters for the hero title, subtitle, tile label/value/detail text, glass tile fill, progress track, badge fill, badge text, and primary/secondary accents. Those colors are preserved in JSON exports, so a consumer can brand the same reusable ChartForgeX template without changing renderer code.
 
@@ -347,7 +347,7 @@ New-BGInfo -Target File {
 } -FilePath .\Examples\Samples\TapC-Evotec-2560x1080.jpg -ConfigurationDirectory .\Examples\Output -OutputFileName 'PowerBGInfo.VisualCanvas.OutlineIcons.jpg' -WallpaperFit Fill
 ```
 
-For a heavier raised glass look, use a more opaque top/bottom tile palette, built-in icons, and progress values:
+For a heavier raised look on a black background, use the `Raised` surface style, a more opaque top/bottom tile palette, built-in icons, and `-Opaque -NoTechBackdrop`:
 
 ```powershell
 $palette = @{
@@ -359,15 +359,15 @@ $palette = @{
 }
 
 $tiles = @(
-    New-BGInfoVisualCanvasTile -Side Left -IconKind Computer -SurfaceStyle Glass -Label HOSTNAME -Value '{{HostName}}'
-    New-BGInfoVisualCanvasTile -Side Left -IconKind Storage -SurfaceStyle Glass -Label 'SYSTEM DRIVE' -Value '62% free' -Progress 0.62
-    New-BGInfoVisualCanvasTile -Side Right -IconKind Cpu -SurfaceStyle Glass -Label CPU -Value '{{CpuCores}} cores / {{CpuLogicalCores}} threads' -Progress 0.28
-    New-BGInfoVisualCanvasTile -Side Right -IconKind Memory -SurfaceStyle Glass -Label RAM -Value '{{RAMSize}}' -Progress 0.41
+    New-BGInfoVisualCanvasTile -Side Left -IconKind Computer -SurfaceStyle Raised -Label HOSTNAME -Value '{{HostName}}'
+    New-BGInfoVisualCanvasTile -Side Left -IconKind Storage -SurfaceStyle Raised -Label 'SYSTEM DRIVE' -Value '62% free' -Progress 0.62
+    New-BGInfoVisualCanvasTile -Side Right -IconKind Cpu -SurfaceStyle Raised -Label CPU -Value '{{CpuCores}} cores / {{CpuLogicalCores}} threads' -Progress 0.28
+    New-BGInfoVisualCanvasTile -Side Right -IconKind Memory -SurfaceStyle Raised -Label RAM -Value '{{RAMSize}}' -Progress 0.41
 )
 
 New-BGInfo -Target File {
-    New-BGInfoVisualCanvas -Title 'PowerBGInfo' -Subtitle 'Raised glass desktop sections over an existing wallpaper' -Tile $tiles @palette
-} -FilePath .\Examples\Samples\TapC-Evotec-2560x1080.jpg -ConfigurationDirectory .\Examples\Output -OutputFileName 'PowerBGInfo.VisualCanvas.RaisedSections.jpg' -WallpaperFit Fill
+    New-BGInfoVisualCanvas -Title 'PowerBGInfo' -Subtitle 'Raised sections on black background' -Opaque -NoTechBackdrop -Tile $tiles @palette
+} -FilePath .\Examples\Samples\TapC-Evotec-2560x1080.jpg -ConfigurationDirectory .\Examples\Output -OutputFileName 'PowerBGInfo.VisualCanvas.Raised3D.jpg' -WallpaperFit Fill
 ```
 
 Mini charts can live inside the same sections as their values, while the logo stays anchored in the bottom-right corner. For at-a-glance wallpaper tiles, avoid mixing a progress rail and a mini chart unless they are clearly different signals. The example below uses the large value for the current state and the mini chart for recent history of that same signal: CPU load uses a recent load trend, memory use uses usage bars, disk capacity uses a free-space trend, and patching uses compliance history. Each tile chooses its own mini-chart kind and values; the image has its own anchor and offsets so it can be moved away from taskbars, rails, or customer branding:

--- a/README.MD
+++ b/README.MD
@@ -370,17 +370,17 @@ New-BGInfo -Target File {
 } -FilePath .\Examples\Samples\TapC-Evotec-2560x1080.jpg -ConfigurationDirectory .\Examples\Output -OutputFileName 'PowerBGInfo.VisualCanvas.RaisedSections.jpg' -WallpaperFit Fill
 ```
 
-Mini charts can live inside the same sections as their values, while the logo stays anchored in the bottom-right corner. Each tile chooses its own mini-chart kind and values; the image has its own anchor and offsets so it can be moved away from taskbars, rails, or customer branding:
+Mini charts can live inside the same sections as their values, while the logo stays anchored in the bottom-right corner. Make the large value, progress rail, and mini chart describe the same question: CPU load uses a recent load trend, memory use uses usage bars, disk capacity uses a free-space trend, and patching uses compliance history. Each tile chooses its own mini-chart kind and values; the image has its own anchor and offsets so it can be moved away from taskbars, rails, or customer branding:
 
 ```powershell
 $tiles = @(
-    New-BGInfoVisualCanvasTile -Side Right -IconKind Cpu -SurfaceStyle Glass -Label CPU -Value '{{CpuCores}} cores / {{CpuLogicalCores}} threads' -Progress 0.28 -MiniChartKind Area -MiniChartValues 18,26,22,37,48,43,51 -MiniChartMaximum 100
-    New-BGInfoVisualCanvasTile -Side Right -IconKind Memory -SurfaceStyle Glass -Label RAM -Value '{{RAMSize}}' -Progress 0.41 -MiniChartKind Bars -MiniChartValues 36,39,41,42,44,43,41 -MiniChartMaximum 100
-    New-BGInfoVisualCanvasTile -Side Right -IconKind Storage -SurfaceStyle Glass -Label 'SYSTEM DRIVE' -Value '62% free' -Progress 0.62 -MiniChartKind Sparkline -MiniChartValues 66,65,64,64,63,62,62 -MiniChartMaximum 100
+    New-BGInfoVisualCanvasTile -Side Right -IconKind Cpu -SurfaceStyle Glass -Label 'CPU LOAD' -Value '33% active' -Detail '{{CpuCores}} cores / {{CpuLogicalCores}} threads' -Progress 0.33 -MiniChartKind Area -MiniChartValues 18,26,22,37,48,43,51,35,29,41,33 -MiniChartMaximum 100
+    New-BGInfoVisualCanvasTile -Side Right -IconKind Memory -SurfaceStyle Glass -Label 'MEMORY USE' -Value '13.2 GB used' -Detail '32 GB installed' -Progress 0.41 -MiniChartKind Bars -MiniChartValues 36,39,41,42,44,43,41 -MiniChartMaximum 100
+    New-BGInfoVisualCanvasTile -Side Right -IconKind Storage -SurfaceStyle Glass -Label 'SYSTEM DRIVE' -Value '62% free' -Detail 'C: 238 GB available' -Progress 0.62 -MiniChartKind Sparkline -MiniChartValues 66,65,64,64,63,62,62 -MiniChartMaximum 100
 )
 
 New-BGInfo -Target File {
-    New-BGInfoVisualCanvas -Title 'PowerBGInfo' -Subtitle 'Mini charts live inside the matching sections' -Tile $tiles @palette
+    New-BGInfoVisualCanvas -Title 'PowerBGInfo' -Subtitle 'Each section pairs the current value with a matching recent trend' -Tile $tiles @palette
     New-BGInfoImage -Path .\Examples\Samples\LogoEvotec.png -Width 210 -Anchor BottomRight -OffsetX 72 -OffsetY 54 -Opacity 0.92
 } -FilePath .\Examples\Samples\TapC-Evotec-2560x1080.jpg -ConfigurationDirectory .\Examples\Output -OutputFileName 'PowerBGInfo.VisualCanvas.MiniCharts.jpg' -WallpaperFit Fill
 ```

--- a/README.MD
+++ b/README.MD
@@ -370,13 +370,13 @@ New-BGInfo -Target File {
 } -FilePath .\Examples\Samples\TapC-Evotec-2560x1080.jpg -ConfigurationDirectory .\Examples\Output -OutputFileName 'PowerBGInfo.VisualCanvas.RaisedSections.jpg' -WallpaperFit Fill
 ```
 
-Mini charts can live inside the same sections as their values, while the logo stays anchored in the bottom-right corner. Make the large value, progress rail, and mini chart describe the same question: CPU load uses a recent load trend, memory use uses usage bars, disk capacity uses a free-space trend, and patching uses compliance history. Each tile chooses its own mini-chart kind and values; the image has its own anchor and offsets so it can be moved away from taskbars, rails, or customer branding:
+Mini charts can live inside the same sections as their values, while the logo stays anchored in the bottom-right corner. For at-a-glance wallpaper tiles, avoid mixing a progress rail and a mini chart unless they are clearly different signals. The example below uses the large value for the current state and the mini chart for recent history of that same signal: CPU load uses a recent load trend, memory use uses usage bars, disk capacity uses a free-space trend, and patching uses compliance history. Each tile chooses its own mini-chart kind and values; the image has its own anchor and offsets so it can be moved away from taskbars, rails, or customer branding:
 
 ```powershell
 $tiles = @(
-    New-BGInfoVisualCanvasTile -Side Right -IconKind Cpu -SurfaceStyle Glass -Label 'CPU LOAD' -Value '33% active' -Detail '{{CpuCores}} cores / {{CpuLogicalCores}} threads' -Progress 0.33 -MiniChartKind Area -MiniChartValues 18,26,22,37,48,43,51,35,29,41,33 -MiniChartMaximum 100
-    New-BGInfoVisualCanvasTile -Side Right -IconKind Memory -SurfaceStyle Glass -Label 'MEMORY USE' -Value '13.2 GB used' -Detail '32 GB installed' -Progress 0.41 -MiniChartKind Bars -MiniChartValues 36,39,41,42,44,43,41 -MiniChartMaximum 100
-    New-BGInfoVisualCanvasTile -Side Right -IconKind Storage -SurfaceStyle Glass -Label 'SYSTEM DRIVE' -Value '62% free' -Detail 'C: 238 GB available' -Progress 0.62 -MiniChartKind Sparkline -MiniChartValues 66,65,64,64,63,62,62 -MiniChartMaximum 100
+    New-BGInfoVisualCanvasTile -Side Right -IconKind Cpu -SurfaceStyle Glass -Label 'CPU LOAD' -Value '33% active' -Detail '{{CpuCores}} cores / {{CpuLogicalCores}} threads' -MiniChartKind Area -MiniChartValues 18,26,22,37,48,43,51,35,29,41,33 -MiniChartMaximum 100
+    New-BGInfoVisualCanvasTile -Side Right -IconKind Memory -SurfaceStyle Glass -Label 'MEMORY USE' -Value '13.2 GB used' -Detail '32 GB installed' -MiniChartKind Bars -MiniChartValues 36,39,41,42,44,43,41 -MiniChartMaximum 100
+    New-BGInfoVisualCanvasTile -Side Right -IconKind Storage -SurfaceStyle Glass -Label 'SYSTEM DRIVE' -Value '62% free' -Detail 'C: 238 GB available' -MiniChartKind Sparkline -MiniChartValues 66,65,64,64,63,62,62 -MiniChartMaximum 100
 )
 
 New-BGInfo -Target File {

--- a/README.MD
+++ b/README.MD
@@ -314,7 +314,7 @@ New-BGInfo -Target File {
 } -FilePath $PSScriptRoot\Examples\Samples\TapC-Evotec-2560x1080.jpg -ConfigurationDirectory $PSScriptRoot\Examples\Output -OutputFileName 'PowerBGInfo.VisualCanvas.jpg' -WallpaperFit Fill
 ```
 
-`Examples\Scripts\PowerBGInfo.VisualCanvas.ps1` renders three variants: glass panels with text badges, outline-only panels with text badges, and outline-only panels with built-in icons. `Examples\Scripts\PowerBGInfo.VisualCanvas.RaisedSections.ps1` shows a stronger glass treatment with icon tiles and progress rails for a more raised section look over the same wallpaper. Tile `-SurfaceStyle` supports `Glass` and `Outline`; tile `-IconKind` can render built-in icons such as `Computer`, `Network`, `OperatingSystem`, `Cpu`, `Memory`, `User`, `Domain`, `Terminal`, `Storage`, and `Shield`.
+`Examples\Scripts\PowerBGInfo.VisualCanvas.ps1` renders three variants: glass panels with text badges, outline-only panels with text badges, and outline-only panels with built-in icons. `Examples\Scripts\PowerBGInfo.VisualCanvas.RaisedSections.ps1` shows a stronger glass treatment with icon tiles and progress rails for a more raised section look over the same wallpaper. `Examples\Scripts\PowerBGInfo.VisualCanvas.MiniCharts.ps1` combines the same visual canvas with small purpose-matched charts and a bottom-right logo image. Tile `-SurfaceStyle` supports `Glass` and `Outline`; tile `-IconKind` can render built-in icons such as `Computer`, `Network`, `OperatingSystem`, `Cpu`, `Memory`, `User`, `Domain`, `Terminal`, `Storage`, and `Shield`.
 
 The visual canvas palette is data-driven. `New-BGInfoVisualCanvas` accepts color parameters for the hero title, subtitle, tile label/value/detail text, glass tile fill, progress track, badge fill, badge text, and primary/secondary accents. Those colors are preserved in JSON exports, so a consumer can brand the same reusable ChartForgeX template without changing renderer code.
 
@@ -368,6 +368,21 @@ $tiles = @(
 New-BGInfo -Target File {
     New-BGInfoVisualCanvas -Title 'PowerBGInfo' -Subtitle 'Raised glass desktop sections over an existing wallpaper' -Tile $tiles @palette
 } -FilePath .\Examples\Samples\TapC-Evotec-2560x1080.jpg -ConfigurationDirectory .\Examples\Output -OutputFileName 'PowerBGInfo.VisualCanvas.RaisedSections.jpg' -WallpaperFit Fill
+```
+
+Mini charts can sit in the clear space below the hero while the logo stays anchored in the bottom-right corner. Each chart and image has its own anchor and offsets, so the layout can be moved away from taskbars, rails, or customer branding:
+
+```powershell
+New-BGInfo -Target File {
+    New-BGInfoVisualCanvas -Title 'PowerBGInfo' -Subtitle 'Mini charts stay below the hero and away from the side rails' -Tile $tiles @palette
+
+    New-BGInfoChart -Title 'CPU burst' -Kind Area -Values 18,26,22,37,48,43,51 -Width 260 -Height 112 -Anchor BottomCenter -OffsetX -450 -OffsetY 210 -LineColor '#38BDF8' -FillColor '#38BDF8' -BackgroundColor '#A6081224' -NoHistory
+    New-BGInfoChart -Title 'Memory load' -Kind RadialBar -Values 41 -Width 230 -Height 112 -Anchor BottomCenter -OffsetX -150 -OffsetY 210 -LineColor '#60A5FA' -BackgroundColor '#A6081224' -Maximum 100 -NoHistory
+    New-BGInfoChart -Title 'Disk free' -Kind ProgressBar -Values 62 -Labels 'C:' -Width 260 -Height 112 -Anchor BottomCenter -OffsetX 145 -OffsetY 210 -LineColor '#34D399' -BackgroundColor '#A6081224' -Maximum 100 -NoHistory
+    New-BGInfoChart -Title 'Patch target' -Kind Bullet -Values 89 -Target 95 -RangeEnds 70,85 -Width 280 -Height 112 -Anchor BottomCenter -OffsetX 455 -OffsetY 210 -LineColor '#FBBF24' -BackgroundColor '#A6081224' -Maximum 100 -NoHistory
+
+    New-BGInfoImage -Path .\Examples\Samples\LogoEvotec.png -Width 210 -Anchor BottomRight -OffsetX 72 -OffsetY 54 -Opacity 0.92
+} -FilePath .\Examples\Samples\TapC-Evotec-2560x1080.jpg -ConfigurationDirectory .\Examples\Output -OutputFileName 'PowerBGInfo.VisualCanvas.MiniCharts.jpg' -WallpaperFit Fill
 ```
 
 ## Topology diagrams

--- a/README.MD
+++ b/README.MD
@@ -314,7 +314,7 @@ New-BGInfo -Target File {
 } -FilePath $PSScriptRoot\Examples\Samples\TapC-Evotec-2560x1080.jpg -ConfigurationDirectory $PSScriptRoot\Examples\Output -OutputFileName 'PowerBGInfo.VisualCanvas.jpg' -WallpaperFit Fill
 ```
 
-`Examples\Scripts\PowerBGInfo.VisualCanvas.ps1` renders three variants: glass panels with text badges, outline-only panels with text badges, and outline-only panels with built-in icons. Tile `-SurfaceStyle` supports `Glass` and `Outline`; tile `-IconKind` can render built-in icons such as `Computer`, `Network`, `OperatingSystem`, `Cpu`, `Memory`, `User`, `Domain`, `Terminal`, `Storage`, and `Shield`.
+`Examples\Scripts\PowerBGInfo.VisualCanvas.ps1` renders three variants: glass panels with text badges, outline-only panels with text badges, and outline-only panels with built-in icons. `Examples\Scripts\PowerBGInfo.VisualCanvas.RaisedSections.ps1` shows a stronger glass treatment with icon tiles and progress rails for a more raised section look over the same wallpaper. Tile `-SurfaceStyle` supports `Glass` and `Outline`; tile `-IconKind` can render built-in icons such as `Computer`, `Network`, `OperatingSystem`, `Cpu`, `Memory`, `User`, `Domain`, `Terminal`, `Storage`, and `Shield`.
 
 The visual canvas palette is data-driven. `New-BGInfoVisualCanvas` accepts color parameters for the hero title, subtitle, tile label/value/detail text, glass tile fill, progress track, badge fill, badge text, and primary/secondary accents. Those colors are preserved in JSON exports, so a consumer can brand the same reusable ChartForgeX template without changing renderer code.
 
@@ -345,6 +345,29 @@ $tiles = @(
 New-BGInfo -Target File {
     New-BGInfoVisualCanvas -Title 'PowerBGInfo' -Subtitle 'Desktop background insights for Windows and PowerShell' -Tile $tiles @palette
 } -FilePath .\Examples\Samples\TapC-Evotec-2560x1080.jpg -ConfigurationDirectory .\Examples\Output -OutputFileName 'PowerBGInfo.VisualCanvas.OutlineIcons.jpg' -WallpaperFit Fill
+```
+
+For a heavier raised glass look, use a more opaque top/bottom tile palette, built-in icons, and progress values:
+
+```powershell
+$palette = @{
+    Accent                 = '#38BDF8'
+    SecondaryAccent        = '#60A5FA'
+    TileGlassTop           = '#F3132444'
+    TileGlassBottom        = '#D9040A18'
+    TileProgressTrackColor = '#F0263A5E'
+}
+
+$tiles = @(
+    New-BGInfoVisualCanvasTile -Side Left -IconKind Computer -SurfaceStyle Glass -Label HOSTNAME -Value '{{HostName}}'
+    New-BGInfoVisualCanvasTile -Side Left -IconKind Storage -SurfaceStyle Glass -Label 'SYSTEM DRIVE' -Value '62% free' -Progress 0.62
+    New-BGInfoVisualCanvasTile -Side Right -IconKind Cpu -SurfaceStyle Glass -Label CPU -Value '{{CpuCores}} cores / {{CpuLogicalCores}} threads' -Progress 0.28
+    New-BGInfoVisualCanvasTile -Side Right -IconKind Memory -SurfaceStyle Glass -Label RAM -Value '{{RAMSize}}' -Progress 0.41
+)
+
+New-BGInfo -Target File {
+    New-BGInfoVisualCanvas -Title 'PowerBGInfo' -Subtitle 'Raised glass desktop sections over an existing wallpaper' -Tile $tiles @palette
+} -FilePath .\Examples\Samples\TapC-Evotec-2560x1080.jpg -ConfigurationDirectory .\Examples\Output -OutputFileName 'PowerBGInfo.VisualCanvas.RaisedSections.jpg' -WallpaperFit Fill
 ```
 
 ## Topology diagrams

--- a/README.MD
+++ b/README.MD
@@ -298,6 +298,55 @@ New-BGInfo -MonitorIndex 0 {
 
 Charts are rendered by ChartForgeX into transparent overlays before PowerBGInfo composites them into the wallpaper. Supported kinds are `Sparkline`, `Line`, `Area`, `Bar`, `HorizontalBar`, `Gauge`, `Circle`, `RadialBar`, `Bullet`, `Pie`, `Donut`, `ProgressBar`, and `Pictorial`.
 
+## Visual canvases
+
+PowerBGInfo can also use ChartForgeX visual canvases for desktop hero overlays: large centered type, side information rails, a central badge, and a feature strip rendered as one reusable transparent HUD layer over the selected wallpaper. The PowerBGInfo surface stays thin; `New-BGInfoVisualCanvas`, `New-BGInfoVisualCanvasTile`, and `New-BGInfoVisualCanvasFeature` only describe the wallpaper-specific data and placement. Use `-Opaque` only when you want a self-contained social-card style background.
+
+```powershell
+$tiles = @(
+    New-BGInfoVisualCanvasTile -Side Left -Icon PC -Label HOSTNAME -Value '{{HostName}}'
+    New-BGInfoVisualCanvasTile -Side Left -Icon OS -Label 'OPERATING SYSTEM' -Value '{{OSName}}' -Detail '{{OSVersion}}'
+    New-BGInfoVisualCanvasTile -Side Right -Icon USER -IconKind User -SurfaceStyle Outline -Label USER -Value '{{UserName}}'
+)
+
+New-BGInfo -Target File {
+    New-BGInfoVisualCanvas -Title 'PowerBGInfo' -Subtitle 'Desktop background insights for Windows and PowerShell' -Tile $tiles
+} -FilePath $PSScriptRoot\Examples\Samples\TapC-Evotec-2560x1080.jpg -ConfigurationDirectory $PSScriptRoot\Examples\Output -OutputFileName 'PowerBGInfo.VisualCanvas.jpg' -WallpaperFit Fill
+```
+
+`Examples\Scripts\PowerBGInfo.VisualCanvas.ps1` renders three variants: glass panels with text badges, outline-only panels with text badges, and outline-only panels with built-in icons. Tile `-SurfaceStyle` supports `Glass` and `Outline`; tile `-IconKind` can render built-in icons such as `Computer`, `Network`, `OperatingSystem`, `Cpu`, `Memory`, `User`, `Domain`, `Terminal`, `Storage`, and `Shield`.
+
+The visual canvas palette is data-driven. `New-BGInfoVisualCanvas` accepts color parameters for the hero title, subtitle, tile label/value/detail text, glass tile fill, progress track, badge fill, badge text, and primary/secondary accents. Those colors are preserved in JSON exports, so a consumer can brand the same reusable ChartForgeX template without changing renderer code.
+
+To generate a border-only icon overlay like the examples, start with explicit tile style, icon kind, and palette values:
+
+```powershell
+$palette = @{
+    Accent           = '#2F80FF'
+    SecondaryAccent  = '#22A7FF'
+    TitleColor       = '#F8FAFC'
+    TitleAccentColor = '#2F80FF'
+    SubtitleColor    = '#D8E3F4'
+    TileLabelColor   = '#C4D4EC'
+    TileValueColor   = '#F8FAFC'
+    TileDetailColor  = '#A8BAD4'
+}
+
+$tiles = @(
+    New-BGInfoVisualCanvasTile -Side Left -IconKind Computer -SurfaceStyle Outline -Label HOSTNAME -Value '{{HostName}}'
+    New-BGInfoVisualCanvasTile -Side Left -IconKind Network -SurfaceStyle Outline -Label 'IP ADDRESS' -Value '{{IPv4Address}}'
+    New-BGInfoVisualCanvasTile -Side Left -IconKind OperatingSystem -SurfaceStyle Outline -Label 'OPERATING SYSTEM' -Value '{{OSName}}' -Detail '{{OSVersion}}'
+    New-BGInfoVisualCanvasTile -Side Right -IconKind Cpu -SurfaceStyle Outline -Label CPU -Value '{{CpuCores}} cores / {{CpuLogicalCores}} threads'
+    New-BGInfoVisualCanvasTile -Side Right -IconKind Memory -SurfaceStyle Outline -Label RAM -Value '{{RAMSize}}'
+    New-BGInfoVisualCanvasTile -Side Right -IconKind User -SurfaceStyle Outline -Label USER -Value '{{UserName}}'
+    New-BGInfoVisualCanvasTile -Side Right -IconKind Domain -SurfaceStyle Outline -Label DOMAIN -Value '{{UserDNSDomain}}'
+)
+
+New-BGInfo -Target File {
+    New-BGInfoVisualCanvas -Title 'PowerBGInfo' -Subtitle 'Desktop background insights for Windows and PowerShell' -Tile $tiles @palette
+} -FilePath .\Examples\Samples\TapC-Evotec-2560x1080.jpg -ConfigurationDirectory .\Examples\Output -OutputFileName 'PowerBGInfo.VisualCanvas.OutlineIcons.jpg' -WallpaperFit Fill
+```
+
 ## Topology diagrams
 
 PowerBGInfo can also place ChartForgeX topology diagrams on the wallpaper. This is useful for lab machines, admin jump boxes, training kiosks, build agents, and shared operational desktops where a compact service or network map is more useful than another metric chart.

--- a/README.MD
+++ b/README.MD
@@ -314,7 +314,7 @@ New-BGInfo -Target File {
 } -FilePath $PSScriptRoot\Examples\Samples\TapC-Evotec-2560x1080.jpg -ConfigurationDirectory $PSScriptRoot\Examples\Output -OutputFileName 'PowerBGInfo.VisualCanvas.jpg' -WallpaperFit Fill
 ```
 
-`Examples\Scripts\PowerBGInfo.VisualCanvas.ps1` renders three variants: glass panels with text badges, outline-only panels with text badges, and outline-only panels with built-in icons. `Examples\Scripts\PowerBGInfo.VisualCanvas.RaisedSections.ps1` shows a stronger glass treatment with icon tiles and progress rails for a more raised section look over the same wallpaper. `Examples\Scripts\PowerBGInfo.VisualCanvas.MiniCharts.ps1` combines the same visual canvas with small purpose-matched charts and a bottom-right logo image. Tile `-SurfaceStyle` supports `Glass` and `Outline`; tile `-IconKind` can render built-in icons such as `Computer`, `Network`, `OperatingSystem`, `Cpu`, `Memory`, `User`, `Domain`, `Terminal`, `Storage`, and `Shield`.
+`Examples\Scripts\PowerBGInfo.VisualCanvas.ps1` renders three variants: glass panels with text badges, outline-only panels with text badges, and outline-only panels with built-in icons. `Examples\Scripts\PowerBGInfo.VisualCanvas.RaisedSections.ps1` shows a stronger glass treatment with icon tiles and progress rails for a more raised section look over the same wallpaper. `Examples\Scripts\PowerBGInfo.VisualCanvas.MiniCharts.ps1` combines the same visual canvas with purpose-matched mini charts inside the CPU, RAM, disk, and patching sections plus a bottom-right logo image. Tile `-SurfaceStyle` supports `Glass` and `Outline`; tile `-IconKind` can render built-in icons such as `Computer`, `Network`, `OperatingSystem`, `Cpu`, `Memory`, `User`, `Domain`, `Terminal`, `Storage`, and `Shield`.
 
 The visual canvas palette is data-driven. `New-BGInfoVisualCanvas` accepts color parameters for the hero title, subtitle, tile label/value/detail text, glass tile fill, progress track, badge fill, badge text, and primary/secondary accents. Those colors are preserved in JSON exports, so a consumer can brand the same reusable ChartForgeX template without changing renderer code.
 
@@ -370,17 +370,17 @@ New-BGInfo -Target File {
 } -FilePath .\Examples\Samples\TapC-Evotec-2560x1080.jpg -ConfigurationDirectory .\Examples\Output -OutputFileName 'PowerBGInfo.VisualCanvas.RaisedSections.jpg' -WallpaperFit Fill
 ```
 
-Mini charts can sit in the clear space below the hero while the logo stays anchored in the bottom-right corner. Each chart and image has its own anchor and offsets, so the layout can be moved away from taskbars, rails, or customer branding:
+Mini charts can live inside the same sections as their values, while the logo stays anchored in the bottom-right corner. Each tile chooses its own mini-chart kind and values; the image has its own anchor and offsets so it can be moved away from taskbars, rails, or customer branding:
 
 ```powershell
+$tiles = @(
+    New-BGInfoVisualCanvasTile -Side Right -IconKind Cpu -SurfaceStyle Glass -Label CPU -Value '{{CpuCores}} cores / {{CpuLogicalCores}} threads' -Progress 0.28 -MiniChartKind Area -MiniChartValues 18,26,22,37,48,43,51 -MiniChartMaximum 100
+    New-BGInfoVisualCanvasTile -Side Right -IconKind Memory -SurfaceStyle Glass -Label RAM -Value '{{RAMSize}}' -Progress 0.41 -MiniChartKind Bars -MiniChartValues 36,39,41,42,44,43,41 -MiniChartMaximum 100
+    New-BGInfoVisualCanvasTile -Side Right -IconKind Storage -SurfaceStyle Glass -Label 'SYSTEM DRIVE' -Value '62% free' -Progress 0.62 -MiniChartKind Sparkline -MiniChartValues 66,65,64,64,63,62,62 -MiniChartMaximum 100
+)
+
 New-BGInfo -Target File {
-    New-BGInfoVisualCanvas -Title 'PowerBGInfo' -Subtitle 'Mini charts stay below the hero and away from the side rails' -Tile $tiles @palette
-
-    New-BGInfoChart -Title 'CPU burst' -Kind Area -Values 18,26,22,37,48,43,51 -Width 260 -Height 112 -Anchor BottomCenter -OffsetX -450 -OffsetY 210 -LineColor '#38BDF8' -FillColor '#38BDF8' -BackgroundColor '#A6081224' -NoHistory
-    New-BGInfoChart -Title 'Memory load' -Kind RadialBar -Values 41 -Width 230 -Height 112 -Anchor BottomCenter -OffsetX -150 -OffsetY 210 -LineColor '#60A5FA' -BackgroundColor '#A6081224' -Maximum 100 -NoHistory
-    New-BGInfoChart -Title 'Disk free' -Kind ProgressBar -Values 62 -Labels 'C:' -Width 260 -Height 112 -Anchor BottomCenter -OffsetX 145 -OffsetY 210 -LineColor '#34D399' -BackgroundColor '#A6081224' -Maximum 100 -NoHistory
-    New-BGInfoChart -Title 'Patch target' -Kind Bullet -Values 89 -Target 95 -RangeEnds 70,85 -Width 280 -Height 112 -Anchor BottomCenter -OffsetX 455 -OffsetY 210 -LineColor '#FBBF24' -BackgroundColor '#A6081224' -Maximum 100 -NoHistory
-
+    New-BGInfoVisualCanvas -Title 'PowerBGInfo' -Subtitle 'Mini charts live inside the matching sections' -Tile $tiles @palette
     New-BGInfoImage -Path .\Examples\Samples\LogoEvotec.png -Width 210 -Anchor BottomRight -OffsetX 72 -OffsetY 54 -Opacity 0.92
 } -FilePath .\Examples\Samples\TapC-Evotec-2560x1080.jpg -ConfigurationDirectory .\Examples\Output -OutputFileName 'PowerBGInfo.VisualCanvas.MiniCharts.jpg' -WallpaperFit Fill
 ```

--- a/Sources/PowerBGInfo.PowerShell/CmdletNewBGInfo.cs
+++ b/Sources/PowerBGInfo.PowerShell/CmdletNewBGInfo.cs
@@ -247,6 +247,12 @@ public class CmdletNewBGInfo : PSCmdlet {
                 continue;
             }
 
+            if (item?.BaseObject is BgInfoImage image)
+            {
+                config.Images.Add(image);
+                continue;
+            }
+
             if (item != null && TryConvertLegacyEntry(item, out var legacyEntry))
             {
                 config.Entries.Add(legacyEntry);

--- a/Sources/PowerBGInfo.PowerShell/CmdletNewBGInfo.cs
+++ b/Sources/PowerBGInfo.PowerShell/CmdletNewBGInfo.cs
@@ -241,6 +241,12 @@ public class CmdletNewBGInfo : PSCmdlet {
                 continue;
             }
 
+            if (item?.BaseObject is BgInfoVisualCanvas visualCanvas)
+            {
+                config.VisualCanvases.Add(visualCanvas);
+                continue;
+            }
+
             if (item != null && TryConvertLegacyEntry(item, out var legacyEntry))
             {
                 config.Entries.Add(legacyEntry);

--- a/Sources/PowerBGInfo.PowerShell/CmdletNewBGInfoConfiguration.cs
+++ b/Sources/PowerBGInfo.PowerShell/CmdletNewBGInfoConfiguration.cs
@@ -156,6 +156,10 @@ public sealed class CmdletNewBGInfoConfiguration : PSCmdlet {
     [Parameter]
     public BgInfoTopology[] Topologies { get; set; } = System.Array.Empty<BgInfoTopology>();
 
+    /// <para>Image overlays to include in the configuration.</para>
+    [Parameter]
+    public BgInfoImage[] Images { get; set; } = System.Array.Empty<BgInfoImage>();
+
     /// <summary>Creates the configuration object.</summary>
     protected override void EndProcessing() {
         var config = new BgInfoConfiguration();
@@ -205,6 +209,9 @@ public sealed class CmdletNewBGInfoConfiguration : PSCmdlet {
         }
         if (IsParameterBound(nameof(Topologies)) && Topologies.Length > 0) {
             config.Topologies.AddRange(Topologies);
+        }
+        if (IsParameterBound(nameof(Images)) && Images.Length > 0) {
+            config.Images.AddRange(Images);
         }
 
         WriteObject(config);

--- a/Sources/PowerBGInfo.PowerShell/CmdletNewBGInfoConfiguration.cs
+++ b/Sources/PowerBGInfo.PowerShell/CmdletNewBGInfoConfiguration.cs
@@ -160,6 +160,11 @@ public sealed class CmdletNewBGInfoConfiguration : PSCmdlet {
     [Parameter]
     public BgInfoImage[] Images { get; set; } = System.Array.Empty<BgInfoImage>();
 
+    /// <para>Visual canvas overlays to include in the configuration.</para>
+    [Parameter]
+    [Alias("VisualCanvas")]
+    public BgInfoVisualCanvas[] VisualCanvases { get; set; } = System.Array.Empty<BgInfoVisualCanvas>();
+
     /// <summary>Creates the configuration object.</summary>
     protected override void EndProcessing() {
         var config = new BgInfoConfiguration();
@@ -211,7 +216,10 @@ public sealed class CmdletNewBGInfoConfiguration : PSCmdlet {
             config.Topologies.AddRange(Topologies);
         }
         if (IsParameterBound(nameof(Images)) && Images.Length > 0) {
-            config.Images.AddRange(Images);
+            foreach (var image in Images) if (image != null) config.Images.Add(image);
+        }
+        if (IsParameterBound(nameof(VisualCanvases)) && VisualCanvases.Length > 0) {
+            foreach (var visual in VisualCanvases) if (visual != null) config.VisualCanvases.Add(visual);
         }
 
         WriteObject(config);

--- a/Sources/PowerBGInfo.PowerShell/CmdletNewBGInfoImage.cs
+++ b/Sources/PowerBGInfo.PowerShell/CmdletNewBGInfoImage.cs
@@ -1,0 +1,79 @@
+using System.Management.Automation;
+
+namespace PowerBGInfo.PowerShell;
+
+/// <summary>Creates a BGInfo image overlay definition.</summary>
+[Cmdlet(VerbsCommon.New, "BGInfoImage")]
+[OutputType(typeof(BgInfoImage))]
+public sealed class CmdletNewBGInfoImage : PSCmdlet {
+    /// <para>Path to the image file.</para>
+    [Parameter(Mandatory = true, Position = 0)]
+    [Alias("FullName")]
+    public string Path { get; set; } = string.Empty;
+
+    /// <para>Target image width in pixels. Omit with Height to preserve aspect ratio.</para>
+    [Parameter]
+    public int Width { get; set; }
+
+    /// <para>Target image height in pixels. Omit with Width to preserve aspect ratio.</para>
+    [Parameter]
+    public int Height { get; set; }
+
+    /// <para>Anchor position for placement.</para>
+    [Parameter]
+    public BgInfoTextPosition Anchor { get; set; } = BgInfoTextPosition.BottomRight;
+
+    /// <para>Horizontal offset from the anchor.</para>
+    [Parameter]
+    public int OffsetX { get; set; } = 32;
+
+    /// <para>Vertical offset from the anchor.</para>
+    [Parameter]
+    public int OffsetY { get; set; } = 32;
+
+    /// <para>Absolute X position for placement.</para>
+    [Parameter]
+    public int PositionX { get; set; }
+
+    /// <para>Absolute Y position for placement.</para>
+    [Parameter]
+    public int PositionY { get; set; }
+
+    /// <para>Image opacity from zero to one.</para>
+    [Parameter]
+    public double Opacity { get; set; } = 1d;
+
+    /// <summary>Emits an image overlay definition.</summary>
+    protected override void EndProcessing() {
+        if (Width < 0) {
+            ThrowTerminatingError(new ErrorRecord(new ArgumentOutOfRangeException(nameof(Width), Width, "Width cannot be negative."), "BGInfoImageInvalidWidth", ErrorCategory.InvalidArgument, Width));
+            return;
+        }
+        if (Height < 0) {
+            ThrowTerminatingError(new ErrorRecord(new ArgumentOutOfRangeException(nameof(Height), Height, "Height cannot be negative."), "BGInfoImageInvalidHeight", ErrorCategory.InvalidArgument, Height));
+            return;
+        }
+        if (Opacity < 0d || Opacity > 1d) {
+            ThrowTerminatingError(new ErrorRecord(new ArgumentOutOfRangeException(nameof(Opacity), Opacity, "Opacity must be between 0 and 1."), "BGInfoImageInvalidOpacity", ErrorCategory.InvalidArgument, Opacity));
+            return;
+        }
+
+        var image = new BgInfoImage {
+            Path = SessionState.Path.GetUnresolvedProviderPathFromPSPath(Path),
+            Width = Width,
+            Height = Height,
+            Anchor = Anchor,
+            OffsetX = OffsetX,
+            OffsetY = OffsetY,
+            Opacity = Opacity
+        };
+
+        if (MyInvocation.BoundParameters.ContainsKey(nameof(PositionX)) &&
+            MyInvocation.BoundParameters.ContainsKey(nameof(PositionY))) {
+            image.PositionX = PositionX;
+            image.PositionY = PositionY;
+        }
+
+        WriteObject(image);
+    }
+}

--- a/Sources/PowerBGInfo.PowerShell/CmdletNewBGInfoImage.cs
+++ b/Sources/PowerBGInfo.PowerShell/CmdletNewBGInfoImage.cs
@@ -53,7 +53,7 @@ public sealed class CmdletNewBGInfoImage : PSCmdlet {
             ThrowTerminatingError(new ErrorRecord(new ArgumentOutOfRangeException(nameof(Height), Height, "Height cannot be negative."), "BGInfoImageInvalidHeight", ErrorCategory.InvalidArgument, Height));
             return;
         }
-        if (Opacity < 0d || Opacity > 1d) {
+        if (double.IsNaN(Opacity) || double.IsInfinity(Opacity) || Opacity < 0d || Opacity > 1d) {
             ThrowTerminatingError(new ErrorRecord(new ArgumentOutOfRangeException(nameof(Opacity), Opacity, "Opacity must be between 0 and 1."), "BGInfoImageInvalidOpacity", ErrorCategory.InvalidArgument, Opacity));
             return;
         }
@@ -68,9 +68,10 @@ public sealed class CmdletNewBGInfoImage : PSCmdlet {
             Opacity = Opacity
         };
 
-        if (MyInvocation.BoundParameters.ContainsKey(nameof(PositionX)) &&
-            MyInvocation.BoundParameters.ContainsKey(nameof(PositionY))) {
+        if (MyInvocation.BoundParameters.ContainsKey(nameof(PositionX))) {
             image.PositionX = PositionX;
+        }
+        if (MyInvocation.BoundParameters.ContainsKey(nameof(PositionY))) {
             image.PositionY = PositionY;
         }
 

--- a/Sources/PowerBGInfo.PowerShell/CmdletNewBGInfoVisualCanvas.cs
+++ b/Sources/PowerBGInfo.PowerShell/CmdletNewBGInfoVisualCanvas.cs
@@ -1,0 +1,151 @@
+using System.Management.Automation;
+using PowerBGInfo;
+
+namespace PowerBGInfo.PowerShell;
+
+/// <summary>Creates a BGInfo visual canvas definition backed by ChartForgeX.</summary>
+[Cmdlet(VerbsCommon.New, "BGInfoVisualCanvas")]
+[OutputType(typeof(BgInfoVisualCanvas))]
+public class CmdletNewBGInfoVisualCanvas : PSCmdlet {
+    /// <para>Visual canvas template.</para>
+    [Parameter]
+    public BgInfoVisualCanvasTemplate Template { get; set; } = BgInfoVisualCanvasTemplate.PowerBgInfoHero;
+
+    /// <para>Canvas title or brand text.</para>
+    [Parameter]
+    public string Title { get; set; } = "PowerBGInfo";
+
+    /// <para>Canvas subtitle text.</para>
+    [Parameter]
+    public string Subtitle { get; set; } = "Desktop background insights for Windows and PowerShell";
+
+    /// <para>Canvas width in pixels. Zero uses the target wallpaper width.</para>
+    [Parameter]
+    public int Width { get; set; }
+
+    /// <para>Canvas height in pixels. Zero uses the target wallpaper height.</para>
+    [Parameter]
+    public int Height { get; set; }
+
+    /// <para>Explicit X position on the generated wallpaper.</para>
+    [Parameter]
+    public int PositionX { get; set; }
+
+    /// <para>Explicit Y position on the generated wallpaper.</para>
+    [Parameter]
+    public int PositionY { get; set; }
+
+    /// <para>Top background color.</para>
+    [Parameter]
+    public object? BackgroundTop { get; set; }
+
+    /// <para>Bottom background color.</para>
+    [Parameter]
+    public object? BackgroundBottom { get; set; }
+
+    /// <para>Primary accent color.</para>
+    [Parameter]
+    public object? Accent { get; set; }
+
+    /// <para>Secondary accent color for badge and backdrop highlights.</para>
+    [Parameter]
+    public object? SecondaryAccent { get; set; }
+
+    /// <para>Primary hero title color.</para>
+    [Parameter]
+    public object? TitleColor { get; set; }
+
+    /// <para>Accent hero title color.</para>
+    [Parameter]
+    public object? TitleAccentColor { get; set; }
+
+    /// <para>Subtitle text color.</para>
+    [Parameter]
+    public object? SubtitleColor { get; set; }
+
+    /// <para>Glass tile top color.</para>
+    [Parameter]
+    public object? TileGlassTop { get; set; }
+
+    /// <para>Glass tile bottom color.</para>
+    [Parameter]
+    public object? TileGlassBottom { get; set; }
+
+    /// <para>Tile label text color.</para>
+    [Parameter]
+    public object? TileLabelColor { get; set; }
+
+    /// <para>Tile value text color.</para>
+    [Parameter]
+    public object? TileValueColor { get; set; }
+
+    /// <para>Tile detail text color.</para>
+    [Parameter]
+    public object? TileDetailColor { get; set; }
+
+    /// <para>Tile progress track color.</para>
+    [Parameter]
+    public object? TileProgressTrackColor { get; set; }
+
+    /// <para>Hero badge top fill color.</para>
+    [Parameter]
+    public object? HeroBadgeTop { get; set; }
+
+    /// <para>Hero badge bottom fill color.</para>
+    [Parameter]
+    public object? HeroBadgeBottom { get; set; }
+
+    /// <para>Hero badge symbol color.</para>
+    [Parameter]
+    public object? HeroBadgeTextColor { get; set; }
+
+    /// <para>Disable the built-in technology backdrop.</para>
+    [Parameter]
+    public SwitchParameter NoTechBackdrop { get; set; }
+
+    /// <para>Render a full ChartForgeX background instead of floating over the wallpaper.</para>
+    [Parameter]
+    public SwitchParameter Opaque { get; set; }
+
+    /// <para>Side rail tile definitions.</para>
+    [Parameter]
+    public BgInfoVisualCanvasTile[] Tile { get; set; } = Array.Empty<BgInfoVisualCanvasTile>();
+
+    /// <para>Feature strip item definitions.</para>
+    [Parameter]
+    public BgInfoVisualCanvasFeature[] Feature { get; set; } = Array.Empty<BgInfoVisualCanvasFeature>();
+
+    /// <summary>Emits a visual canvas definition.</summary>
+    protected override void EndProcessing() {
+        var visual = new BgInfoVisualCanvas {
+            Template = Template,
+            Title = Title,
+            Subtitle = Subtitle,
+            Width = Width,
+            Height = Height,
+            PositionX = PositionX,
+            PositionY = PositionY,
+            BackgroundTop = PowerShellColorConverter.ConvertOptional(BackgroundTop, nameof(BackgroundTop)) ?? System.Drawing.Color.FromArgb(255, 2, 7, 19),
+            BackgroundBottom = PowerShellColorConverter.ConvertOptional(BackgroundBottom, nameof(BackgroundBottom)) ?? System.Drawing.Color.FromArgb(255, 7, 26, 53),
+            Accent = PowerShellColorConverter.ConvertOptional(Accent, nameof(Accent)) ?? System.Drawing.Color.FromArgb(255, 47, 128, 255),
+            SecondaryAccent = PowerShellColorConverter.ConvertOptional(SecondaryAccent, nameof(SecondaryAccent)),
+            TitleColor = PowerShellColorConverter.ConvertOptional(TitleColor, nameof(TitleColor)),
+            TitleAccentColor = PowerShellColorConverter.ConvertOptional(TitleAccentColor, nameof(TitleAccentColor)),
+            SubtitleColor = PowerShellColorConverter.ConvertOptional(SubtitleColor, nameof(SubtitleColor)),
+            TileGlassTop = PowerShellColorConverter.ConvertOptional(TileGlassTop, nameof(TileGlassTop)),
+            TileGlassBottom = PowerShellColorConverter.ConvertOptional(TileGlassBottom, nameof(TileGlassBottom)),
+            TileLabelColor = PowerShellColorConverter.ConvertOptional(TileLabelColor, nameof(TileLabelColor)),
+            TileValueColor = PowerShellColorConverter.ConvertOptional(TileValueColor, nameof(TileValueColor)),
+            TileDetailColor = PowerShellColorConverter.ConvertOptional(TileDetailColor, nameof(TileDetailColor)),
+            TileProgressTrackColor = PowerShellColorConverter.ConvertOptional(TileProgressTrackColor, nameof(TileProgressTrackColor)),
+            HeroBadgeTop = PowerShellColorConverter.ConvertOptional(HeroBadgeTop, nameof(HeroBadgeTop)),
+            HeroBadgeBottom = PowerShellColorConverter.ConvertOptional(HeroBadgeBottom, nameof(HeroBadgeBottom)),
+            HeroBadgeTextColor = PowerShellColorConverter.ConvertOptional(HeroBadgeTextColor, nameof(HeroBadgeTextColor)),
+            Transparent = !Opaque.IsPresent,
+            TechBackdrop = !NoTechBackdrop.IsPresent
+        };
+        foreach (var tile in Tile ?? Array.Empty<BgInfoVisualCanvasTile>()) if (tile != null) visual.Tiles.Add(tile);
+        foreach (var feature in Feature ?? Array.Empty<BgInfoVisualCanvasFeature>()) if (feature != null) visual.Features.Add(feature);
+        WriteObject(visual);
+    }
+}

--- a/Sources/PowerBGInfo.PowerShell/CmdletNewBGInfoVisualCanvasFeature.cs
+++ b/Sources/PowerBGInfo.PowerShell/CmdletNewBGInfoVisualCanvasFeature.cs
@@ -1,0 +1,25 @@
+using System.Management.Automation;
+using PowerBGInfo;
+
+namespace PowerBGInfo.PowerShell;
+
+/// <summary>Creates a BGInfo visual canvas feature-strip item.</summary>
+[Cmdlet(VerbsCommon.New, "BGInfoVisualCanvasFeature")]
+[OutputType(typeof(BgInfoVisualCanvasFeature))]
+public class CmdletNewBGInfoVisualCanvasFeature : PSCmdlet {
+    /// <para>Compact item icon or symbol.</para>
+    [Parameter]
+    public string Icon { get; set; } = string.Empty;
+
+    /// <para>Feature label.</para>
+    [Parameter(Mandatory = true)]
+    public string Label { get; set; } = string.Empty;
+
+    /// <summary>Emits a visual canvas feature-strip item.</summary>
+    protected override void EndProcessing() {
+        WriteObject(new BgInfoVisualCanvasFeature {
+            Icon = Icon,
+            Label = Label
+        });
+    }
+}

--- a/Sources/PowerBGInfo.PowerShell/CmdletNewBGInfoVisualCanvasTile.cs
+++ b/Sources/PowerBGInfo.PowerShell/CmdletNewBGInfoVisualCanvasTile.cs
@@ -1,0 +1,60 @@
+using System.Management.Automation;
+using PowerBGInfo;
+
+namespace PowerBGInfo.PowerShell;
+
+/// <summary>Creates a BGInfo visual canvas tile definition.</summary>
+[Cmdlet(VerbsCommon.New, "BGInfoVisualCanvasTile")]
+[OutputType(typeof(BgInfoVisualCanvasTile))]
+public class CmdletNewBGInfoVisualCanvasTile : PSCmdlet {
+    /// <para>Side rail placement.</para>
+    [Parameter]
+    public BgInfoVisualCanvasSide Side { get; set; }
+
+    /// <para>Compact tile icon or symbol.</para>
+    [Parameter]
+    public string Icon { get; set; } = string.Empty;
+
+    /// <para>Tile label. Templates such as {{HostName}} are resolved at render time.</para>
+    [Parameter(Mandatory = true)]
+    public string Label { get; set; } = string.Empty;
+
+    /// <para>Primary tile value. Templates such as {{HostName}} are resolved at render time.</para>
+    [Parameter(Mandatory = true)]
+    public string Value { get; set; } = string.Empty;
+
+    /// <para>Optional detail text. Templates are resolved at render time.</para>
+    [Parameter]
+    public string Detail { get; set; } = string.Empty;
+
+    /// <para>Optional accent color.</para>
+    [Parameter]
+    public object? Accent { get; set; }
+
+    /// <para>Optional progress value from zero to one.</para>
+    [Parameter]
+    public double? Progress { get; set; }
+
+    /// <para>Tile surface style.</para>
+    [Parameter]
+    public BgInfoVisualCanvasTileSurfaceStyle SurfaceStyle { get; set; }
+
+    /// <para>Built-in icon to render instead of the Icon text.</para>
+    [Parameter]
+    public BgInfoVisualCanvasTileIconKind IconKind { get; set; }
+
+    /// <summary>Emits a visual canvas tile definition.</summary>
+    protected override void EndProcessing() {
+        WriteObject(new BgInfoVisualCanvasTile {
+            Side = Side,
+            Icon = Icon,
+            Label = Label,
+            Value = Value,
+            Detail = Detail,
+            Accent = PowerShellColorConverter.ConvertOptional(Accent, nameof(Accent)),
+            Progress = Progress,
+            SurfaceStyle = SurfaceStyle,
+            IconKind = IconKind
+        });
+    }
+}

--- a/Sources/PowerBGInfo.PowerShell/CmdletNewBGInfoVisualCanvasTile.cs
+++ b/Sources/PowerBGInfo.PowerShell/CmdletNewBGInfoVisualCanvasTile.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Management.Automation;
 using PowerBGInfo;
 
@@ -43,6 +44,18 @@ public class CmdletNewBGInfoVisualCanvasTile : PSCmdlet {
     [Parameter]
     public BgInfoVisualCanvasTileIconKind IconKind { get; set; }
 
+    /// <para>Compact chart kind rendered inside the tile.</para>
+    [Parameter]
+    public BgInfoVisualCanvasTileMiniChartKind MiniChartKind { get; set; }
+
+    /// <para>Compact chart values rendered inside the tile.</para>
+    [Parameter]
+    public double[] MiniChartValues { get; set; } = Array.Empty<double>();
+
+    /// <para>Optional compact chart maximum.</para>
+    [Parameter]
+    public double? MiniChartMaximum { get; set; }
+
     /// <summary>Emits a visual canvas tile definition.</summary>
     protected override void EndProcessing() {
         WriteObject(new BgInfoVisualCanvasTile {
@@ -54,7 +67,10 @@ public class CmdletNewBGInfoVisualCanvasTile : PSCmdlet {
             Accent = PowerShellColorConverter.ConvertOptional(Accent, nameof(Accent)),
             Progress = Progress,
             SurfaceStyle = SurfaceStyle,
-            IconKind = IconKind
+            IconKind = IconKind,
+            MiniChartKind = MiniChartKind,
+            MiniChartValues = MiniChartValues ?? Array.Empty<double>(),
+            MiniChartMaximum = MiniChartMaximum
         });
     }
 }

--- a/Sources/PowerBGInfo.Tests/BgInfoConfigurationJsonTests.cs
+++ b/Sources/PowerBGInfo.Tests/BgInfoConfigurationJsonTests.cs
@@ -328,6 +328,44 @@ public class BgInfoConfigurationJsonTests
     }
 
     [Fact]
+    public void LoadSkipsNullVisualCanvasChildren() {
+        var tempDirectory = Path.Combine(Path.GetTempPath(), "bginfo-json-" + Path.GetRandomFileName());
+        Directory.CreateDirectory(tempDirectory);
+        var path = Path.Combine(tempDirectory, "config.json");
+
+        File.WriteAllText(path, """
+{
+  "VisualCanvases": [
+    {
+      "Tiles": [
+        null,
+        {
+          "Side": "Left",
+          "Icon": "PC",
+          "Label": "HOSTNAME",
+          "Value": "{{HostName}}"
+        }
+      ],
+      "Features": [
+        null,
+        {
+          "Icon": "PS",
+          "Label": "LIGHTWEIGHT"
+        }
+      ]
+    }
+  ]
+}
+""");
+
+        var configuration = BgInfoConfigurationJson.Load(path);
+
+        var visual = Assert.Single(configuration.VisualCanvases);
+        Assert.Single(visual.Tiles);
+        Assert.Single(visual.Features);
+    }
+
+    [Fact]
     public void SaveAndLoadPreservesImageOverlays() {
         var tempDirectory = Path.Combine(Path.GetTempPath(), "bginfo-json-" + Path.GetRandomFileName());
         Directory.CreateDirectory(tempDirectory);
@@ -345,6 +383,7 @@ public class BgInfoConfigurationJsonTests
             OffsetY = 54,
             Opacity = 0.85
         });
+        configuration.Images.Add(null!);
 
         BgInfoConfigurationJson.Save(configuration, path);
 
@@ -357,5 +396,24 @@ public class BgInfoConfigurationJsonTests
         Assert.Equal(72, image.OffsetX);
         Assert.Equal(54, image.OffsetY);
         Assert.Equal(0.85, image.Opacity);
+    }
+
+    [Fact]
+    public void LoadRejectsInvalidImageOpacity() {
+        var tempDirectory = Path.Combine(Path.GetTempPath(), "bginfo-json-" + Path.GetRandomFileName());
+        Directory.CreateDirectory(tempDirectory);
+        var path = Path.Combine(tempDirectory, "config.json");
+        File.WriteAllText(path, """
+{
+  "Images": [
+    {
+      "Path": "logo.png",
+      "Opacity": 1.2
+    }
+  ]
+}
+""");
+
+        Assert.Throws<InvalidDataException>(() => BgInfoConfigurationJson.Load(path));
     }
 }

--- a/Sources/PowerBGInfo.Tests/BgInfoConfigurationJsonTests.cs
+++ b/Sources/PowerBGInfo.Tests/BgInfoConfigurationJsonTests.cs
@@ -227,4 +227,97 @@ public class BgInfoConfigurationJsonTests
         Assert.Equal("gateway-api", loaded.Edges[0].Id);
         Assert.Equal(TopologyEdgeKind.Connectivity, loaded.Edges[0].Kind);
     }
+
+    [Fact]
+    public void SaveAndLoadPreservesVisualCanvasOptions() {
+        var tempDirectory = Path.Combine(Path.GetTempPath(), "bginfo-json-" + Path.GetRandomFileName());
+        Directory.CreateDirectory(tempDirectory);
+        var path = Path.Combine(tempDirectory, "config.json");
+
+        var configuration = new BgInfoConfiguration {
+            ConfigurationDirectory = tempDirectory
+        };
+        var visual = new BgInfoVisualCanvas {
+            Title = "PowerBGInfo",
+            Subtitle = "Desktop background insights",
+            Width = 1200,
+            Height = 630,
+            PositionX = 12,
+            PositionY = 34,
+            BackgroundTop = Color.FromArgb(255, 2, 7, 19),
+            BackgroundBottom = Color.FromArgb(255, 7, 26, 53),
+            Accent = Color.DeepSkyBlue,
+            SecondaryAccent = Color.Cyan,
+            TitleColor = Color.White,
+            TitleAccentColor = Color.DeepSkyBlue,
+            SubtitleColor = Color.LightSteelBlue,
+            TileGlassTop = Color.FromArgb(230, 10, 20, 30),
+            TileGlassBottom = Color.FromArgb(220, 5, 10, 15),
+            TileLabelColor = Color.LightBlue,
+            TileValueColor = Color.WhiteSmoke,
+            TileDetailColor = Color.SlateGray,
+            TileProgressTrackColor = Color.DarkSlateBlue,
+            HeroBadgeTop = Color.Navy,
+            HeroBadgeBottom = Color.Black,
+            HeroBadgeTextColor = Color.AliceBlue,
+            TechBackdrop = false
+        };
+        visual.Tiles.Add(new BgInfoVisualCanvasTile {
+            Side = BgInfoVisualCanvasSide.Left,
+            Icon = "PC",
+            Label = "HOSTNAME",
+            Value = "{{HostName}}",
+            Detail = "{{OSName}}",
+            Accent = Color.DodgerBlue,
+            Progress = 0.42,
+            SurfaceStyle = BgInfoVisualCanvasTileSurfaceStyle.Outline,
+            IconKind = BgInfoVisualCanvasTileIconKind.Computer
+        });
+        visual.Features.Add(new BgInfoVisualCanvasFeature {
+            Icon = "PS",
+            Label = "LIGHTWEIGHT"
+        });
+        configuration.VisualCanvases.Add(visual);
+
+        BgInfoConfigurationJson.Save(configuration, path);
+
+        var roundTripped = BgInfoConfigurationJson.Load(path);
+        var loaded = Assert.Single(roundTripped.VisualCanvases);
+        Assert.Equal("PowerBGInfo", loaded.Title);
+        Assert.Equal("Desktop background insights", loaded.Subtitle);
+        Assert.Equal(1200, loaded.Width);
+        Assert.Equal(630, loaded.Height);
+        Assert.Equal(12, loaded.PositionX);
+        Assert.Equal(34, loaded.PositionY);
+        Assert.Equal(Color.DeepSkyBlue.ToArgb(), loaded.Accent.ToArgb());
+        Assert.Equal(Color.Cyan.ToArgb(), loaded.SecondaryAccent!.Value.ToArgb());
+        Assert.Equal(Color.White.ToArgb(), loaded.TitleColor!.Value.ToArgb());
+        Assert.Equal(Color.DeepSkyBlue.ToArgb(), loaded.TitleAccentColor!.Value.ToArgb());
+        Assert.Equal(Color.LightSteelBlue.ToArgb(), loaded.SubtitleColor!.Value.ToArgb());
+        Assert.Equal(Color.FromArgb(230, 10, 20, 30).ToArgb(), loaded.TileGlassTop!.Value.ToArgb());
+        Assert.Equal(Color.FromArgb(220, 5, 10, 15).ToArgb(), loaded.TileGlassBottom!.Value.ToArgb());
+        Assert.Equal(Color.LightBlue.ToArgb(), loaded.TileLabelColor!.Value.ToArgb());
+        Assert.Equal(Color.WhiteSmoke.ToArgb(), loaded.TileValueColor!.Value.ToArgb());
+        Assert.Equal(Color.SlateGray.ToArgb(), loaded.TileDetailColor!.Value.ToArgb());
+        Assert.Equal(Color.DarkSlateBlue.ToArgb(), loaded.TileProgressTrackColor!.Value.ToArgb());
+        Assert.Equal(Color.Navy.ToArgb(), loaded.HeroBadgeTop!.Value.ToArgb());
+        Assert.Equal(Color.Black.ToArgb(), loaded.HeroBadgeBottom!.Value.ToArgb());
+        Assert.Equal(Color.AliceBlue.ToArgb(), loaded.HeroBadgeTextColor!.Value.ToArgb());
+        Assert.False(loaded.TechBackdrop);
+
+        var tile = Assert.Single(loaded.Tiles);
+        Assert.Equal(BgInfoVisualCanvasSide.Left, tile.Side);
+        Assert.Equal("PC", tile.Icon);
+        Assert.Equal("HOSTNAME", tile.Label);
+        Assert.Equal("{{HostName}}", tile.Value);
+        Assert.Equal("{{OSName}}", tile.Detail);
+        Assert.Equal(Color.DodgerBlue.ToArgb(), tile.Accent!.Value.ToArgb());
+        Assert.Equal(0.42, tile.Progress);
+        Assert.Equal(BgInfoVisualCanvasTileSurfaceStyle.Outline, tile.SurfaceStyle);
+        Assert.Equal(BgInfoVisualCanvasTileIconKind.Computer, tile.IconKind);
+
+        var feature = Assert.Single(loaded.Features);
+        Assert.Equal("PS", feature.Icon);
+        Assert.Equal("LIGHTWEIGHT", feature.Label);
+    }
 }

--- a/Sources/PowerBGInfo.Tests/BgInfoConfigurationJsonTests.cs
+++ b/Sources/PowerBGInfo.Tests/BgInfoConfigurationJsonTests.cs
@@ -270,7 +270,7 @@ public class BgInfoConfigurationJsonTests
             Detail = "{{OSName}}",
             Accent = Color.DodgerBlue,
             Progress = 0.42,
-            SurfaceStyle = BgInfoVisualCanvasTileSurfaceStyle.Outline,
+            SurfaceStyle = BgInfoVisualCanvasTileSurfaceStyle.Raised,
             IconKind = BgInfoVisualCanvasTileIconKind.Computer,
             MiniChartKind = BgInfoVisualCanvasTileMiniChartKind.Area,
             MiniChartValues = new[] { 18d, 26d, 22d, 37d },
@@ -316,7 +316,7 @@ public class BgInfoConfigurationJsonTests
         Assert.Equal("{{OSName}}", tile.Detail);
         Assert.Equal(Color.DodgerBlue.ToArgb(), tile.Accent!.Value.ToArgb());
         Assert.Equal(0.42, tile.Progress);
-        Assert.Equal(BgInfoVisualCanvasTileSurfaceStyle.Outline, tile.SurfaceStyle);
+        Assert.Equal(BgInfoVisualCanvasTileSurfaceStyle.Raised, tile.SurfaceStyle);
         Assert.Equal(BgInfoVisualCanvasTileIconKind.Computer, tile.IconKind);
         Assert.Equal(BgInfoVisualCanvasTileMiniChartKind.Area, tile.MiniChartKind);
         Assert.Equal(new[] { 18d, 26d, 22d, 37d }, tile.MiniChartValues);

--- a/Sources/PowerBGInfo.Tests/BgInfoConfigurationJsonTests.cs
+++ b/Sources/PowerBGInfo.Tests/BgInfoConfigurationJsonTests.cs
@@ -320,4 +320,36 @@ public class BgInfoConfigurationJsonTests
         Assert.Equal("PS", feature.Icon);
         Assert.Equal("LIGHTWEIGHT", feature.Label);
     }
+
+    [Fact]
+    public void SaveAndLoadPreservesImageOverlays() {
+        var tempDirectory = Path.Combine(Path.GetTempPath(), "bginfo-json-" + Path.GetRandomFileName());
+        Directory.CreateDirectory(tempDirectory);
+        var path = Path.Combine(tempDirectory, "config.json");
+
+        var configuration = new BgInfoConfiguration {
+            ConfigurationDirectory = tempDirectory
+        };
+        configuration.Images.Add(new BgInfoImage {
+            Path = @"Images\PowerBGInfo.png",
+            Width = 180,
+            Height = 64,
+            Anchor = BgInfoTextPosition.BottomRight,
+            OffsetX = 72,
+            OffsetY = 54,
+            Opacity = 0.85
+        });
+
+        BgInfoConfigurationJson.Save(configuration, path);
+
+        var roundTripped = BgInfoConfigurationJson.Load(path);
+        var image = Assert.Single(roundTripped.Images);
+        Assert.EndsWith(Path.Combine("Images", "PowerBGInfo.png"), image.Path);
+        Assert.Equal(180, image.Width);
+        Assert.Equal(64, image.Height);
+        Assert.Equal(BgInfoTextPosition.BottomRight, image.Anchor);
+        Assert.Equal(72, image.OffsetX);
+        Assert.Equal(54, image.OffsetY);
+        Assert.Equal(0.85, image.Opacity);
+    }
 }

--- a/Sources/PowerBGInfo.Tests/BgInfoConfigurationJsonTests.cs
+++ b/Sources/PowerBGInfo.Tests/BgInfoConfigurationJsonTests.cs
@@ -271,7 +271,10 @@ public class BgInfoConfigurationJsonTests
             Accent = Color.DodgerBlue,
             Progress = 0.42,
             SurfaceStyle = BgInfoVisualCanvasTileSurfaceStyle.Outline,
-            IconKind = BgInfoVisualCanvasTileIconKind.Computer
+            IconKind = BgInfoVisualCanvasTileIconKind.Computer,
+            MiniChartKind = BgInfoVisualCanvasTileMiniChartKind.Area,
+            MiniChartValues = new[] { 18d, 26d, 22d, 37d },
+            MiniChartMaximum = 100
         });
         visual.Features.Add(new BgInfoVisualCanvasFeature {
             Icon = "PS",
@@ -315,6 +318,9 @@ public class BgInfoConfigurationJsonTests
         Assert.Equal(0.42, tile.Progress);
         Assert.Equal(BgInfoVisualCanvasTileSurfaceStyle.Outline, tile.SurfaceStyle);
         Assert.Equal(BgInfoVisualCanvasTileIconKind.Computer, tile.IconKind);
+        Assert.Equal(BgInfoVisualCanvasTileMiniChartKind.Area, tile.MiniChartKind);
+        Assert.Equal(new[] { 18d, 26d, 22d, 37d }, tile.MiniChartValues);
+        Assert.Equal(100, tile.MiniChartMaximum);
 
         var feature = Assert.Single(loaded.Features);
         Assert.Equal("PS", feature.Icon);

--- a/Sources/PowerBGInfo.Tests/Cmdlet.Tests.ps1
+++ b/Sources/PowerBGInfo.Tests/Cmdlet.Tests.ps1
@@ -83,7 +83,7 @@ Describe 'New-BGInfo cmdlet parameters' {
 
 Describe 'New-BGInfoVisualCanvas cmdlets' {
     It 'creates a visual canvas model' {
-        $tile = New-BGInfoVisualCanvasTile -Side Left -Icon PC -Label HOSTNAME -Value '{{HostName}}' -Detail '{{OSName}}' -Progress 0.25 -SurfaceStyle Outline -IconKind Computer -MiniChartKind Sparkline -MiniChartValues 18,26,22 -MiniChartMaximum 100
+        $tile = New-BGInfoVisualCanvasTile -Side Left -Icon PC -Label HOSTNAME -Value '{{HostName}}' -Detail '{{OSName}}' -Progress 0.25 -SurfaceStyle Raised -IconKind Computer -MiniChartKind Sparkline -MiniChartValues 18,26,22 -MiniChartMaximum 100
         $feature = New-BGInfoVisualCanvasFeature -Icon PS -Label 'LIGHTWEIGHT'
 
         $visual = New-BGInfoVisualCanvas -Title PowerBGInfo -Subtitle 'Desktop insights' -Width 1200 -Height 630 -TitleColor White -TileValueColor '#F8FAFC' -HeroBadgeTextColor AliceBlue -Tile $tile -Feature $feature
@@ -95,7 +95,7 @@ Describe 'New-BGInfoVisualCanvas cmdlets' {
         $visual.HeroBadgeTextColor | Should -Not -BeNullOrEmpty
         $visual.Tiles.Count | Should -Be 1
         $visual.Tiles[0].Value | Should -Be '{{HostName}}'
-        $visual.Tiles[0].SurfaceStyle | Should -Be ([PowerBGInfo.BgInfoVisualCanvasTileSurfaceStyle]::Outline)
+        $visual.Tiles[0].SurfaceStyle | Should -Be ([PowerBGInfo.BgInfoVisualCanvasTileSurfaceStyle]::Raised)
         $visual.Tiles[0].IconKind | Should -Be ([PowerBGInfo.BgInfoVisualCanvasTileIconKind]::Computer)
         $visual.Tiles[0].MiniChartKind | Should -Be ([PowerBGInfo.BgInfoVisualCanvasTileMiniChartKind]::Sparkline)
         $visual.Tiles[0].MiniChartValues.Count | Should -Be 3

--- a/Sources/PowerBGInfo.Tests/Cmdlet.Tests.ps1
+++ b/Sources/PowerBGInfo.Tests/Cmdlet.Tests.ps1
@@ -64,6 +64,39 @@ Describe 'New-BGInfo cmdlet parameters' {
         $command = Get-Command New-BGInfoVariable
         $command.Parameters.Keys | Should -Contain 'Provider'
     }
+
+    It 'exports visual canvas helper cmdlets' {
+        Get-Command New-BGInfoVisualCanvas | Should -Not -BeNullOrEmpty
+        Get-Command New-BGInfoVisualCanvasTile | Should -Not -BeNullOrEmpty
+        Get-Command New-BGInfoVisualCanvasFeature | Should -Not -BeNullOrEmpty
+    }
+
+    It 'supports visual canvas theme parameters' {
+        $command = Get-Command New-BGInfoVisualCanvas
+        $command.Parameters.Keys | Should -Contain 'TitleColor'
+        $command.Parameters.Keys | Should -Contain 'TileValueColor'
+        $command.Parameters.Keys | Should -Contain 'HeroBadgeTextColor'
+    }
+}
+
+Describe 'New-BGInfoVisualCanvas cmdlets' {
+    It 'creates a visual canvas model' {
+        $tile = New-BGInfoVisualCanvasTile -Side Left -Icon PC -Label HOSTNAME -Value '{{HostName}}' -Detail '{{OSName}}' -Progress 0.25 -SurfaceStyle Outline -IconKind Computer
+        $feature = New-BGInfoVisualCanvasFeature -Icon PS -Label 'LIGHTWEIGHT'
+
+        $visual = New-BGInfoVisualCanvas -Title PowerBGInfo -Subtitle 'Desktop insights' -Width 1200 -Height 630 -TitleColor White -TileValueColor '#F8FAFC' -HeroBadgeTextColor AliceBlue -Tile $tile -Feature $feature
+
+        $visual | Should -BeOfType ([PowerBGInfo.BgInfoVisualCanvas])
+        $visual.Title | Should -Be 'PowerBGInfo'
+        $visual.TitleColor | Should -Not -BeNullOrEmpty
+        $visual.TileValueColor | Should -Not -BeNullOrEmpty
+        $visual.HeroBadgeTextColor | Should -Not -BeNullOrEmpty
+        $visual.Tiles.Count | Should -Be 1
+        $visual.Tiles[0].Value | Should -Be '{{HostName}}'
+        $visual.Tiles[0].SurfaceStyle | Should -Be ([PowerBGInfo.BgInfoVisualCanvasTileSurfaceStyle]::Outline)
+        $visual.Tiles[0].IconKind | Should -Be ([PowerBGInfo.BgInfoVisualCanvasTileIconKind]::Computer)
+        $visual.Features.Count | Should -Be 1
+    }
 }
 
 Describe 'Export-BGInfoConfiguration cmdlet' {
@@ -153,6 +186,19 @@ Describe 'New-BGInfo json export' {
         $json | Should -Match '"BuiltinValue"\s*:\s*"HostName"'
         $json | Should -Match '"Metric"\s*:\s*"CpuPercent"'
         $json | Should -Match '"Target"\s*:\s*"Both"'
+    }
+
+    It 'exports visual canvases from inline authoring' {
+        $path = Join-Path -Path $TestDrive -ChildPath 'visual-canvas.json'
+        $tile = New-BGInfoVisualCanvasTile -Side Left -Icon PC -Label HOSTNAME -Value '{{HostName}}'
+
+        New-BGInfo {
+            New-BGInfoVisualCanvas -Title PowerBGInfo -Subtitle 'Desktop insights' -Tile $tile
+        } -ConfigurationDirectory $TestDrive -Target File -JsonPath $path -ExportOnly | Out-Null
+
+        $json = Get-Content -LiteralPath $path -Raw
+        $json | Should -Match '"VisualCanvases"'
+        $json | Should -Match '"Value"\s*:\s*"\{\{HostName\}\}"'
     }
 }
 

--- a/Sources/PowerBGInfo.Tests/Cmdlet.Tests.ps1
+++ b/Sources/PowerBGInfo.Tests/Cmdlet.Tests.ps1
@@ -69,6 +69,7 @@ Describe 'New-BGInfo cmdlet parameters' {
         Get-Command New-BGInfoVisualCanvas | Should -Not -BeNullOrEmpty
         Get-Command New-BGInfoVisualCanvasTile | Should -Not -BeNullOrEmpty
         Get-Command New-BGInfoVisualCanvasFeature | Should -Not -BeNullOrEmpty
+        Get-Command New-BGInfoImage | Should -Not -BeNullOrEmpty
     }
 
     It 'supports visual canvas theme parameters' {
@@ -96,6 +97,23 @@ Describe 'New-BGInfoVisualCanvas cmdlets' {
         $visual.Tiles[0].SurfaceStyle | Should -Be ([PowerBGInfo.BgInfoVisualCanvasTileSurfaceStyle]::Outline)
         $visual.Tiles[0].IconKind | Should -Be ([PowerBGInfo.BgInfoVisualCanvasTileIconKind]::Computer)
         $visual.Features.Count | Should -Be 1
+    }
+}
+
+Describe 'New-BGInfoImage cmdlet' {
+    It 'creates an image overlay model' {
+        $path = Join-Path -Path $TestDrive -ChildPath 'logo.png'
+        Set-Content -LiteralPath $path -Value 'not-a-real-rendered-image'
+
+        $image = New-BGInfoImage -Path $path -Width 180 -Anchor BottomRight -OffsetX 72 -OffsetY 54 -Opacity 0.85
+
+        $image | Should -BeOfType ([PowerBGInfo.BgInfoImage])
+        $image.Path | Should -Be (Resolve-Path -LiteralPath $path).Path
+        $image.Width | Should -Be 180
+        $image.Anchor | Should -Be ([PowerBGInfo.BgInfoTextPosition]::BottomRight)
+        $image.OffsetX | Should -Be 72
+        $image.OffsetY | Should -Be 54
+        $image.Opacity | Should -Be 0.85
     }
 }
 

--- a/Sources/PowerBGInfo.Tests/Cmdlet.Tests.ps1
+++ b/Sources/PowerBGInfo.Tests/Cmdlet.Tests.ps1
@@ -77,12 +77,13 @@ Describe 'New-BGInfo cmdlet parameters' {
         $command.Parameters.Keys | Should -Contain 'TitleColor'
         $command.Parameters.Keys | Should -Contain 'TileValueColor'
         $command.Parameters.Keys | Should -Contain 'HeroBadgeTextColor'
+        (Get-Command New-BGInfoVisualCanvasTile).Parameters.Keys | Should -Contain 'MiniChartKind'
     }
 }
 
 Describe 'New-BGInfoVisualCanvas cmdlets' {
     It 'creates a visual canvas model' {
-        $tile = New-BGInfoVisualCanvasTile -Side Left -Icon PC -Label HOSTNAME -Value '{{HostName}}' -Detail '{{OSName}}' -Progress 0.25 -SurfaceStyle Outline -IconKind Computer
+        $tile = New-BGInfoVisualCanvasTile -Side Left -Icon PC -Label HOSTNAME -Value '{{HostName}}' -Detail '{{OSName}}' -Progress 0.25 -SurfaceStyle Outline -IconKind Computer -MiniChartKind Sparkline -MiniChartValues 18,26,22 -MiniChartMaximum 100
         $feature = New-BGInfoVisualCanvasFeature -Icon PS -Label 'LIGHTWEIGHT'
 
         $visual = New-BGInfoVisualCanvas -Title PowerBGInfo -Subtitle 'Desktop insights' -Width 1200 -Height 630 -TitleColor White -TileValueColor '#F8FAFC' -HeroBadgeTextColor AliceBlue -Tile $tile -Feature $feature
@@ -96,6 +97,9 @@ Describe 'New-BGInfoVisualCanvas cmdlets' {
         $visual.Tiles[0].Value | Should -Be '{{HostName}}'
         $visual.Tiles[0].SurfaceStyle | Should -Be ([PowerBGInfo.BgInfoVisualCanvasTileSurfaceStyle]::Outline)
         $visual.Tiles[0].IconKind | Should -Be ([PowerBGInfo.BgInfoVisualCanvasTileIconKind]::Computer)
+        $visual.Tiles[0].MiniChartKind | Should -Be ([PowerBGInfo.BgInfoVisualCanvasTileMiniChartKind]::Sparkline)
+        $visual.Tiles[0].MiniChartValues.Count | Should -Be 3
+        $visual.Tiles[0].MiniChartMaximum | Should -Be 100
         $visual.Features.Count | Should -Be 1
     }
 }

--- a/Sources/PowerBGInfo.Tests/Cmdlet.Tests.ps1
+++ b/Sources/PowerBGInfo.Tests/Cmdlet.Tests.ps1
@@ -119,6 +119,27 @@ Describe 'New-BGInfoImage cmdlet' {
         $image.OffsetY | Should -Be 54
         $image.Opacity | Should -Be 0.85
     }
+
+    It 'rejects non-finite opacity' {
+        $path = Join-Path -Path $TestDrive -ChildPath 'logo.png'
+        Set-Content -LiteralPath $path -Value 'not-a-real-rendered-image'
+
+        { New-BGInfoImage -Path $path -Opacity ([double]::NaN) } | Should -Throw
+        { New-BGInfoImage -Path $path -Opacity ([double]::PositiveInfinity) } | Should -Throw
+    }
+
+    It 'honors single-axis absolute positions' {
+        $path = Join-Path -Path $TestDrive -ChildPath 'logo.png'
+        Set-Content -LiteralPath $path -Value 'not-a-real-rendered-image'
+
+        $xOnly = New-BGInfoImage -Path $path -PositionX 123
+        $yOnly = New-BGInfoImage -Path $path -PositionY 456
+
+        $xOnly.PositionX | Should -Be 123
+        $xOnly.PositionY | Should -BeNullOrEmpty
+        $yOnly.PositionX | Should -BeNullOrEmpty
+        $yOnly.PositionY | Should -Be 456
+    }
 }
 
 Describe 'Export-BGInfoConfiguration cmdlet' {
@@ -165,6 +186,15 @@ Describe 'New-BGInfoConfiguration cmdlet' {
         $config.ChartLayout | Should -Be ([PowerBGInfo.BgInfoChartLayoutMode]::Stack)
         $config.ChartStackAlignToTextBlock | Should -BeTrue
         $config.ChartStackOutsideTextBlock | Should -BeTrue
+    }
+
+    It 'accepts visual canvas overlays directly' {
+        $visual = New-BGInfoVisualCanvas -Title PowerBGInfo
+
+        $config = New-BGInfoConfiguration -Target File -VisualCanvas $visual
+
+        $config.VisualCanvases.Count | Should -Be 1
+        $config.VisualCanvases[0].Title | Should -Be 'PowerBGInfo'
     }
 }
 

--- a/Sources/PowerBGInfo/BgInfoConfiguration.cs
+++ b/Sources/PowerBGInfo/BgInfoConfiguration.cs
@@ -160,4 +160,8 @@ public class BgInfoConfiguration {
     /// Gets the collection of ChartForgeX visual canvases to render.
     /// </summary>
     public List<BgInfoVisualCanvas> VisualCanvases { get; } = new();
+    /// <summary>
+    /// Gets the collection of image overlays to render.
+    /// </summary>
+    public List<BgInfoImage> Images { get; } = new();
 }

--- a/Sources/PowerBGInfo/BgInfoConfiguration.cs
+++ b/Sources/PowerBGInfo/BgInfoConfiguration.cs
@@ -156,4 +156,8 @@ public class BgInfoConfiguration {
     /// Gets the collection of topology diagrams to render.
     /// </summary>
     public List<BgInfoTopology> Topologies { get; } = new();
+    /// <summary>
+    /// Gets the collection of ChartForgeX visual canvases to render.
+    /// </summary>
+    public List<BgInfoVisualCanvas> VisualCanvases { get; } = new();
 }

--- a/Sources/PowerBGInfo/BgInfoConfigurationJson.cs
+++ b/Sources/PowerBGInfo/BgInfoConfigurationJson.cs
@@ -383,6 +383,9 @@ public static class BgInfoConfigurationJson {
         if (configuration.VisualCanvases.Count > 0) {
             model.VisualCanvases = new List<BgInfoVisualCanvasFile>();
             foreach (var visual in configuration.VisualCanvases) {
+                if (visual == null) {
+                    continue;
+                }
                 model.VisualCanvases.Add(new BgInfoVisualCanvasFile {
                     Template = visual.Template.ToString(),
                     Title = visual.Title,
@@ -409,8 +412,8 @@ public static class BgInfoConfigurationJson {
                     HeroBadgeTextColor = visual.HeroBadgeTextColor.HasValue ? BgInfoColorParser.ToHex(visual.HeroBadgeTextColor.Value) : null,
                     Transparent = visual.Transparent,
                     TechBackdrop = visual.TechBackdrop,
-                    Tiles = visual.Tiles.Select(MapVisualCanvasTileFile).ToList(),
-                    Features = visual.Features.Select(MapVisualCanvasFeatureFile).ToList()
+                    Tiles = visual.Tiles.Where(tile => tile != null).Select(MapVisualCanvasTileFile).ToList(),
+                    Features = visual.Features.Where(feature => feature != null).Select(MapVisualCanvasFeatureFile).ToList()
                 });
             }
         }
@@ -418,6 +421,9 @@ public static class BgInfoConfigurationJson {
         if (configuration.Images.Count > 0) {
             model.Images = new List<BgInfoImageFile>();
             foreach (var image in configuration.Images) {
+                if (image == null) {
+                    continue;
+                }
                 model.Images.Add(new BgInfoImageFile {
                     Path = image.Path,
                     Width = image.Width,
@@ -427,7 +433,7 @@ public static class BgInfoConfigurationJson {
                     OffsetY = image.OffsetY,
                     PositionX = image.PositionX,
                     PositionY = image.PositionY,
-                    Opacity = image.Opacity
+                    Opacity = ValidateImageOpacity(image.Opacity)
                 });
             }
         }
@@ -832,12 +838,12 @@ public static class BgInfoConfigurationJson {
 
         if (model.Tiles != null) {
             foreach (var item in model.Tiles) {
-                visual.Tiles.Add(MapVisualCanvasTile(item));
+                if (item != null) visual.Tiles.Add(MapVisualCanvasTile(item));
             }
         }
         if (model.Features != null) {
             foreach (var item in model.Features) {
-                visual.Features.Add(MapVisualCanvasFeature(item));
+                if (item != null) visual.Features.Add(MapVisualCanvasFeature(item));
             }
         }
 
@@ -917,8 +923,16 @@ public static class BgInfoConfigurationJson {
         if (model.OffsetY.HasValue) image.OffsetY = model.OffsetY.Value;
         if (model.PositionX.HasValue) image.PositionX = model.PositionX.Value;
         if (model.PositionY.HasValue) image.PositionY = model.PositionY.Value;
-        if (model.Opacity.HasValue) image.Opacity = model.Opacity.Value;
+        if (model.Opacity.HasValue) image.Opacity = ValidateImageOpacity(model.Opacity.Value);
         return image;
+    }
+
+    private static double ValidateImageOpacity(double opacity) {
+        if (double.IsNaN(opacity) || double.IsInfinity(opacity) || opacity < 0d || opacity > 1d) {
+            throw new InvalidDataException("Image opacity must be a finite value between 0 and 1.");
+        }
+
+        return opacity;
     }
 
     private static void ApplyColor(string? text, Action<System.Drawing.Color> setter) {

--- a/Sources/PowerBGInfo/BgInfoConfigurationJson.cs
+++ b/Sources/PowerBGInfo/BgInfoConfigurationJson.cs
@@ -863,8 +863,14 @@ public static class BgInfoConfigurationJson {
             Enum.TryParse(model.IconKind, true, out BgInfoVisualCanvasTileIconKind iconKind)) {
             tile.IconKind = iconKind;
         }
+        if (!string.IsNullOrWhiteSpace(model.MiniChartKind) &&
+            Enum.TryParse(model.MiniChartKind, true, out BgInfoVisualCanvasTileMiniChartKind miniChartKind)) {
+            tile.MiniChartKind = miniChartKind;
+        }
         ApplyColor(model.Accent, value => tile.Accent = value);
         if (model.Progress.HasValue) tile.Progress = model.Progress.Value;
+        if (model.MiniChartValues != null) tile.MiniChartValues = model.MiniChartValues;
+        if (model.MiniChartMaximum.HasValue) tile.MiniChartMaximum = model.MiniChartMaximum.Value;
         return tile;
     }
 
@@ -882,7 +888,10 @@ public static class BgInfoConfigurationJson {
         Accent = tile.Accent.HasValue ? BgInfoColorParser.ToHex(tile.Accent.Value) : null,
         Progress = tile.Progress,
         SurfaceStyle = tile.SurfaceStyle.ToString(),
-        IconKind = tile.IconKind.ToString()
+        IconKind = tile.IconKind.ToString(),
+        MiniChartKind = tile.MiniChartKind.ToString(),
+        MiniChartValues = tile.MiniChartValues is null ? null : new List<double>(tile.MiniChartValues).ToArray(),
+        MiniChartMaximum = tile.MiniChartMaximum
     };
 
     private static BgInfoVisualCanvasFeatureFile MapVisualCanvasFeatureFile(BgInfoVisualCanvasFeature feature) => new() {
@@ -1161,6 +1170,9 @@ public static class BgInfoConfigurationJson {
         public double? Progress { get; set; }
         public string? SurfaceStyle { get; set; }
         public string? IconKind { get; set; }
+        public string? MiniChartKind { get; set; }
+        public double[]? MiniChartValues { get; set; }
+        public double? MiniChartMaximum { get; set; }
     }
 
     internal sealed class BgInfoVisualCanvasFeatureFile {

--- a/Sources/PowerBGInfo/BgInfoConfigurationJson.cs
+++ b/Sources/PowerBGInfo/BgInfoConfigurationJson.cs
@@ -199,6 +199,15 @@ public static class BgInfoConfigurationJson {
             }
         }
 
+        if (model.VisualCanvases != null) {
+            foreach (var visualModel in model.VisualCanvases) {
+                var visual = MapVisualCanvas(visualModel);
+                if (visual != null) {
+                    configuration.VisualCanvases.Add(visual);
+                }
+            }
+        }
+
         return configuration;
     }
 
@@ -358,6 +367,41 @@ public static class BgInfoConfigurationJson {
                     Groups = topology.Groups.Select(MapGroupFile).ToList(),
                     Nodes = topology.Nodes.Select(MapNodeFile).ToList(),
                     Edges = topology.Edges.Select(MapEdgeFile).ToList()
+                });
+            }
+        }
+
+        if (configuration.VisualCanvases.Count > 0) {
+            model.VisualCanvases = new List<BgInfoVisualCanvasFile>();
+            foreach (var visual in configuration.VisualCanvases) {
+                model.VisualCanvases.Add(new BgInfoVisualCanvasFile {
+                    Template = visual.Template.ToString(),
+                    Title = visual.Title,
+                    Subtitle = visual.Subtitle,
+                    Width = visual.Width,
+                    Height = visual.Height,
+                    PositionX = visual.PositionX,
+                    PositionY = visual.PositionY,
+                    BackgroundTop = BgInfoColorParser.ToHex(visual.BackgroundTop),
+                    BackgroundBottom = BgInfoColorParser.ToHex(visual.BackgroundBottom),
+                    Accent = BgInfoColorParser.ToHex(visual.Accent),
+                    SecondaryAccent = visual.SecondaryAccent.HasValue ? BgInfoColorParser.ToHex(visual.SecondaryAccent.Value) : null,
+                    TitleColor = visual.TitleColor.HasValue ? BgInfoColorParser.ToHex(visual.TitleColor.Value) : null,
+                    TitleAccentColor = visual.TitleAccentColor.HasValue ? BgInfoColorParser.ToHex(visual.TitleAccentColor.Value) : null,
+                    SubtitleColor = visual.SubtitleColor.HasValue ? BgInfoColorParser.ToHex(visual.SubtitleColor.Value) : null,
+                    TileGlassTop = visual.TileGlassTop.HasValue ? BgInfoColorParser.ToHex(visual.TileGlassTop.Value) : null,
+                    TileGlassBottom = visual.TileGlassBottom.HasValue ? BgInfoColorParser.ToHex(visual.TileGlassBottom.Value) : null,
+                    TileLabelColor = visual.TileLabelColor.HasValue ? BgInfoColorParser.ToHex(visual.TileLabelColor.Value) : null,
+                    TileValueColor = visual.TileValueColor.HasValue ? BgInfoColorParser.ToHex(visual.TileValueColor.Value) : null,
+                    TileDetailColor = visual.TileDetailColor.HasValue ? BgInfoColorParser.ToHex(visual.TileDetailColor.Value) : null,
+                    TileProgressTrackColor = visual.TileProgressTrackColor.HasValue ? BgInfoColorParser.ToHex(visual.TileProgressTrackColor.Value) : null,
+                    HeroBadgeTop = visual.HeroBadgeTop.HasValue ? BgInfoColorParser.ToHex(visual.HeroBadgeTop.Value) : null,
+                    HeroBadgeBottom = visual.HeroBadgeBottom.HasValue ? BgInfoColorParser.ToHex(visual.HeroBadgeBottom.Value) : null,
+                    HeroBadgeTextColor = visual.HeroBadgeTextColor.HasValue ? BgInfoColorParser.ToHex(visual.HeroBadgeTextColor.Value) : null,
+                    Transparent = visual.Transparent,
+                    TechBackdrop = visual.TechBackdrop,
+                    Tiles = visual.Tiles.Select(MapVisualCanvasTileFile).ToList(),
+                    Features = visual.Features.Select(MapVisualCanvasFeatureFile).ToList()
                 });
             }
         }
@@ -723,6 +767,103 @@ public static class BgInfoConfigurationJson {
         Muted = edge.IsMuted
     };
 
+    private static BgInfoVisualCanvas? MapVisualCanvas(BgInfoVisualCanvasFile model) {
+        if (model == null) {
+            return null;
+        }
+
+        var visual = new BgInfoVisualCanvas {
+            Title = model.Title ?? "PowerBGInfo",
+            Subtitle = model.Subtitle ?? "Desktop background insights for Windows and PowerShell"
+        };
+
+        if (!string.IsNullOrWhiteSpace(model.Template) &&
+            Enum.TryParse(model.Template, true, out BgInfoVisualCanvasTemplate template)) {
+            visual.Template = template;
+        }
+        if (model.Width.HasValue) visual.Width = model.Width.Value;
+        if (model.Height.HasValue) visual.Height = model.Height.Value;
+        if (model.PositionX.HasValue) visual.PositionX = model.PositionX.Value;
+        if (model.PositionY.HasValue) visual.PositionY = model.PositionY.Value;
+        if (model.Transparent.HasValue) visual.Transparent = model.Transparent.Value;
+        if (model.TechBackdrop.HasValue) visual.TechBackdrop = model.TechBackdrop.Value;
+        ApplyColor(model.BackgroundTop, value => visual.BackgroundTop = value);
+        ApplyColor(model.BackgroundBottom, value => visual.BackgroundBottom = value);
+        ApplyColor(model.Accent, value => visual.Accent = value);
+        ApplyColor(model.SecondaryAccent, value => visual.SecondaryAccent = value);
+        ApplyColor(model.TitleColor, value => visual.TitleColor = value);
+        ApplyColor(model.TitleAccentColor, value => visual.TitleAccentColor = value);
+        ApplyColor(model.SubtitleColor, value => visual.SubtitleColor = value);
+        ApplyColor(model.TileGlassTop, value => visual.TileGlassTop = value);
+        ApplyColor(model.TileGlassBottom, value => visual.TileGlassBottom = value);
+        ApplyColor(model.TileLabelColor, value => visual.TileLabelColor = value);
+        ApplyColor(model.TileValueColor, value => visual.TileValueColor = value);
+        ApplyColor(model.TileDetailColor, value => visual.TileDetailColor = value);
+        ApplyColor(model.TileProgressTrackColor, value => visual.TileProgressTrackColor = value);
+        ApplyColor(model.HeroBadgeTop, value => visual.HeroBadgeTop = value);
+        ApplyColor(model.HeroBadgeBottom, value => visual.HeroBadgeBottom = value);
+        ApplyColor(model.HeroBadgeTextColor, value => visual.HeroBadgeTextColor = value);
+
+        if (model.Tiles != null) {
+            foreach (var item in model.Tiles) {
+                visual.Tiles.Add(MapVisualCanvasTile(item));
+            }
+        }
+        if (model.Features != null) {
+            foreach (var item in model.Features) {
+                visual.Features.Add(MapVisualCanvasFeature(item));
+            }
+        }
+
+        return visual;
+    }
+
+    private static BgInfoVisualCanvasTile MapVisualCanvasTile(BgInfoVisualCanvasTileFile model) {
+        var tile = new BgInfoVisualCanvasTile {
+            Icon = model.Icon ?? string.Empty,
+            Label = model.Label ?? string.Empty,
+            Value = model.Value ?? string.Empty,
+            Detail = model.Detail ?? string.Empty
+        };
+        if (!string.IsNullOrWhiteSpace(model.Side) &&
+            Enum.TryParse(model.Side, true, out BgInfoVisualCanvasSide side)) {
+            tile.Side = side;
+        }
+        if (!string.IsNullOrWhiteSpace(model.SurfaceStyle) &&
+            Enum.TryParse(model.SurfaceStyle, true, out BgInfoVisualCanvasTileSurfaceStyle surfaceStyle)) {
+            tile.SurfaceStyle = surfaceStyle;
+        }
+        if (!string.IsNullOrWhiteSpace(model.IconKind) &&
+            Enum.TryParse(model.IconKind, true, out BgInfoVisualCanvasTileIconKind iconKind)) {
+            tile.IconKind = iconKind;
+        }
+        ApplyColor(model.Accent, value => tile.Accent = value);
+        if (model.Progress.HasValue) tile.Progress = model.Progress.Value;
+        return tile;
+    }
+
+    private static BgInfoVisualCanvasFeature MapVisualCanvasFeature(BgInfoVisualCanvasFeatureFile model) => new() {
+        Icon = model.Icon ?? string.Empty,
+        Label = model.Label ?? string.Empty
+    };
+
+    private static BgInfoVisualCanvasTileFile MapVisualCanvasTileFile(BgInfoVisualCanvasTile tile) => new() {
+        Side = tile.Side.ToString(),
+        Icon = tile.Icon,
+        Label = tile.Label,
+        Value = tile.Value,
+        Detail = tile.Detail,
+        Accent = tile.Accent.HasValue ? BgInfoColorParser.ToHex(tile.Accent.Value) : null,
+        Progress = tile.Progress,
+        SurfaceStyle = tile.SurfaceStyle.ToString(),
+        IconKind = tile.IconKind.ToString()
+    };
+
+    private static BgInfoVisualCanvasFeatureFile MapVisualCanvasFeatureFile(BgInfoVisualCanvasFeature feature) => new() {
+        Icon = feature.Icon,
+        Label = feature.Label
+    };
+
     private static void ApplyColor(string? text, Action<System.Drawing.Color> setter) {
         if (string.IsNullOrWhiteSpace(text)) {
             return;
@@ -788,6 +929,7 @@ public static class BgInfoConfigurationJson {
         public List<BgInfoEntryFile>? Entries { get; set; }
         public List<BgInfoChartFile>? Charts { get; set; }
         public List<BgInfoTopologyFile>? Topologies { get; set; }
+        public List<BgInfoVisualCanvasFile>? VisualCanvases { get; set; }
     }
 
     internal sealed class BgInfoVariableFile {
@@ -928,6 +1070,53 @@ public static class BgInfoConfigurationJson {
         public string? Routing { get; set; }
         public string? Color { get; set; }
         public bool? Muted { get; set; }
+    }
+
+    internal sealed class BgInfoVisualCanvasFile {
+        public string? Template { get; set; }
+        public string? Title { get; set; }
+        public string? Subtitle { get; set; }
+        public int? Width { get; set; }
+        public int? Height { get; set; }
+        public int? PositionX { get; set; }
+        public int? PositionY { get; set; }
+        public string? BackgroundTop { get; set; }
+        public string? BackgroundBottom { get; set; }
+        public string? Accent { get; set; }
+        public string? SecondaryAccent { get; set; }
+        public string? TitleColor { get; set; }
+        public string? TitleAccentColor { get; set; }
+        public string? SubtitleColor { get; set; }
+        public string? TileGlassTop { get; set; }
+        public string? TileGlassBottom { get; set; }
+        public string? TileLabelColor { get; set; }
+        public string? TileValueColor { get; set; }
+        public string? TileDetailColor { get; set; }
+        public string? TileProgressTrackColor { get; set; }
+        public string? HeroBadgeTop { get; set; }
+        public string? HeroBadgeBottom { get; set; }
+        public string? HeroBadgeTextColor { get; set; }
+        public bool? Transparent { get; set; }
+        public bool? TechBackdrop { get; set; }
+        public List<BgInfoVisualCanvasTileFile>? Tiles { get; set; }
+        public List<BgInfoVisualCanvasFeatureFile>? Features { get; set; }
+    }
+
+    internal sealed class BgInfoVisualCanvasTileFile {
+        public string? Side { get; set; }
+        public string? Icon { get; set; }
+        public string? Label { get; set; }
+        public string? Value { get; set; }
+        public string? Detail { get; set; }
+        public string? Accent { get; set; }
+        public double? Progress { get; set; }
+        public string? SurfaceStyle { get; set; }
+        public string? IconKind { get; set; }
+    }
+
+    internal sealed class BgInfoVisualCanvasFeatureFile {
+        public string? Icon { get; set; }
+        public string? Label { get; set; }
     }
 }
 

--- a/Sources/PowerBGInfo/BgInfoConfigurationJson.cs
+++ b/Sources/PowerBGInfo/BgInfoConfigurationJson.cs
@@ -208,6 +208,15 @@ public static class BgInfoConfigurationJson {
             }
         }
 
+        if (model.Images != null) {
+            foreach (var imageModel in model.Images) {
+                var image = MapImage(imageModel, baseDirectory);
+                if (image != null) {
+                    configuration.Images.Add(image);
+                }
+            }
+        }
+
         return configuration;
     }
 
@@ -402,6 +411,23 @@ public static class BgInfoConfigurationJson {
                     TechBackdrop = visual.TechBackdrop,
                     Tiles = visual.Tiles.Select(MapVisualCanvasTileFile).ToList(),
                     Features = visual.Features.Select(MapVisualCanvasFeatureFile).ToList()
+                });
+            }
+        }
+
+        if (configuration.Images.Count > 0) {
+            model.Images = new List<BgInfoImageFile>();
+            foreach (var image in configuration.Images) {
+                model.Images.Add(new BgInfoImageFile {
+                    Path = image.Path,
+                    Width = image.Width,
+                    Height = image.Height,
+                    Anchor = image.Anchor.ToString(),
+                    OffsetX = image.OffsetX,
+                    OffsetY = image.OffsetY,
+                    PositionX = image.PositionX,
+                    PositionY = image.PositionY,
+                    Opacity = image.Opacity
                 });
             }
         }
@@ -864,6 +890,28 @@ public static class BgInfoConfigurationJson {
         Label = feature.Label
     };
 
+    private static BgInfoImage? MapImage(BgInfoImageFile model, string baseDirectory) {
+        if (model == null) {
+            return null;
+        }
+
+        var image = new BgInfoImage {
+            Path = ResolvePath(model.Path, baseDirectory)
+        };
+        if (model.Width.HasValue) image.Width = model.Width.Value;
+        if (model.Height.HasValue) image.Height = model.Height.Value;
+        if (!string.IsNullOrWhiteSpace(model.Anchor) &&
+            Enum.TryParse(model.Anchor, true, out BgInfoTextPosition anchor)) {
+            image.Anchor = anchor;
+        }
+        if (model.OffsetX.HasValue) image.OffsetX = model.OffsetX.Value;
+        if (model.OffsetY.HasValue) image.OffsetY = model.OffsetY.Value;
+        if (model.PositionX.HasValue) image.PositionX = model.PositionX.Value;
+        if (model.PositionY.HasValue) image.PositionY = model.PositionY.Value;
+        if (model.Opacity.HasValue) image.Opacity = model.Opacity.Value;
+        return image;
+    }
+
     private static void ApplyColor(string? text, Action<System.Drawing.Color> setter) {
         if (string.IsNullOrWhiteSpace(text)) {
             return;
@@ -930,6 +978,7 @@ public static class BgInfoConfigurationJson {
         public List<BgInfoChartFile>? Charts { get; set; }
         public List<BgInfoTopologyFile>? Topologies { get; set; }
         public List<BgInfoVisualCanvasFile>? VisualCanvases { get; set; }
+        public List<BgInfoImageFile>? Images { get; set; }
     }
 
     internal sealed class BgInfoVariableFile {
@@ -1117,6 +1166,18 @@ public static class BgInfoConfigurationJson {
     internal sealed class BgInfoVisualCanvasFeatureFile {
         public string? Icon { get; set; }
         public string? Label { get; set; }
+    }
+
+    internal sealed class BgInfoImageFile {
+        public string? Path { get; set; }
+        public int? Width { get; set; }
+        public int? Height { get; set; }
+        public string? Anchor { get; set; }
+        public int? OffsetX { get; set; }
+        public int? OffsetY { get; set; }
+        public int? PositionX { get; set; }
+        public int? PositionY { get; set; }
+        public double? Opacity { get; set; }
     }
 }
 

--- a/Sources/PowerBGInfo/BgInfoGenerator.cs
+++ b/Sources/PowerBGInfo/BgInfoGenerator.cs
@@ -782,13 +782,9 @@ public class BgInfoGenerator
 
     private static System.Drawing.PointF ResolveImagePosition(Image image, BgInfoImage overlay, int width, int height)
     {
-        if (overlay.PositionX.HasValue && overlay.PositionY.HasValue)
-        {
-            return new System.Drawing.PointF(overlay.PositionX.Value, overlay.PositionY.Value);
-        }
-
-        return ResolveChartPosition(new System.Drawing.RectangleF(0, 0, image.Width, image.Height),
+        var anchored = ResolveChartPosition(new System.Drawing.RectangleF(0, 0, image.Width, image.Height),
             width, height, overlay.Anchor, overlay.OffsetX, overlay.OffsetY);
+        return new System.Drawing.PointF(overlay.PositionX ?? anchored.X, overlay.PositionY ?? anchored.Y);
     }
 
     private static (int Width, int Height) ResolveImageSize(BgInfoImage overlay, int sourceWidth, int sourceHeight)

--- a/Sources/PowerBGInfo/BgInfoGenerator.cs
+++ b/Sources/PowerBGInfo/BgInfoGenerator.cs
@@ -199,6 +199,7 @@ public class BgInfoGenerator
 
         RenderCharts(image, config, textBlock);
         RenderTopologies(image, config);
+        RenderVisualCanvases(image, config);
 
         _imageService.Save(image, outputPath);
 
@@ -450,6 +451,21 @@ public class BgInfoGenerator
             using var topologyImage = BgInfoTopologyRenderer.Render(topology, config);
             var position = ResolveTopologyPosition(image, topology);
             image.DrawImage(topologyImage, position.X, position.Y);
+        }
+    }
+
+    private static void RenderVisualCanvases(Image image, BgInfoConfiguration config)
+    {
+        if (config.VisualCanvases.Count == 0)
+        {
+            return;
+        }
+
+        for (int i = 0; i < config.VisualCanvases.Count; i++)
+        {
+            var visual = config.VisualCanvases[i];
+            using var visualImage = BgInfoVisualCanvasRenderer.Render(visual, config, image.Width, image.Height);
+            image.DrawImage(visualImage, visual.PositionX, visual.PositionY);
         }
     }
 

--- a/Sources/PowerBGInfo/BgInfoGenerator.cs
+++ b/Sources/PowerBGInfo/BgInfoGenerator.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Collections.Generic;
+using System.Drawing.Imaging;
 using ImagePlayground.Gdi;
 using DesktopManager;
 
@@ -200,6 +201,7 @@ public class BgInfoGenerator
         RenderCharts(image, config, textBlock);
         RenderTopologies(image, config);
         RenderVisualCanvases(image, config);
+        RenderImages(image, config);
 
         _imageService.Save(image, outputPath);
 
@@ -466,6 +468,32 @@ public class BgInfoGenerator
             var visual = config.VisualCanvases[i];
             using var visualImage = BgInfoVisualCanvasRenderer.Render(visual, config, image.Width, image.Height);
             image.DrawImage(visualImage, visual.PositionX, visual.PositionY);
+        }
+    }
+
+    private static void RenderImages(Image image, BgInfoConfiguration config)
+    {
+        if (config.Images.Count == 0)
+        {
+            return;
+        }
+
+        foreach (var overlay in config.Images)
+        {
+            if (overlay == null || string.IsNullOrWhiteSpace(overlay.Path))
+            {
+                continue;
+            }
+            if (!File.Exists(overlay.Path))
+            {
+                throw new FileNotFoundException("BGInfo image overlay file was not found.", overlay.Path);
+            }
+
+            using var stream = File.OpenRead(overlay.Path);
+            using var bitmap = System.Drawing.Image.FromStream(stream);
+            var (width, height) = ResolveImageSize(overlay, bitmap.Width, bitmap.Height);
+            var position = ResolveImagePosition(image, overlay, width, height);
+            DrawBitmap(image, bitmap, position.X, position.Y, width, height, overlay.Opacity);
         }
     }
 
@@ -752,6 +780,37 @@ public class BgInfoGenerator
             Math.Max(1, topology.Width), Math.Max(1, topology.Height), topology.Anchor, topology.OffsetX, topology.OffsetY);
     }
 
+    private static System.Drawing.PointF ResolveImagePosition(Image image, BgInfoImage overlay, int width, int height)
+    {
+        if (overlay.PositionX.HasValue && overlay.PositionY.HasValue)
+        {
+            return new System.Drawing.PointF(overlay.PositionX.Value, overlay.PositionY.Value);
+        }
+
+        return ResolveChartPosition(new System.Drawing.RectangleF(0, 0, image.Width, image.Height),
+            width, height, overlay.Anchor, overlay.OffsetX, overlay.OffsetY);
+    }
+
+    private static (int Width, int Height) ResolveImageSize(BgInfoImage overlay, int sourceWidth, int sourceHeight)
+    {
+        var width = overlay.Width;
+        var height = overlay.Height;
+        if (width <= 0 && height <= 0)
+        {
+            return (Math.Max(1, sourceWidth), Math.Max(1, sourceHeight));
+        }
+        if (width > 0 && height <= 0)
+        {
+            height = (int)Math.Round(sourceHeight * (width / (double)Math.Max(1, sourceWidth)));
+        }
+        if (height > 0 && width <= 0)
+        {
+            width = (int)Math.Round(sourceWidth * (height / (double)Math.Max(1, sourceHeight)));
+        }
+
+        return (Math.Max(1, width), Math.Max(1, height));
+    }
+
     internal static System.Drawing.PointF ResolveChartPosition(System.Drawing.RectangleF area, int chartWidth, int chartHeight, BgInfoTextPosition anchor, int offsetX, int offsetY)
     {
         float x = area.X + offsetX;
@@ -792,6 +851,25 @@ public class BgInfoGenerator
         }
 
         return new System.Drawing.PointF(x, y);
+    }
+
+    private static void DrawBitmap(Image image, System.Drawing.Image bitmap, float x, float y, int width, int height, double opacity)
+    {
+        image.WithGraphics(graphics => {
+            var destination = new System.Drawing.RectangleF(x, y, width, height);
+            if (opacity >= 0.999d)
+            {
+                graphics.DrawImage(bitmap, destination);
+                return;
+            }
+
+            using var attributes = new ImageAttributes();
+            var matrix = new ColorMatrix {
+                Matrix33 = (float)Math.Max(0d, Math.Min(1d, opacity))
+            };
+            attributes.SetColorMatrix(matrix, ColorMatrixFlag.Default, ColorAdjustType.Bitmap);
+            graphics.DrawImage(bitmap, System.Drawing.Rectangle.Round(destination), 0, 0, bitmap.Width, bitmap.Height, System.Drawing.GraphicsUnit.Pixel, attributes);
+        });
     }
 
     private static List<EntryLayout> BuildEntryLayouts(Image image, BgInfoConfiguration config, IReadOnlyList<BgInfoEntry> entries)

--- a/Sources/PowerBGInfo/BgInfoImage.cs
+++ b/Sources/PowerBGInfo/BgInfoImage.cs
@@ -1,0 +1,23 @@
+namespace PowerBGInfo;
+
+/// <summary>Defines an image overlay rendered on top of the generated wallpaper.</summary>
+public sealed class BgInfoImage {
+    /// <summary>Path to the image file.</summary>
+    public string Path { get; set; } = string.Empty;
+    /// <summary>Target image width in pixels. Zero preserves the source width or derives it from Height.</summary>
+    public int Width { get; set; }
+    /// <summary>Target image height in pixels. Zero preserves the source height or derives it from Width.</summary>
+    public int Height { get; set; }
+    /// <summary>Anchor position used for placement.</summary>
+    public BgInfoTextPosition Anchor { get; set; } = BgInfoTextPosition.BottomRight;
+    /// <summary>Horizontal offset from the anchor.</summary>
+    public int OffsetX { get; set; } = 32;
+    /// <summary>Vertical offset from the anchor.</summary>
+    public int OffsetY { get; set; } = 32;
+    /// <summary>Explicit X position override.</summary>
+    public int? PositionX { get; set; }
+    /// <summary>Explicit Y position override.</summary>
+    public int? PositionY { get; set; }
+    /// <summary>Image opacity from zero to one.</summary>
+    public double Opacity { get; set; } = 1d;
+}

--- a/Sources/PowerBGInfo/BgInfoVisualCanvas.cs
+++ b/Sources/PowerBGInfo/BgInfoVisualCanvas.cs
@@ -22,7 +22,9 @@ public enum BgInfoVisualCanvasTileSurfaceStyle {
     /// <summary>Translucent filled panel.</summary>
     Glass,
     /// <summary>Border-only panel without a background fill.</summary>
-    Outline
+    Outline,
+    /// <summary>Raised panel with stronger depth and edge highlights.</summary>
+    Raised
 }
 
 /// <summary>Built-in visual canvas tile icon.</summary>

--- a/Sources/PowerBGInfo/BgInfoVisualCanvas.cs
+++ b/Sources/PowerBGInfo/BgInfoVisualCanvas.cs
@@ -51,6 +51,18 @@ public enum BgInfoVisualCanvasTileIconKind {
     Shield
 }
 
+/// <summary>Compact chart treatment for visual canvas tiles.</summary>
+public enum BgInfoVisualCanvasTileMiniChartKind {
+    /// <summary>Render no mini chart.</summary>
+    None,
+    /// <summary>Render a compact sparkline inside the tile.</summary>
+    Sparkline,
+    /// <summary>Render a compact area sparkline inside the tile.</summary>
+    Area,
+    /// <summary>Render compact bars inside the tile.</summary>
+    Bars
+}
+
 /// <summary>Defines a reusable ChartForgeX visual canvas overlay.</summary>
 public sealed class BgInfoVisualCanvas {
     /// <summary>Template used to build the canvas.</summary>
@@ -129,6 +141,12 @@ public sealed class BgInfoVisualCanvasTile {
     public BgInfoVisualCanvasTileSurfaceStyle SurfaceStyle { get; set; }
     /// <summary>Tile icon kind.</summary>
     public BgInfoVisualCanvasTileIconKind IconKind { get; set; }
+    /// <summary>Compact tile chart kind.</summary>
+    public BgInfoVisualCanvasTileMiniChartKind MiniChartKind { get; set; }
+    /// <summary>Compact tile chart values.</summary>
+    public IReadOnlyList<double> MiniChartValues { get; set; } = System.Array.Empty<double>();
+    /// <summary>Optional compact tile chart maximum.</summary>
+    public double? MiniChartMaximum { get; set; }
 }
 
 /// <summary>Defines one visual canvas feature-strip item.</summary>

--- a/Sources/PowerBGInfo/BgInfoVisualCanvas.cs
+++ b/Sources/PowerBGInfo/BgInfoVisualCanvas.cs
@@ -1,0 +1,140 @@
+using System.Collections.Generic;
+using System.Drawing;
+
+namespace PowerBGInfo;
+
+/// <summary>Built-in visual canvas template.</summary>
+public enum BgInfoVisualCanvasTemplate {
+    /// <summary>PowerBGInfo-style hero wallpaper/social preview with side rails and central title.</summary>
+    PowerBgInfoHero
+}
+
+/// <summary>Visual canvas side rail placement.</summary>
+public enum BgInfoVisualCanvasSide {
+    /// <summary>Place the tile on the left side rail.</summary>
+    Left,
+    /// <summary>Place the tile on the right side rail.</summary>
+    Right
+}
+
+/// <summary>Visual canvas tile surface treatment.</summary>
+public enum BgInfoVisualCanvasTileSurfaceStyle {
+    /// <summary>Translucent filled panel.</summary>
+    Glass,
+    /// <summary>Border-only panel without a background fill.</summary>
+    Outline
+}
+
+/// <summary>Built-in visual canvas tile icon.</summary>
+public enum BgInfoVisualCanvasTileIconKind {
+    /// <summary>Render the Icon text as the tile symbol.</summary>
+    Text,
+    /// <summary>Computer monitor icon.</summary>
+    Computer,
+    /// <summary>Network/globe icon.</summary>
+    Network,
+    /// <summary>Operating system/window icon.</summary>
+    OperatingSystem,
+    /// <summary>Processor icon.</summary>
+    Cpu,
+    /// <summary>Memory module icon.</summary>
+    Memory,
+    /// <summary>User icon.</summary>
+    User,
+    /// <summary>Domain/building icon.</summary>
+    Domain,
+    /// <summary>Terminal prompt icon.</summary>
+    Terminal,
+    /// <summary>Storage icon.</summary>
+    Storage,
+    /// <summary>Shield icon.</summary>
+    Shield
+}
+
+/// <summary>Defines a reusable ChartForgeX visual canvas overlay.</summary>
+public sealed class BgInfoVisualCanvas {
+    /// <summary>Template used to build the canvas.</summary>
+    public BgInfoVisualCanvasTemplate Template { get; set; } = BgInfoVisualCanvasTemplate.PowerBgInfoHero;
+    /// <summary>Canvas title or brand text.</summary>
+    public string Title { get; set; } = "PowerBGInfo";
+    /// <summary>Canvas subtitle text.</summary>
+    public string Subtitle { get; set; } = "Desktop background insights for Windows and PowerShell";
+    /// <summary>Canvas width in pixels. A value of zero uses the target wallpaper width.</summary>
+    public int Width { get; set; }
+    /// <summary>Canvas height in pixels. A value of zero uses the target wallpaper height.</summary>
+    public int Height { get; set; }
+    /// <summary>Explicit X position on the generated wallpaper.</summary>
+    public int PositionX { get; set; }
+    /// <summary>Explicit Y position on the generated wallpaper.</summary>
+    public int PositionY { get; set; }
+    /// <summary>Top background color.</summary>
+    public Color BackgroundTop { get; set; } = Color.FromArgb(255, 2, 7, 19);
+    /// <summary>Bottom background color.</summary>
+    public Color BackgroundBottom { get; set; } = Color.FromArgb(255, 7, 26, 53);
+    /// <summary>Primary accent color.</summary>
+    public Color Accent { get; set; } = Color.FromArgb(255, 47, 128, 255);
+    /// <summary>Secondary accent color for badge and backdrop highlights.</summary>
+    public Color? SecondaryAccent { get; set; }
+    /// <summary>Primary hero title color.</summary>
+    public Color? TitleColor { get; set; }
+    /// <summary>Accent hero title color.</summary>
+    public Color? TitleAccentColor { get; set; }
+    /// <summary>Subtitle text color.</summary>
+    public Color? SubtitleColor { get; set; }
+    /// <summary>Glass tile top color.</summary>
+    public Color? TileGlassTop { get; set; }
+    /// <summary>Glass tile bottom color.</summary>
+    public Color? TileGlassBottom { get; set; }
+    /// <summary>Tile label text color.</summary>
+    public Color? TileLabelColor { get; set; }
+    /// <summary>Tile value text color.</summary>
+    public Color? TileValueColor { get; set; }
+    /// <summary>Tile detail text color.</summary>
+    public Color? TileDetailColor { get; set; }
+    /// <summary>Tile progress track color.</summary>
+    public Color? TileProgressTrackColor { get; set; }
+    /// <summary>Hero badge top fill color.</summary>
+    public Color? HeroBadgeTop { get; set; }
+    /// <summary>Hero badge bottom fill color.</summary>
+    public Color? HeroBadgeBottom { get; set; }
+    /// <summary>Hero badge symbol color.</summary>
+    public Color? HeroBadgeTextColor { get; set; }
+    /// <summary>Render only floating HUD layers without a full canvas background.</summary>
+    public bool Transparent { get; set; } = true;
+    /// <summary>Render ChartForgeX's built-in technology backdrop when the canvas is not transparent.</summary>
+    public bool TechBackdrop { get; set; }
+    /// <summary>Gets side rail tiles.</summary>
+    public List<BgInfoVisualCanvasTile> Tiles { get; } = new();
+    /// <summary>Gets bottom feature strip items.</summary>
+    public List<BgInfoVisualCanvasFeature> Features { get; } = new();
+}
+
+/// <summary>Defines one visual canvas side-rail tile.</summary>
+public sealed class BgInfoVisualCanvasTile {
+    /// <summary>Side rail placement.</summary>
+    public BgInfoVisualCanvasSide Side { get; set; }
+    /// <summary>Compact tile icon or symbol.</summary>
+    public string Icon { get; set; } = string.Empty;
+    /// <summary>Tile label. Templates such as {{HostName}} are resolved at render time.</summary>
+    public string Label { get; set; } = string.Empty;
+    /// <summary>Tile value. Templates such as {{HostName}} are resolved at render time.</summary>
+    public string Value { get; set; } = string.Empty;
+    /// <summary>Optional detail text. Templates are resolved at render time.</summary>
+    public string Detail { get; set; } = string.Empty;
+    /// <summary>Optional tile accent color.</summary>
+    public Color? Accent { get; set; }
+    /// <summary>Optional progress value from zero to one.</summary>
+    public double? Progress { get; set; }
+    /// <summary>Tile surface style.</summary>
+    public BgInfoVisualCanvasTileSurfaceStyle SurfaceStyle { get; set; }
+    /// <summary>Tile icon kind.</summary>
+    public BgInfoVisualCanvasTileIconKind IconKind { get; set; }
+}
+
+/// <summary>Defines one visual canvas feature-strip item.</summary>
+public sealed class BgInfoVisualCanvasFeature {
+    /// <summary>Compact item icon or symbol.</summary>
+    public string Icon { get; set; } = string.Empty;
+    /// <summary>Feature label.</summary>
+    public string Label { get; set; } = string.Empty;
+}

--- a/Sources/PowerBGInfo/BgInfoVisualCanvasRenderer.cs
+++ b/Sources/PowerBGInfo/BgInfoVisualCanvasRenderer.cs
@@ -155,8 +155,13 @@ internal static class BgInfoVisualCanvasRenderer {
         if (color.HasValue) setter(ToChartColor(color.Value));
     }
 
-    private static VisualCanvasInfoTileSurfaceStyle MapSurfaceStyle(BgInfoVisualCanvasTileSurfaceStyle style) =>
-        style == BgInfoVisualCanvasTileSurfaceStyle.Outline ? VisualCanvasInfoTileSurfaceStyle.Outline : VisualCanvasInfoTileSurfaceStyle.Glass;
+    private static VisualCanvasInfoTileSurfaceStyle MapSurfaceStyle(BgInfoVisualCanvasTileSurfaceStyle style) {
+        switch (style) {
+            case BgInfoVisualCanvasTileSurfaceStyle.Outline: return VisualCanvasInfoTileSurfaceStyle.Outline;
+            case BgInfoVisualCanvasTileSurfaceStyle.Raised: return VisualCanvasInfoTileSurfaceStyle.Raised;
+            default: return VisualCanvasInfoTileSurfaceStyle.Glass;
+        }
+    }
 
     private static VisualCanvasInfoTileMiniChartKind MapMiniChartKind(BgInfoVisualCanvasTileMiniChartKind kind) {
         switch (kind) {

--- a/Sources/PowerBGInfo/BgInfoVisualCanvasRenderer.cs
+++ b/Sources/PowerBGInfo/BgInfoVisualCanvasRenderer.cs
@@ -103,7 +103,10 @@ internal static class BgInfoVisualCanvasRenderer {
                 tile.Accent.HasValue ? ToChartColor(tile.Accent.Value) : (ChartColor?)null,
                 tile.Progress,
                 MapSurfaceStyle(tile.SurfaceStyle),
-                MapIconKind(tile.IconKind));
+                MapIconKind(tile.IconKind),
+                MapMiniChartKind(tile.MiniChartKind),
+                tile.MiniChartValues,
+                tile.MiniChartMaximum);
             index++;
         }
     }
@@ -154,6 +157,15 @@ internal static class BgInfoVisualCanvasRenderer {
 
     private static VisualCanvasInfoTileSurfaceStyle MapSurfaceStyle(BgInfoVisualCanvasTileSurfaceStyle style) =>
         style == BgInfoVisualCanvasTileSurfaceStyle.Outline ? VisualCanvasInfoTileSurfaceStyle.Outline : VisualCanvasInfoTileSurfaceStyle.Glass;
+
+    private static VisualCanvasInfoTileMiniChartKind MapMiniChartKind(BgInfoVisualCanvasTileMiniChartKind kind) {
+        switch (kind) {
+            case BgInfoVisualCanvasTileMiniChartKind.Sparkline: return VisualCanvasInfoTileMiniChartKind.Sparkline;
+            case BgInfoVisualCanvasTileMiniChartKind.Area: return VisualCanvasInfoTileMiniChartKind.Area;
+            case BgInfoVisualCanvasTileMiniChartKind.Bars: return VisualCanvasInfoTileMiniChartKind.Bars;
+            default: return VisualCanvasInfoTileMiniChartKind.None;
+        }
+    }
 
     private static VisualCanvasInfoTileIconKind MapIconKind(BgInfoVisualCanvasTileIconKind kind) {
         switch (kind) {

--- a/Sources/PowerBGInfo/BgInfoVisualCanvasRenderer.cs
+++ b/Sources/PowerBGInfo/BgInfoVisualCanvasRenderer.cs
@@ -13,8 +13,8 @@ namespace PowerBGInfo;
 internal static class BgInfoVisualCanvasRenderer {
     public static GdiImage Render(BgInfoVisualCanvas visual, BgInfoConfiguration config, int targetWidth, int targetHeight) {
         if (visual == null) throw new ArgumentNullException(nameof(visual));
-        var width = visual.Width > 0 ? visual.Width : Math.Max(1, targetWidth - visual.PositionX);
-        var height = visual.Height > 0 ? visual.Height : Math.Max(1, targetHeight - visual.PositionY);
+        var width = visual.Width > 0 ? visual.Width : Math.Max(1, targetWidth);
+        var height = visual.Height > 0 ? visual.Height : Math.Max(1, targetHeight);
         var chartCanvas = BuildCanvas(visual, width, height);
         var image = new GdiImage();
         image.Create(string.Empty, width, height, Color.Transparent);
@@ -60,30 +60,36 @@ internal static class BgInfoVisualCanvasRenderer {
 
     private static void BuildPowerBgInfoOverlay(VisualCanvas canvas, BgInfoVisualCanvas visual, int width, int height) {
         var accent = ToChartColor(visual.Accent);
-        var marginX = Clamp(width * 0.045, 72, 132);
-        var tileWidth = Clamp(width * 0.18, 380, 470);
-        var tileHeight = Clamp(height * 0.092, 92, 106);
-        var tileGap = Clamp(height * 0.018, 16, 24);
-        var railY = Clamp(height * 0.16, 92, 190);
+        var marginX = Clamp(width * 0.045, Math.Min(24, width * 0.04), Math.Min(132, width * 0.08));
+        var railBudget = Math.Max(1, (width - (marginX * 2) - 96) / 2);
+        var tileWidth = Math.Min(Clamp(width * 0.18, Math.Min(180, railBudget), Math.Min(470, railBudget)), railBudget);
+        var tileHeight = Clamp(height * 0.092, Math.Min(56, height * 0.18), Math.Min(106, height * 0.22));
+        var tileGap = Clamp(height * 0.018, Math.Min(8, height * 0.02), Math.Min(24, height * 0.04));
+        var railY = Clamp(height * 0.16, Math.Min(32, height * 0.08), Math.Min(190, height * 0.25));
         AddTiles(canvas, visual.Tiles, BgInfoVisualCanvasSide.Left, marginX, railY, tileWidth, tileHeight, tileGap);
         AddTiles(canvas, visual.Tiles, BgInfoVisualCanvasSide.Right, width - marginX - tileWidth, railY, tileWidth, tileHeight, tileGap);
 
         var centerLeft = marginX + tileWidth + 48;
         var centerRight = width - marginX - tileWidth - 48;
-        var centerWidth = Math.Max(360, centerRight - centerLeft);
-        var badgeWidth = Clamp(width * 0.065, 104, 144);
-        var badgeHeight = Clamp(height * 0.085, 76, 100);
-        var badgeY = Clamp(height * 0.23, 156, 260);
-        var titleFont = Clamp(width * 0.042, 62, 96);
-        var titleY = Clamp(height * 0.39, 300, 450);
-        var subtitleFont = Clamp(width * 0.014, 20, 30);
+        var centerWidth = Math.Max(1, centerRight - centerLeft);
+        var badgeWidth = Math.Min(centerWidth, Clamp(width * 0.065, Math.Min(64, centerWidth), Math.Min(144, centerWidth)));
+        var badgeHeight = Clamp(height * 0.085, Math.Min(42, height * 0.16), Math.Min(100, height * 0.22));
+        var badgeY = Clamp(height * 0.23, Math.Min(24, height * 0.08), Math.Max(24, height - badgeHeight - 24));
+        var titleFont = Clamp(width * 0.042, Math.Min(28, height * 0.09), Math.Min(96, height * 0.16));
+        var subtitleFont = Clamp(width * 0.014, Math.Min(12, height * 0.035), Math.Min(30, height * 0.07));
+        var subtitleGap = Clamp(height * 0.035, 8, 32);
+        var titleTopMin = badgeY + badgeHeight + Math.Min(12, height * 0.025);
+        var titleTopMax = Math.Max(titleTopMin, height - titleFont - subtitleFont - subtitleGap - Math.Min(24, height * 0.06));
+        var titleY = Clamp(height * 0.39, titleTopMin, titleTopMax);
         canvas
             .AddHeroBadge(centerLeft + (centerWidth - badgeWidth) / 2, badgeY, badgeWidth, badgeHeight, ">_", accent)
             .AddHeroTitle(centerLeft, titleY, centerWidth, titleFont, SplitTitle(Resolve(visual.Title), canvas.Theme))
-            .AddText(centerLeft, titleY + titleFont + 32, centerWidth, Resolve(visual.Subtitle), subtitleFont, canvas.Theme.SubtitleColor, VisualCanvasTextAlignment.Center);
+            .AddText(centerLeft, titleY + titleFont + subtitleGap, centerWidth, Resolve(visual.Subtitle), subtitleFont, canvas.Theme.SubtitleColor, VisualCanvasTextAlignment.Center);
         if (visual.Features.Count > 0) {
-            var stripWidth = Clamp(centerWidth * 0.72, 520, 760);
-            canvas.AddFeatureStrip(centerLeft + (centerWidth - stripWidth) / 2, height - Clamp(height * 0.18, 132, 190), stripWidth, 64, BuildFeatureItems(visual.Features));
+            var stripHeight = Clamp(height * 0.075, Math.Min(36, height * 0.1), Math.Min(64, height * 0.14));
+            var stripWidth = Clamp(centerWidth * 0.72, Math.Min(120, centerWidth), Math.Min(760, centerWidth));
+            var stripY = Math.Max(0, height - Clamp(height * 0.18, stripHeight + 8, Math.Min(190, height * 0.28)));
+            canvas.AddFeatureStrip(centerLeft + (centerWidth - stripWidth) / 2, stripY, stripWidth, stripHeight, BuildFeatureItems(visual.Features));
         }
     }
 
@@ -188,7 +194,10 @@ internal static class BgInfoVisualCanvasRenderer {
         }
     }
 
-    private static double Clamp(double value, double min, double max) => Math.Max(min, Math.Min(max, value));
+    private static double Clamp(double value, double min, double max) {
+        if (max < min) max = min;
+        return Math.Max(min, Math.Min(max, value));
+    }
 
     private static void DrawPng(GdiImage image, byte[] png, float x, float y, float width, float height) {
         image.WithGraphics(graphics => {

--- a/Sources/PowerBGInfo/BgInfoVisualCanvasRenderer.cs
+++ b/Sources/PowerBGInfo/BgInfoVisualCanvasRenderer.cs
@@ -1,0 +1,183 @@
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.IO;
+using ChartForgeX;
+using ChartForgeX.Composition;
+using ChartForgeX.Primitives;
+using ImagePlayground.Gdi;
+using GdiImage = ImagePlayground.Gdi.Image;
+
+namespace PowerBGInfo;
+
+internal static class BgInfoVisualCanvasRenderer {
+    public static GdiImage Render(BgInfoVisualCanvas visual, BgInfoConfiguration config, int targetWidth, int targetHeight) {
+        if (visual == null) throw new ArgumentNullException(nameof(visual));
+        var width = visual.Width > 0 ? visual.Width : Math.Max(1, targetWidth - visual.PositionX);
+        var height = visual.Height > 0 ? visual.Height : Math.Max(1, targetHeight - visual.PositionY);
+        var chartCanvas = BuildCanvas(visual, width, height);
+        var image = new GdiImage();
+        image.Create(string.Empty, width, height, Color.Transparent);
+        DrawPng(image, chartCanvas.ToPng(), 0, 0, width, height);
+        return image;
+    }
+
+    private static VisualCanvas BuildCanvas(BgInfoVisualCanvas visual, int width, int height) {
+        var canvas = VisualCanvas.Create(width, height)
+            .WithTitle(Resolve(visual.Title))
+            .WithTheme(BuildTheme(visual))
+            .WithBackground(ToChartColor(visual.BackgroundTop), ToChartColor(visual.BackgroundBottom))
+            .WithBackdrop(visual.Transparent ? VisualCanvasBackdropStyle.Transparent : (visual.TechBackdrop ? VisualCanvasBackdropStyle.TechHorizon : VisualCanvasBackdropStyle.Plain));
+
+        switch (visual.Template) {
+            case BgInfoVisualCanvasTemplate.PowerBgInfoHero:
+                BuildPowerBgInfoHero(canvas, visual, width, height);
+                return canvas;
+            default:
+                throw new NotSupportedException("Unsupported visual canvas template: " + visual.Template);
+        }
+    }
+
+    private static void BuildPowerBgInfoHero(VisualCanvas canvas, BgInfoVisualCanvas visual, int width, int height) {
+        if (visual.Transparent) {
+            BuildPowerBgInfoOverlay(canvas, visual, width, height);
+            return;
+        }
+
+        var scaleX = width / 1200.0;
+        var scaleY = height / 630.0;
+        var accent = ToChartColor(visual.Accent);
+        AddTiles(canvas, visual.Tiles, BgInfoVisualCanvasSide.Left, 48 * scaleX, 92 * scaleY, 300 * scaleX, 82 * scaleY, 16 * scaleY);
+        AddTiles(canvas, visual.Tiles, BgInfoVisualCanvasSide.Right, 852 * scaleX, 70 * scaleY, 300 * scaleX, 96 * scaleY, 18 * scaleY);
+        canvas
+            .AddHeroBadge(538 * scaleX, 157 * scaleY, 124 * scaleX, 88 * scaleY, ">_", accent)
+            .AddHeroTitle(312 * scaleX, 296 * scaleY, 576 * scaleX, 82 * scaleY, SplitTitle(Resolve(visual.Title), canvas.Theme))
+            .AddText(240 * scaleX, 402 * scaleY, 720 * scaleX, Resolve(visual.Subtitle), 24 * scaleY, canvas.Theme.SubtitleColor, VisualCanvasTextAlignment.Center);
+        if (visual.Features.Count > 0) {
+            canvas.AddFeatureStrip(290 * scaleX, 522 * scaleY, 620 * scaleX, 62 * scaleY, BuildFeatureItems(visual.Features));
+        }
+    }
+
+    private static void BuildPowerBgInfoOverlay(VisualCanvas canvas, BgInfoVisualCanvas visual, int width, int height) {
+        var accent = ToChartColor(visual.Accent);
+        var marginX = Clamp(width * 0.045, 72, 132);
+        var tileWidth = Clamp(width * 0.18, 380, 470);
+        var tileHeight = Clamp(height * 0.092, 92, 106);
+        var tileGap = Clamp(height * 0.018, 16, 24);
+        var railY = Clamp(height * 0.16, 92, 190);
+        AddTiles(canvas, visual.Tiles, BgInfoVisualCanvasSide.Left, marginX, railY, tileWidth, tileHeight, tileGap);
+        AddTiles(canvas, visual.Tiles, BgInfoVisualCanvasSide.Right, width - marginX - tileWidth, railY, tileWidth, tileHeight, tileGap);
+
+        var centerLeft = marginX + tileWidth + 48;
+        var centerRight = width - marginX - tileWidth - 48;
+        var centerWidth = Math.Max(360, centerRight - centerLeft);
+        var badgeWidth = Clamp(width * 0.065, 104, 144);
+        var badgeHeight = Clamp(height * 0.085, 76, 100);
+        var badgeY = Clamp(height * 0.23, 156, 260);
+        var titleFont = Clamp(width * 0.042, 62, 96);
+        var titleY = Clamp(height * 0.39, 300, 450);
+        var subtitleFont = Clamp(width * 0.014, 20, 30);
+        canvas
+            .AddHeroBadge(centerLeft + (centerWidth - badgeWidth) / 2, badgeY, badgeWidth, badgeHeight, ">_", accent)
+            .AddHeroTitle(centerLeft, titleY, centerWidth, titleFont, SplitTitle(Resolve(visual.Title), canvas.Theme))
+            .AddText(centerLeft, titleY + titleFont + 32, centerWidth, Resolve(visual.Subtitle), subtitleFont, canvas.Theme.SubtitleColor, VisualCanvasTextAlignment.Center);
+        if (visual.Features.Count > 0) {
+            var stripWidth = Clamp(centerWidth * 0.72, 520, 760);
+            canvas.AddFeatureStrip(centerLeft + (centerWidth - stripWidth) / 2, height - Clamp(height * 0.18, 132, 190), stripWidth, 64, BuildFeatureItems(visual.Features));
+        }
+    }
+
+    private static void AddTiles(VisualCanvas canvas, IReadOnlyList<BgInfoVisualCanvasTile> tiles, BgInfoVisualCanvasSide side, double x, double y, double width, double height, double gap) {
+        var index = 0;
+        foreach (var tile in tiles) {
+            if (tile.Side != side) continue;
+            canvas.AddInfoTile(
+                x,
+                y + index * (height + gap),
+                width,
+                height,
+                Resolve(tile.Icon),
+                Resolve(tile.Label),
+                Resolve(tile.Value),
+                Resolve(tile.Detail),
+                tile.Accent.HasValue ? ToChartColor(tile.Accent.Value) : (ChartColor?)null,
+                tile.Progress,
+                MapSurfaceStyle(tile.SurfaceStyle),
+                MapIconKind(tile.IconKind));
+            index++;
+        }
+    }
+
+    private static IEnumerable<VisualCanvasTextRun> SplitTitle(string title, VisualCanvasTheme theme) {
+        if (title.EndsWith("BGInfo", StringComparison.OrdinalIgnoreCase) && title.Length > "BGInfo".Length) {
+            yield return new VisualCanvasTextRun(title.Substring(0, title.Length - "BGInfo".Length), theme.HeroTitleColor);
+            yield return new VisualCanvasTextRun(title.Substring(title.Length - "BGInfo".Length), theme.HeroTitleAccentColor);
+            yield break;
+        }
+
+        yield return new VisualCanvasTextRun(title, theme.HeroTitleColor);
+    }
+
+    private static IEnumerable<VisualCanvasFeatureItem> BuildFeatureItems(IEnumerable<BgInfoVisualCanvasFeature> features) {
+        foreach (var feature in features) yield return new VisualCanvasFeatureItem(Resolve(feature.Icon), Resolve(feature.Label));
+    }
+
+    private static string Resolve(string? value) => BgInfoVariableResolver.RenderTemplate(value, new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase));
+
+    private static ChartColor ToChartColor(Color color) => ChartColor.FromRgba(color.R, color.G, color.B, color.A);
+
+    private static VisualCanvasTheme BuildTheme(BgInfoVisualCanvas visual) {
+        var theme = new VisualCanvasTheme {
+            Accent = ToChartColor(visual.Accent),
+            HeroTitleAccentColor = ToChartColor(visual.Accent),
+            ImagePlaceholderStroke = ToChartColor(visual.Accent).WithOpacity(0.34)
+        };
+        ApplyColor(visual.SecondaryAccent, value => theme.SecondaryAccent = value);
+        ApplyColor(visual.TitleColor, value => theme.HeroTitleColor = value);
+        ApplyColor(visual.TitleAccentColor, value => theme.HeroTitleAccentColor = value);
+        ApplyColor(visual.SubtitleColor, value => theme.SubtitleColor = value);
+        ApplyColor(visual.TileGlassTop, value => theme.TileGlassTop = value);
+        ApplyColor(visual.TileGlassBottom, value => theme.TileGlassBottom = value);
+        ApplyColor(visual.TileLabelColor, value => theme.TileLabelColor = value);
+        ApplyColor(visual.TileValueColor, value => theme.TileValueColor = value);
+        ApplyColor(visual.TileDetailColor, value => theme.TileDetailColor = value);
+        ApplyColor(visual.TileProgressTrackColor, value => theme.TileProgressTrackColor = value);
+        ApplyColor(visual.HeroBadgeTop, value => theme.HeroBadgeTop = value);
+        ApplyColor(visual.HeroBadgeBottom, value => theme.HeroBadgeBottom = value);
+        ApplyColor(visual.HeroBadgeTextColor, value => theme.HeroBadgeTextColor = value);
+        return theme;
+    }
+
+    private static void ApplyColor(Color? color, Action<ChartColor> setter) {
+        if (color.HasValue) setter(ToChartColor(color.Value));
+    }
+
+    private static VisualCanvasInfoTileSurfaceStyle MapSurfaceStyle(BgInfoVisualCanvasTileSurfaceStyle style) =>
+        style == BgInfoVisualCanvasTileSurfaceStyle.Outline ? VisualCanvasInfoTileSurfaceStyle.Outline : VisualCanvasInfoTileSurfaceStyle.Glass;
+
+    private static VisualCanvasInfoTileIconKind MapIconKind(BgInfoVisualCanvasTileIconKind kind) {
+        switch (kind) {
+            case BgInfoVisualCanvasTileIconKind.Computer: return VisualCanvasInfoTileIconKind.Computer;
+            case BgInfoVisualCanvasTileIconKind.Network: return VisualCanvasInfoTileIconKind.Network;
+            case BgInfoVisualCanvasTileIconKind.OperatingSystem: return VisualCanvasInfoTileIconKind.OperatingSystem;
+            case BgInfoVisualCanvasTileIconKind.Cpu: return VisualCanvasInfoTileIconKind.Cpu;
+            case BgInfoVisualCanvasTileIconKind.Memory: return VisualCanvasInfoTileIconKind.Memory;
+            case BgInfoVisualCanvasTileIconKind.User: return VisualCanvasInfoTileIconKind.User;
+            case BgInfoVisualCanvasTileIconKind.Domain: return VisualCanvasInfoTileIconKind.Domain;
+            case BgInfoVisualCanvasTileIconKind.Terminal: return VisualCanvasInfoTileIconKind.Terminal;
+            case BgInfoVisualCanvasTileIconKind.Storage: return VisualCanvasInfoTileIconKind.Storage;
+            case BgInfoVisualCanvasTileIconKind.Shield: return VisualCanvasInfoTileIconKind.Shield;
+            default: return VisualCanvasInfoTileIconKind.Text;
+        }
+    }
+
+    private static double Clamp(double value, double min, double max) => Math.Max(min, Math.Min(max, value));
+
+    private static void DrawPng(GdiImage image, byte[] png, float x, float y, float width, float height) {
+        image.WithGraphics(graphics => {
+            using var stream = new MemoryStream(png);
+            using var bitmap = System.Drawing.Image.FromStream(stream);
+            graphics.DrawImage(bitmap, x, y, width, height);
+        });
+    }
+}

--- a/Sources/PowerBGInfo/PowerBGInfo.csproj
+++ b/Sources/PowerBGInfo/PowerBGInfo.csproj
@@ -25,7 +25,7 @@
         <ProjectReference Include="$(ChartForgeXProjectPath)" />
     </ItemGroup>
     <ItemGroup Condition="'$(ChartForgeXProjectPath)' == ''">
-        <PackageReference Include="ChartForgeX" Version="0.1.1" />
+        <PackageReference Include="ChartForgeX" Version="0.1.2" />
     </ItemGroup>
     <ItemGroup>
         <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">


### PR DESCRIPTION
## Summary

Adds PowerBGInfo support for ChartForgeX visual canvas overlays while keeping PowerBGInfo as a thin consumer. The new cmdlets describe desktop/wallpaper data, tile placement, surface style, icon choices, and theme colors, then delegate reusable rendering to ChartForgeX.

Depends on ChartForgeX PR: https://github.com/EvotecIT/ChartForgeX/pull/72

## Details

- Adds `BgInfoVisualCanvas` model types and renderer adapter.
- Adds `New-BGInfoVisualCanvas`, `New-BGInfoVisualCanvasTile`, and `New-BGInfoVisualCanvasFeature` cmdlets.
- Supports transparent HUD overlays by default, with `-Opaque` available for self-contained card/social-style output.
- Supports glass and outline tile surfaces, text badges, built-in icons, and configurable theme colors.
- Preserves visual canvas configuration through JSON load/save.
- Adds README guidance and `Examples/Scripts/PowerBGInfo.VisualCanvas.ps1`, which renders glass text, outline text, and outline icon variants.

## Validation

- `dotnet build .\Sources\PowerBGInfo.sln -c Debug -p:ChartForgeXProjectPath=C:\Support\GitHub\ChartForgeX-visual-canvas\ChartForgeX\ChartForgeX.csproj -m:1 -nr:false -p:UseSharedCompilation=false`
- `dotnet test .\Sources\PowerBGInfo.Tests\PowerBGInfo.Tests.csproj -c Debug -f net8.0-windows -p:ChartForgeXProjectPath=C:\Support\GitHub\ChartForgeX-visual-canvas\ChartForgeX\ChartForgeX.csproj -m:1 -nr:false -p:UseSharedCompilation=false --no-restore`
- `Invoke-Pester -Path .\Sources\PowerBGInfo.Tests\Cmdlet.Tests.ps1 -FullName '*visual canvas*' -CI`

Results:

- PowerBGInfo C# tests: `19/19` passed.
- Visual-canvas Pester tests: `4/4` passed.
- Example script rendered all three visual canvas variants.