### PR TITLE
Use DesktopManager slideshow support

### DIFF
--- a/.github/workflows/test-powershell.yml
+++ b/.github/workflows/test-powershell.yml
@@ -36,6 +36,10 @@ jobs:
       - name: Setup PowerShell modules
         shell: pwsh
         run: |
+          if (-not (Get-PSRepository -Name PSGallery -ErrorAction SilentlyContinue)) {
+            Register-PSRepository -Default
+          }
+          Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
           Install-Module PSPublishModule -MinimumVersion 3.0.4 -Force -Scope CurrentUser -AllowClobber
 
       - name: Refresh module manifest
@@ -83,6 +87,10 @@ jobs:
         shell: powershell
         run: |
           Write-Host "PowerShell Version: $($PSVersionTable.PSVersion)"
+          if (-not (Get-PSRepository -Name PSGallery -ErrorAction SilentlyContinue)) {
+            Register-PSRepository -Default
+          }
+          Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
           Install-Module -Name Pester -Repository PSGallery -Force -SkipPublisherCheck -AllowClobber
           Install-Module -Name PSWriteColor -Repository PSGallery -Force -SkipPublisherCheck -AllowClobber
 
@@ -127,6 +135,10 @@ jobs:
         shell: pwsh
         run: |
           Write-Host "PowerShell Version: $($PSVersionTable.PSVersion)"
+          if (-not (Get-PSRepository -Name PSGallery -ErrorAction SilentlyContinue)) {
+            Register-PSRepository -Default
+          }
+          Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
           Install-Module -Name Pester -Repository PSGallery -Force -SkipPublisherCheck -AllowClobber
           Install-Module -Name PSWriteColor -Repository PSGallery -Force -SkipPublisherCheck -AllowClobber
 
@@ -171,6 +183,10 @@ jobs:
         shell: pwsh
         run: |
           Write-Host "PowerShell Version: $($PSVersionTable.PSVersion)"
+          if (-not (Get-PSRepository -Name PSGallery -ErrorAction SilentlyContinue)) {
+            Register-PSRepository -Default
+          }
+          Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
           Install-Module -Name PSPublishModule -Repository PSGallery -MinimumVersion 3.0.4 -Force -Scope CurrentUser -AllowClobber
           Install-Module -Name Pester -Repository PSGallery -Force -SkipPublisherCheck -AllowClobber
           Install-Module -Name PSWriteColor -Repository PSGallery -Force -SkipPublisherCheck -AllowClobber

--- a/Docs/New-BGInfo.md
+++ b/Docs/New-BGInfo.md
@@ -17,7 +17,7 @@ New-BGInfo [-BGInfoContent] <ScriptBlock> [[-FilePath] <String>] [-Configuration
  [[-FontFamilyName] <String>] [[-Color] <Color>] [[-FontSize] <Int32>] [[-ValueColor] <Color>]
  [[-ValueFontSize] <Single>] [[-ValueFontFamilyName] <String>] [[-SpaceBetweenLines] <Int32>]
  [[-SpaceBetweenColumns] <Int32>] [[-PositionX] <Int32>] [[-PositionY] <Int32>] [[-MonitorIndex] <Int32>]
- [[-WallpaperFit] <String>] [<CommonParameters>]
+ [[-WallpaperFit] <String>] [-DisableWallpaperSlideshow] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -75,6 +75,7 @@ Accept wildcard characters: False
 ### -FilePath
 Path to the image that will be used as a background.
 If not provided current Desktop Background will be used.
+When omitted and the current desktop uses a Windows wallpaper slideshow, PowerBGInfo preserves that slideshow by rendering one generated image per slideshow source.
 
 ```yaml
 Type: String
@@ -294,6 +295,22 @@ Aliases:
 Required: False
 Position: 15
 Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DisableWallpaperSlideshow
+Forces one static generated wallpaper even when the current Windows desktop wallpaper is a slideshow.
+By default, when `-FilePath` is not provided, PowerBGInfo renders every slideshow source image and reapplies the slideshow with the same DesktopManager options and interval.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/README.MD
+++ b/README.MD
@@ -34,6 +34,7 @@ You can read about this project on this [blog post](https://evotec.xyz/powerbgin
 - Place information in corners, center positions, or explicit screen coordinates.
 - Wrap long values such as AD computer descriptions with `-ValueWrapWidth`.
 - Apply output to the current user, all users, the logon/lock screen, or just write a file.
+- Preserve the current Windows wallpaper slideshow by rendering one BGInfo image per slideshow source.
 - Handle solid-color desktops when Windows has no wallpaper file.
 - Add transparent ChartForgeX charts and topology diagrams on top of real wallpapers.
 - Export JSON configurations when you need a portable deployment artifact.
@@ -125,6 +126,7 @@ New-BGInfo -MonitorIndex 0 -Target Both {
 ## Operational notes
 
 - Solid-color desktops: when no wallpaper file exists, PowerBGInfo renders a blank image using the desktop background color or `-BackgroundColor`.
+- Wallpaper slideshows: when no explicit `-FilePath` is provided and Windows has a wallpaper slideshow configured, PowerBGInfo renders every slideshow source image into the configuration directory and restarts the slideshow with the generated images while preserving DesktopManager slideshow options and interval. Use `-DisableWallpaperSlideshow` when you want one static generated wallpaper instead.
 - Refresh behavior: by default the wallpaper is refreshed to avoid Windows caching issues; use `-DisableWallpaperRefresh` only when you need the old behavior.
 - All users: use `-AllUsers` elevated. Use `-ExcludeDefaultUserProfile` to skip the default profile.
 - Logon screen: use `-Target LogonScreen` or `-Target Both` elevated.
@@ -174,6 +176,7 @@ Example output:
 - `-TextPosition`, `-PositionX`, `-PositionY`, `-SpaceX`, and `-SpaceY` control where the text block is placed.
 - `-UseScreenCoordinates` makes placement calculations match the monitor coordinate space.
 - `-OutputFileName` controls the generated image name and path.
+- `-DisableWallpaperSlideshow` forces static wallpaper output instead of preserving the active Windows slideshow.
 - `-JsonPath` and `-ExportOnly` save reusable configuration without applying the wallpaper.
 - `New-BGInfoChart` and `New-BGInfoTopology` add ChartForgeX-backed transparent overlays with optional chart history.
 
@@ -492,6 +495,7 @@ When hand-editing JSON on Windows, remember that backslashes inside string value
   "MonitorIndex": 0,
   "Target": "Wallpaper",
   "WallpaperFit": "Fill",
+  "PreserveWallpaperSlideshow": true,
   "Color": "#FFFFFFFF",
   "ValueColor": "#00FFFFFF",
   "ValueWrapWidth": 320,

--- a/Sources/PowerBGInfo.Cli/PowerShellConfigurationLoader.cs
+++ b/Sources/PowerBGInfo.Cli/PowerShellConfigurationLoader.cs
@@ -195,14 +195,14 @@ $ErrorActionPreference = 'Stop'
 if ($ModulePath) {
     Import-Module -Name $ModulePath -Force
 } elseif (-not (Get-Module -Name PowerBGInfo)) {
-    $scriptImportsModule = $false
+    $scriptImportsPowerBGInfo = $false
     try {
         $scriptText = Get-Content -LiteralPath $ScriptPath -Raw -ErrorAction Stop
-        $scriptImportsModule = $scriptText -match '(?im)^\s*Import-Module\b'
+        $scriptImportsPowerBGInfo = $scriptText -match '(?im)^\s*Import-Module\b[^\r\n]*(PowerBGInfo|PowerBGInfo\.psd1|PowerBGInfo\.psm1|PowerBGInfo\.PowerShell\.dll)\b'
     } catch {
     }
 
-    if (-not $scriptImportsModule) {
+    if (-not $scriptImportsPowerBGInfo) {
         try {
             Import-Module -Name PowerBGInfo -Force -ErrorAction Stop
         } catch {

--- a/Sources/PowerBGInfo.Cli/PowerShellConfigurationLoader.cs
+++ b/Sources/PowerBGInfo.Cli/PowerShellConfigurationLoader.cs
@@ -194,10 +194,19 @@ $ErrorActionPreference = 'Stop'
 
 if ($ModulePath) {
     Import-Module -Name $ModulePath -Force
-} elseif (-not (Get-Command -Name New-BGInfo -ErrorAction SilentlyContinue)) {
+} elseif (-not (Get-Module -Name PowerBGInfo)) {
+    $scriptImportsModule = $false
     try {
-        Import-Module -Name PowerBGInfo -Force -ErrorAction Stop
+        $scriptText = Get-Content -LiteralPath $ScriptPath -Raw -ErrorAction Stop
+        $scriptImportsModule = $scriptText -match '(?im)^\s*Import-Module\b'
     } catch {
+    }
+
+    if (-not $scriptImportsModule) {
+        try {
+            Import-Module -Name PowerBGInfo -Force -ErrorAction Stop
+        } catch {
+        }
     }
 }
 
@@ -213,9 +222,19 @@ try {
     Pop-Location
 }
 
-$config = @($results | Where-Object { $_ -is [PowerBGInfo.BgInfoConfiguration] } | Select-Object -Last 1)
+$config = @($results | Where-Object {
+    $candidate = $_.PSObject.BaseObject
+    $candidate -ne $null -and $candidate.GetType().FullName -eq 'PowerBGInfo.BgInfoConfiguration'
+} | Select-Object -Last 1)
 if ($config.Count -gt 0) {
-    [PowerBGInfo.BgInfoConfigurationJson]::Save($config[0], $OutputPath)
+    $configuration = $config[0].PSObject.BaseObject
+    $configurationType = $configuration.GetType()
+    $jsonType = $configurationType.Assembly.GetType('PowerBGInfo.BgInfoConfigurationJson', $true)
+    $saveMethod = $jsonType.GetMethod('Save', [type[]] @($configurationType, [string]))
+    if ($null -eq $saveMethod) {
+        throw "Unable to find PowerBGInfo.BgInfoConfigurationJson.Save."
+    }
+    $saveMethod.Invoke($null, @($configuration, $OutputPath)) | Out-Null
     Write-Output $OutputPath
     return
 }

--- a/Sources/PowerBGInfo.Cli/Program.cs
+++ b/Sources/PowerBGInfo.Cli/Program.cs
@@ -27,6 +27,7 @@ internal static class Program {
             int? monitorIndex = null;
             bool noApply = false;
             bool exportOnly = false;
+            bool disableWallpaperSlideshow = false;
             string? scriptDirectory = null;
 
             for (int i = 0; i < args.Length; i++) {
@@ -74,6 +75,9 @@ internal static class Program {
                     case "--no-apply":
                         noApply = true;
                         break;
+                    case "--disable-wallpaper-slideshow":
+                        disableWallpaperSlideshow = true;
+                        break;
                     default:
                         return Fail($"Unknown argument: {arg}");
                 }
@@ -113,6 +117,9 @@ internal static class Program {
             }
             if (noApply) {
                 config.Target = BgInfoTarget.File;
+            }
+            if (disableWallpaperSlideshow) {
+                config.PreserveWallpaperSlideshow = false;
             }
 
             if (!string.IsNullOrWhiteSpace(exportJsonPath)) {
@@ -185,6 +192,8 @@ internal static class Program {
         Console.WriteLine("      --pwsh <path>         Override the PowerShell executable used for --script.");
         Console.WriteLine("      --module <path>       Import the PowerBGInfo module before running --script.");
         Console.WriteLine("      --no-apply            Generate the image without applying wallpaper.");
+        Console.WriteLine("      --disable-wallpaper-slideshow");
+        Console.WriteLine("                            Generate one static wallpaper even if Windows slideshow is active.");
     }
 
     private static void ResolveScriptRelativePaths(BgInfoConfiguration configuration, string scriptDirectory) {

--- a/Sources/PowerBGInfo.PowerShell/CmdletNewBGInfo.cs
+++ b/Sources/PowerBGInfo.PowerShell/CmdletNewBGInfo.cs
@@ -141,6 +141,10 @@ public class CmdletNewBGInfo : PSCmdlet {
     [Parameter]
     public SwitchParameter DisableWallpaperRefresh { get; set; }
 
+    /// <para>Disable automatic preservation of the current Windows wallpaper slideshow.</para>
+    [Parameter]
+    public SwitchParameter DisableWallpaperSlideshow { get; set; }
+
     /// <para>Use screen coordinates for placement calculations.</para>
     [Parameter]
     public SwitchParameter UseScreenCoordinates { get; set; }
@@ -210,6 +214,7 @@ public class CmdletNewBGInfo : PSCmdlet {
             ChartStackOutsideTextBlock = ChartStackOutsideTextBlock.IsPresent,
             UseScreenCoordinates = UseScreenCoordinates.IsPresent,
             ForceWallpaperRefresh = !DisableWallpaperRefresh.IsPresent,
+            PreserveWallpaperSlideshow = !DisableWallpaperSlideshow.IsPresent,
             ApplyToAllUsers = AllUsers.IsPresent,
             IncludeDefaultUserProfile = !ExcludeDefaultUserProfile.IsPresent
         };

--- a/Sources/PowerBGInfo.PowerShell/CmdletNewBGInfoConfiguration.cs
+++ b/Sources/PowerBGInfo.PowerShell/CmdletNewBGInfoConfiguration.cs
@@ -136,6 +136,10 @@ public sealed class CmdletNewBGInfoConfiguration : PSCmdlet {
     [Parameter]
     public SwitchParameter DisableWallpaperRefresh { get; set; }
 
+    /// <para>Disable automatic preservation of the current Windows wallpaper slideshow.</para>
+    [Parameter]
+    public SwitchParameter DisableWallpaperSlideshow { get; set; }
+
     /// <para>Use screen coordinates for layout positioning.</para>
     [Parameter]
     public SwitchParameter UseScreenCoordinates { get; set; }
@@ -199,6 +203,7 @@ public sealed class CmdletNewBGInfoConfiguration : PSCmdlet {
         if (IsParameterBound(nameof(ChartStackAlignToTextBlock))) config.ChartStackAlignToTextBlock = ChartStackAlignToTextBlock.IsPresent;
         if (IsParameterBound(nameof(ChartStackOutsideTextBlock))) config.ChartStackOutsideTextBlock = ChartStackOutsideTextBlock.IsPresent;
         if (IsParameterBound(nameof(DisableWallpaperRefresh))) config.ForceWallpaperRefresh = !DisableWallpaperRefresh.IsPresent;
+        if (IsParameterBound(nameof(DisableWallpaperSlideshow))) config.PreserveWallpaperSlideshow = !DisableWallpaperSlideshow.IsPresent;
         if (IsParameterBound(nameof(AllUsers))) config.ApplyToAllUsers = AllUsers.IsPresent;
         if (IsParameterBound(nameof(ExcludeDefaultUserProfile))) config.IncludeDefaultUserProfile = !ExcludeDefaultUserProfile.IsPresent;
         if (IsParameterBound(nameof(UseScreenCoordinates))) config.UseScreenCoordinates = UseScreenCoordinates.IsPresent;

--- a/Sources/PowerBGInfo.Tests/BgInfoConfigurationJsonTests.cs
+++ b/Sources/PowerBGInfo.Tests/BgInfoConfigurationJsonTests.cs
@@ -94,6 +94,40 @@ public class BgInfoConfigurationJsonTests
     }
 
     [Fact]
+    public void SaveAndLoadPreservesWallpaperSlideshowPreference()
+    {
+        var tempDirectory = Path.Combine(Path.GetTempPath(), "bginfo-json-" + Path.GetRandomFileName());
+        Directory.CreateDirectory(tempDirectory);
+        var path = Path.Combine(tempDirectory, "config.json");
+
+        var configuration = new BgInfoConfiguration {
+            ConfigurationDirectory = tempDirectory,
+            PreserveWallpaperSlideshow = false
+        };
+
+        BgInfoConfigurationJson.Save(configuration, path);
+
+        var json = File.ReadAllText(path);
+        Assert.Contains("\"PreserveWallpaperSlideshow\"", json);
+
+        var roundTripped = BgInfoConfigurationJson.Load(path);
+        Assert.False(roundTripped.PreserveWallpaperSlideshow);
+    }
+
+    [Fact]
+    public void LoadUsesWallpaperSlideshowPreservationByDefault()
+    {
+        var tempDirectory = Path.Combine(Path.GetTempPath(), "bginfo-json-" + Path.GetRandomFileName());
+        Directory.CreateDirectory(tempDirectory);
+        var path = Path.Combine(tempDirectory, "config.json");
+        File.WriteAllText(path, "{}");
+
+        var configuration = BgInfoConfigurationJson.Load(path);
+
+        Assert.True(configuration.PreserveWallpaperSlideshow);
+    }
+
+    [Fact]
     public void SaveAndLoadPreservesChartForgeXChartOptions() {
         var tempDirectory = Path.Combine(Path.GetTempPath(), "bginfo-json-" + Path.GetRandomFileName());
         Directory.CreateDirectory(tempDirectory);

--- a/Sources/PowerBGInfo.Tests/BgInfoGeneratorTests.cs
+++ b/Sources/PowerBGInfo.Tests/BgInfoGeneratorTests.cs
@@ -90,6 +90,85 @@ public class BgInfoGeneratorTests
     }
 
     [Fact]
+    public void GeneratePreservesWallpaperSlideshowWhenNoFilePathIsConfigured()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        var tempDirectory = Path.Combine(Path.GetTempPath(), "bginfo" + Path.GetRandomFileName());
+        Directory.CreateDirectory(tempDirectory);
+        var sourceOne = Path.Combine(tempDirectory, "slide-one.jpg");
+        var sourceTwo = Path.Combine(tempDirectory, "slide-two.jpg");
+        File.Copy(Path.Combine(AppContext.BaseDirectory, "TapC-Evotec-2560x1080.jpg"), sourceOne);
+        File.Copy(Path.Combine(AppContext.BaseDirectory, "TapC-Evotec-2560x1080.jpg"), sourceTwo);
+
+        var imageService = new ImageService();
+        var wallpaperService = new FakeWallpaperService {
+            Slideshow = new DesktopWallpaperSlideshow {
+                ImagePaths = new[] { sourceOne, sourceTwo },
+                State = DesktopSlideshowState.Enabled | DesktopSlideshowState.Slideshow,
+                Options = DesktopSlideshowOptions.ShuffleImages,
+                SlideshowTick = 600000
+            }
+        };
+        var generator = new BgInfoGenerator(imageService, wallpaperService);
+        var config = new BgInfoConfiguration
+        {
+            OutputFileName = "generated.png",
+            ConfigurationDirectory = tempDirectory,
+            WallpaperFit = DesktopWallpaperPosition.Fill
+        };
+        config.Entries.Add(new BgInfoEntry { Type = BgInfoEntryType.Value, Name = "Test", Value = "1" });
+
+        var path = generator.Generate(config);
+
+        Assert.True(File.Exists(path));
+        Assert.Equal(1, wallpaperService.SlideshowCalls);
+        Assert.Equal(0, wallpaperService.Calls);
+        Assert.Equal(DesktopWallpaperPosition.Fill, wallpaperService.SlideshowPosition);
+        Assert.Equal(DesktopSlideshowOptions.ShuffleImages, wallpaperService.SlideshowOptions);
+        Assert.Equal(600000u, wallpaperService.SlideshowTick);
+        Assert.Equal(2, wallpaperService.SlideshowPaths.Count);
+        Assert.All(wallpaperService.SlideshowPaths, generated => Assert.True(File.Exists(generated)));
+        Assert.EndsWith("generated_001.png", wallpaperService.SlideshowPaths[0]);
+        Assert.EndsWith("generated_002.png", wallpaperService.SlideshowPaths[1]);
+    }
+
+    [Fact]
+    public void GenerateUsesStaticWallpaperWhenFilePathIsConfigured()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        var imageService = new ImageService();
+        var wallpaperService = new FakeWallpaperService {
+            Slideshow = new DesktopWallpaperSlideshow {
+                ImagePaths = new[] { Path.Combine(AppContext.BaseDirectory, "TapC-Evotec-2560x1080.jpg") },
+                State = DesktopSlideshowState.Enabled | DesktopSlideshowState.Slideshow,
+                Options = DesktopSlideshowOptions.ShuffleImages,
+                SlideshowTick = 600000
+            }
+        };
+        var generator = new BgInfoGenerator(imageService, wallpaperService);
+        var config = new BgInfoConfiguration
+        {
+            FilePath = Path.Combine(AppContext.BaseDirectory, "TapC-Evotec-2560x1080.jpg"),
+            ConfigurationDirectory = Path.Combine(Path.GetTempPath(), "bginfo" + Path.GetRandomFileName()),
+            ForceWallpaperRefresh = false
+        };
+        config.Entries.Add(new BgInfoEntry { Type = BgInfoEntryType.Value, Name = "Test", Value = "1" });
+
+        generator.Generate(config);
+
+        Assert.Equal(1, wallpaperService.Calls);
+        Assert.Equal(0, wallpaperService.SlideshowCalls);
+    }
+
+    [Fact]
     public void GenerateCallsLogonWallpaperWhenRequested()
     {
         if (!OperatingSystem.IsWindows())
@@ -262,6 +341,13 @@ internal class FakeWallpaperService : IWallpaperService
     public int Calls { get; private set; }
     public int LogonCalls { get; private set; }
     public int AllUsersCalls { get; private set; }
+    public int SlideshowCalls { get; private set; }
+    public DesktopWallpaperSlideshow Slideshow { get; set; } = new();
+    public List<string> SlideshowPaths { get; } = new();
+    public DesktopWallpaperPosition SlideshowPosition { get; private set; }
+    public DesktopSlideshowOptions SlideshowOptions { get; private set; }
+    public uint SlideshowTick { get; private set; }
+
     public void SetWallpaper(int monitorIndex, string filePath, DesktopManager.DesktopWallpaperPosition position)
     {
         Calls++;
@@ -275,5 +361,20 @@ internal class FakeWallpaperService : IWallpaperService
     public void SetWallpaperForAllUsers(string filePath, DesktopWallpaperPosition position, bool includeDefaultUserProfile)
     {
         AllUsersCalls++;
+    }
+
+    public DesktopWallpaperSlideshow GetWallpaperSlideshow()
+    {
+        return Slideshow;
+    }
+
+    public void StartWallpaperSlideshow(IEnumerable<string> filePaths, DesktopWallpaperPosition position, DesktopSlideshowOptions options, uint slideshowTick)
+    {
+        SlideshowCalls++;
+        SlideshowPaths.Clear();
+        SlideshowPaths.AddRange(filePaths);
+        SlideshowPosition = position;
+        SlideshowOptions = options;
+        SlideshowTick = slideshowTick;
     }
 }

--- a/Sources/PowerBGInfo.Tests/BgInfoGeneratorTests.cs
+++ b/Sources/PowerBGInfo.Tests/BgInfoGeneratorTests.cs
@@ -137,6 +137,125 @@ public class BgInfoGeneratorTests
     }
 
     [Fact]
+    public void GeneratePreservesWallpaperSlideshowFromDirectorySources()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        var tempDirectory = Path.Combine(Path.GetTempPath(), "bginfo" + Path.GetRandomFileName());
+        var sourceDirectory = Path.Combine(tempDirectory, "slides");
+        Directory.CreateDirectory(sourceDirectory);
+        File.Copy(Path.Combine(AppContext.BaseDirectory, "TapC-Evotec-2560x1080.jpg"), Path.Combine(sourceDirectory, "slide-one.jpg"));
+        File.Copy(Path.Combine(AppContext.BaseDirectory, "TapC-Evotec-2560x1080.jpg"), Path.Combine(sourceDirectory, "slide-two.png"));
+        File.WriteAllText(Path.Combine(sourceDirectory, "notes.txt"), "not an image");
+
+        var imageService = new ImageService();
+        var wallpaperService = new FakeWallpaperService {
+            Slideshow = new DesktopWallpaperSlideshow {
+                ImagePaths = new[] { sourceDirectory },
+                State = DesktopSlideshowState.Enabled | DesktopSlideshowState.Slideshow
+            }
+        };
+        var generator = new BgInfoGenerator(imageService, wallpaperService);
+        var config = new BgInfoConfiguration
+        {
+            OutputFileName = "directory-slides.png",
+            ConfigurationDirectory = tempDirectory
+        };
+        config.Entries.Add(new BgInfoEntry { Type = BgInfoEntryType.Value, Name = "Test", Value = "1" });
+
+        generator.Generate(config);
+
+        Assert.Equal(1, wallpaperService.SlideshowCalls);
+        Assert.Equal(2, wallpaperService.SlideshowPaths.Count);
+        Assert.All(wallpaperService.SlideshowPaths, generated => Assert.True(File.Exists(generated)));
+    }
+
+    [Fact]
+    public void GenerateDoesNotPreserveWallpaperSlideshowWhenItIsNotRunning()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        var tempDirectory = Path.Combine(Path.GetTempPath(), "bginfo" + Path.GetRandomFileName());
+        Directory.CreateDirectory(tempDirectory);
+        var source = Path.Combine(tempDirectory, "slide-one.jpg");
+        File.Copy(Path.Combine(AppContext.BaseDirectory, "TapC-Evotec-2560x1080.jpg"), source);
+
+        var imageService = new ImageService();
+        var wallpaperService = new FakeWallpaperService {
+            Slideshow = new DesktopWallpaperSlideshow {
+                ImagePaths = new[] { source },
+                State = DesktopSlideshowState.Enabled
+            }
+        };
+        var generator = new BgInfoGenerator(imageService, wallpaperService);
+        var config = new BgInfoConfiguration
+        {
+            OutputFileName = "static-fallback.png",
+            ConfigurationDirectory = tempDirectory,
+            BackgroundColor = Color.Black,
+            ForceWallpaperRefresh = false
+        };
+        config.Entries.Add(new BgInfoEntry { Type = BgInfoEntryType.Value, Name = "Test", Value = "1" });
+
+        var path = generator.Generate(config);
+
+        Assert.True(File.Exists(path));
+        Assert.Equal(0, wallpaperService.SlideshowCalls);
+    }
+
+    [Fact]
+    public void GeneratePreservesWallpaperSlideshowWithoutDuplicatingChartHistory()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        var tempDirectory = Path.Combine(Path.GetTempPath(), "bginfo" + Path.GetRandomFileName());
+        Directory.CreateDirectory(tempDirectory);
+        var sourceOne = Path.Combine(tempDirectory, "slide-one.jpg");
+        var sourceTwo = Path.Combine(tempDirectory, "slide-two.jpg");
+        File.Copy(Path.Combine(AppContext.BaseDirectory, "TapC-Evotec-2560x1080.jpg"), sourceOne);
+        File.Copy(Path.Combine(AppContext.BaseDirectory, "TapC-Evotec-2560x1080.jpg"), sourceTwo);
+
+        var imageService = new ImageService();
+        var wallpaperService = new FakeWallpaperService {
+            Slideshow = new DesktopWallpaperSlideshow {
+                ImagePaths = new[] { sourceOne, sourceTwo },
+                State = DesktopSlideshowState.Enabled | DesktopSlideshowState.Slideshow
+            }
+        };
+        var generator = new BgInfoGenerator(imageService, wallpaperService);
+        var config = new BgInfoConfiguration
+        {
+            OutputFileName = "chart-slideshow.png",
+            ConfigurationDirectory = tempDirectory
+        };
+        config.Entries.Add(new BgInfoEntry { Type = BgInfoEntryType.Value, Name = "Test", Value = "1" });
+        config.Charts.Add(new BgInfoChart
+        {
+            Id = "cpu",
+            Title = "CPU",
+            Kind = BgInfoChartKind.Sparkline,
+            Values = new[] { 10d },
+            MaxPoints = 10
+        });
+
+        generator.Generate(config);
+
+        var historyPath = Path.Combine(tempDirectory, "Charts", "cpu.txt");
+        Assert.True(File.Exists(historyPath));
+        Assert.Single(File.ReadAllLines(historyPath));
+        Assert.Equal(2, wallpaperService.SlideshowPaths.Count);
+    }
+
+    [Fact]
     public void GenerateUsesStaticWallpaperWhenFilePathIsConfigured()
     {
         if (!OperatingSystem.IsWindows())

--- a/Sources/PowerBGInfo.Tests/Cmdlet.Tests.ps1
+++ b/Sources/PowerBGInfo.Tests/Cmdlet.Tests.ps1
@@ -101,6 +101,11 @@ Describe 'New-BGInfo cmdlet parameters' {
         $command.Parameters.Keys | Should -Contain 'ChartStackOutsideTextBlock'
     }
 
+    It 'supports disabling wallpaper slideshow preservation' {
+        $command = Get-Command New-BGInfo
+        $command.Parameters.Keys | Should -Contain 'DisableWallpaperSlideshow'
+    }
+
     It 'supports recipe variables through inline content' {
         $command = Get-Command New-BGInfoVariable
         $command.Parameters.Keys | Should -Contain 'Provider'
@@ -218,7 +223,7 @@ Describe 'Export-BGInfoConfiguration cmdlet' {
 
 Describe 'New-BGInfoConfiguration cmdlet' {
     It 'creates configuration with overrides' {
-        $config = New-BGInfoConfiguration -Target File -MonitorIndex 1 -SpaceX 5 -SpaceY 7 -ValueWrapWidth 240 -ChartLayout Stack -ChartStackAlignToTextBlock -ChartStackOutsideTextBlock
+        $config = New-BGInfoConfiguration -Target File -MonitorIndex 1 -SpaceX 5 -SpaceY 7 -ValueWrapWidth 240 -ChartLayout Stack -ChartStackAlignToTextBlock -ChartStackOutsideTextBlock -DisableWallpaperSlideshow
         $config.Target | Should -Be ([PowerBGInfo.BgInfoTarget]::File)
         $config.MonitorIndex | Should -Be 1
         $config.SpaceX | Should -Be 5
@@ -227,6 +232,7 @@ Describe 'New-BGInfoConfiguration cmdlet' {
         $config.ChartLayout | Should -Be ([PowerBGInfo.BgInfoChartLayoutMode]::Stack)
         $config.ChartStackAlignToTextBlock | Should -BeTrue
         $config.ChartStackOutsideTextBlock | Should -BeTrue
+        $config.PreserveWallpaperSlideshow | Should -BeFalse
     }
 
     It 'accepts visual canvas overlays directly' {

--- a/Sources/PowerBGInfo/BgInfoConfiguration.cs
+++ b/Sources/PowerBGInfo/BgInfoConfiguration.cs
@@ -129,6 +129,10 @@ public class BgInfoConfiguration {
     /// </summary>
     public bool ForceWallpaperRefresh { get; set; } = true;
     /// <summary>
+    /// Gets or sets a value indicating whether Windows wallpaper slideshows are preserved when no explicit base image is configured.
+    /// </summary>
+    public bool PreserveWallpaperSlideshow { get; set; } = true;
+    /// <summary>
     /// Gets or sets a value indicating whether to apply the wallpaper to all user profiles.
     /// </summary>
     public bool ApplyToAllUsers { get; set; }

--- a/Sources/PowerBGInfo/BgInfoConfigurationJson.cs
+++ b/Sources/PowerBGInfo/BgInfoConfigurationJson.cs
@@ -130,6 +130,7 @@ public static class BgInfoConfigurationJson {
         if (model.SpaceY.HasValue) configuration.SpaceY = model.SpaceY.Value;
         if (model.UseScreenCoordinates.HasValue) configuration.UseScreenCoordinates = model.UseScreenCoordinates.Value;
         if (model.ForceWallpaperRefresh.HasValue) configuration.ForceWallpaperRefresh = model.ForceWallpaperRefresh.Value;
+        if (model.PreserveWallpaperSlideshow.HasValue) configuration.PreserveWallpaperSlideshow = model.PreserveWallpaperSlideshow.Value;
         if (model.ApplyToAllUsers.HasValue) configuration.ApplyToAllUsers = model.ApplyToAllUsers.Value;
         if (model.IncludeDefaultUserProfile.HasValue) configuration.IncludeDefaultUserProfile = model.IncludeDefaultUserProfile.Value;
 
@@ -244,6 +245,7 @@ public static class BgInfoConfigurationJson {
             TextPosition = configuration.TextPosition.ToString(),
             Target = configuration.Target.ToString(),
             ForceWallpaperRefresh = configuration.ForceWallpaperRefresh,
+            PreserveWallpaperSlideshow = configuration.PreserveWallpaperSlideshow,
             ApplyToAllUsers = configuration.ApplyToAllUsers,
             IncludeDefaultUserProfile = configuration.IncludeDefaultUserProfile,
             UseScreenCoordinates = configuration.UseScreenCoordinates,
@@ -985,6 +987,7 @@ public static class BgInfoConfigurationJson {
         public string? TextPosition { get; set; }
         public string? Target { get; set; }
         public bool? ForceWallpaperRefresh { get; set; }
+        public bool? PreserveWallpaperSlideshow { get; set; }
         public bool? ApplyToAllUsers { get; set; }
         public bool? IncludeDefaultUserProfile { get; set; }
         public bool? UseScreenCoordinates { get; set; }

--- a/Sources/PowerBGInfo/BgInfoGenerator.cs
+++ b/Sources/PowerBGInfo/BgInfoGenerator.cs
@@ -15,6 +15,20 @@ public class BgInfoGenerator
 {
     private readonly ImageService _imageService;
     private readonly IWallpaperService _wallpaperService;
+    private static readonly HashSet<string> SlideshowImageExtensions = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ".bmp",
+        ".dib",
+        ".gif",
+        ".jfif",
+        ".jpe",
+        ".jpeg",
+        ".jpg",
+        ".png",
+        ".tif",
+        ".tiff",
+        ".wdp"
+    };
 
     /// <summary>
     /// Initializes a new instance of the <see cref="BgInfoGenerator"/> class.
@@ -61,7 +75,12 @@ public class BgInfoGenerator
             return slideshowOutputPath;
         }
 
-        var imagePath = ResolveBaseImagePath(config, index => GetWallpaper(GetMonitors(), index));
+        return GenerateImage(config, index => GetWallpaper(GetMonitors(), index), GetMonitors, applyTargets: true);
+    }
+
+    private string GenerateImage(BgInfoConfiguration config, Func<int, string?> getWallpaperPath, Func<Monitors?> getMonitors, bool applyTargets)
+    {
+        var imagePath = ResolveBaseImagePath(config, getWallpaperPath);
 
         bool hasBaseImage = !string.IsNullOrEmpty(imagePath) && File.Exists(imagePath);
         var outputPath = BuildOutputPath(config, imagePath, hasBaseImage);
@@ -73,7 +92,7 @@ public class BgInfoGenerator
 
         using var image = hasBaseImage
             ? LoadBaseImage(imagePath!, outputPath)
-            : CreateBaseImage(config, GetMonitors(), outputPath);
+            : CreateBaseImage(config, getMonitors(), outputPath);
 
         var expandedEntries = BgInfoVariableResolver.ExpandEntries(config);
         var entryLayouts = BuildEntryLayouts(image, config, expandedEntries);
@@ -90,7 +109,7 @@ public class BgInfoGenerator
 
         if (config.UseScreenCoordinates)
         {
-            var (screenWidth, screenHeight) = GetMonitorSize(GetMonitors(), config.MonitorIndex);
+            var (screenWidth, screenHeight) = GetMonitorSize(getMonitors(), config.MonitorIndex);
 
             float scaleX;
             float scaleY;
@@ -210,7 +229,7 @@ public class BgInfoGenerator
 
         _imageService.Save(image, outputPath);
 
-        if (config.Target.HasFlag(BgInfoTarget.Wallpaper))
+        if (applyTargets && config.Target.HasFlag(BgInfoTarget.Wallpaper))
         {
             if (config.ApplyToAllUsers)
             {
@@ -220,7 +239,7 @@ public class BgInfoGenerator
             ApplyWallpaper(config, outputPath);
         }
 
-        if (config.Target.HasFlag(BgInfoTarget.LogonScreen))
+        if (applyTargets && config.Target.HasFlag(BgInfoTarget.LogonScreen))
         {
             _wallpaperService.SetLogonWallpaper(outputPath);
         }
@@ -246,20 +265,23 @@ public class BgInfoGenerator
             return false;
         }
 
-        var sourcePaths = slideshow.ImagePaths
-            .Where(path => !string.IsNullOrWhiteSpace(path) && File.Exists(path))
-            .Distinct(StringComparer.OrdinalIgnoreCase)
-            .ToArray();
+        if (!slideshow.IsRunning || slideshow.IsDisabledByRemoteSession)
+        {
+            return false;
+        }
+
+        var sourcePaths = ResolveSlideshowSourcePaths(slideshow.ImagePaths);
         if (sourcePaths.Length == 0)
         {
             return false;
         }
 
         var generatedPaths = new List<string>(sourcePaths.Length);
+        var slideshowCharts = BuildSlideshowCharts(config);
         for (int i = 0; i < sourcePaths.Length; i++)
         {
-            var itemConfig = CloneForSlideshowItem(config, sourcePaths[i], BuildSlideshowOutputPath(config, sourcePaths[i], i));
-            generatedPaths.Add(Generate(itemConfig));
+            var itemConfig = CloneForSlideshowItem(config, sourcePaths[i], BuildSlideshowOutputPath(config, sourcePaths[i], i), slideshowCharts);
+            generatedPaths.Add(GenerateImage(itemConfig, _ => null, () => null, applyTargets: false));
         }
 
         if (generatedPaths.Count == 0)
@@ -293,7 +315,134 @@ public class BgInfoGenerator
             && string.IsNullOrWhiteSpace(config.FilePath);
     }
 
-    private static BgInfoConfiguration CloneForSlideshowItem(BgInfoConfiguration source, string filePath, string outputPath)
+    private static string[] ResolveSlideshowSourcePaths(IEnumerable<string> paths)
+    {
+        var sourcePaths = new List<string>();
+        foreach (var path in paths ?? Array.Empty<string>())
+        {
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                continue;
+            }
+
+            if (File.Exists(path))
+            {
+                if (IsSupportedSlideshowImage(path))
+                {
+                    sourcePaths.Add(path);
+                }
+                continue;
+            }
+
+            if (Directory.Exists(path))
+            {
+                sourcePaths.AddRange(EnumerateSlideshowImages(path));
+            }
+        }
+
+        return sourcePaths
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+    }
+
+    private static IEnumerable<string> EnumerateSlideshowImages(string directory)
+    {
+        try
+        {
+            return Directory.EnumerateFiles(directory, "*", SearchOption.TopDirectoryOnly)
+                .Where(IsSupportedSlideshowImage)
+                .ToArray();
+        }
+        catch
+        {
+            return Array.Empty<string>();
+        }
+    }
+
+    private static bool IsSupportedSlideshowImage(string path)
+    {
+        return SlideshowImageExtensions.Contains(Path.GetExtension(path));
+    }
+
+    private static IReadOnlyList<BgInfoChart> BuildSlideshowCharts(BgInfoConfiguration source)
+    {
+        if (source.Charts.Count == 0)
+        {
+            return Array.Empty<BgInfoChart>();
+        }
+
+        var now = DateTimeOffset.UtcNow;
+        var charts = new List<BgInfoChart>(source.Charts.Count);
+        for (int i = 0; i < source.Charts.Count; i++)
+        {
+            var sourceChart = source.Charts[i];
+            var values = ResolveChartValues(source, sourceChart, now, i);
+            charts.Add(CloneChartForSlideshow(sourceChart, values));
+        }
+
+        return charts;
+    }
+
+    private static BgInfoChart CloneChartForSlideshow(BgInfoChart source, IReadOnlyList<double> values)
+    {
+        return new BgInfoChart
+        {
+            Id = source.Id,
+            Title = source.Title,
+            Kind = source.Kind,
+            Width = source.Width,
+            Height = source.Height,
+            Anchor = source.Anchor,
+            OffsetX = source.OffsetX,
+            OffsetY = source.OffsetY,
+            PositionX = source.PositionX,
+            PositionY = source.PositionY,
+            Values = values.ToArray(),
+            Labels = source.Labels.ToArray(),
+            Target = source.Target,
+            RangeEnds = source.RangeEnds.ToArray(),
+            Metric = BgInfoChartMetric.None,
+            MetricArgument = source.MetricArgument,
+            MaxPoints = source.MaxPoints,
+            UseHistory = false,
+            AppendValues = false,
+            BackgroundColor = source.BackgroundColor,
+            LineColor = source.LineColor,
+            FillColor = source.FillColor,
+            Palette = source.Palette.ToArray(),
+            TextColor = source.TextColor,
+            FontFamilyName = source.FontFamilyName,
+            TitleFontSize = source.TitleFontSize,
+            ValueFontSize = source.ValueFontSize,
+            ShowLatestValue = source.ShowLatestValue,
+            ValueFormat = source.ValueFormat,
+            ValueSuffix = source.ValueSuffix,
+            BarGap = source.BarGap,
+            Padding = source.Padding,
+            ShowGrid = source.ShowGrid,
+            GridColor = source.GridColor,
+            GridLineCount = source.GridLineCount,
+            ShowLegend = source.ShowLegend,
+            ShowPointLegend = source.ShowPointLegend,
+            LegendPosition = source.LegendPosition,
+            ShowDataLabels = source.ShowDataLabels,
+            Minimum = source.Minimum,
+            Maximum = source.Maximum,
+            ShowDonutCenterLabel = source.ShowDonutCenterLabel,
+            DonutInnerRadiusRatio = source.DonutInnerRadiusRatio,
+            DonutCenterValue = source.DonutCenterValue,
+            DonutCenterLabel = source.DonutCenterLabel,
+            ShowRadialBarCenterLabel = source.ShowRadialBarCenterLabel,
+            ShowCircleStatusLabel = source.ShowCircleStatusLabel,
+            ShowProgressValues = source.ShowProgressValues,
+            ShowProgressHandles = source.ShowProgressHandles,
+            ProgressBarThicknessRatio = source.ProgressBarThicknessRatio,
+            PictorialSymbol = source.PictorialSymbol,
+            PictorialColumns = source.PictorialColumns
+        };
+    }
+
+    private static BgInfoConfiguration CloneForSlideshowItem(BgInfoConfiguration source, string filePath, string outputPath, IReadOnlyList<BgInfoChart> charts)
     {
         var clone = new BgInfoConfiguration {
             ChartLayout = source.ChartLayout,
@@ -334,7 +483,7 @@ public class BgInfoGenerator
 
         clone.Variables.AddRange(source.Variables);
         clone.Entries.AddRange(source.Entries);
-        clone.Charts.AddRange(source.Charts);
+        clone.Charts.AddRange(charts);
         clone.Topologies.AddRange(source.Topologies);
         clone.VisualCanvases.AddRange(source.VisualCanvases);
         clone.Images.AddRange(source.Images);

--- a/Sources/PowerBGInfo/BgInfoGenerator.cs
+++ b/Sources/PowerBGInfo/BgInfoGenerator.cs
@@ -56,6 +56,11 @@ public class BgInfoGenerator
             return monitors;
         }
 
+        if (TryGenerateWallpaperSlideshow(config, out var slideshowOutputPath))
+        {
+            return slideshowOutputPath;
+        }
+
         var imagePath = ResolveBaseImagePath(config, index => GetWallpaper(GetMonitors(), index));
 
         bool hasBaseImage = !string.IsNullOrEmpty(imagePath) && File.Exists(imagePath);
@@ -223,6 +228,119 @@ public class BgInfoGenerator
         return outputPath;
     }
 
+    private bool TryGenerateWallpaperSlideshow(BgInfoConfiguration config, out string outputPath)
+    {
+        outputPath = string.Empty;
+        if (!ShouldPreserveWallpaperSlideshow(config))
+        {
+            return false;
+        }
+
+        DesktopWallpaperSlideshow slideshow;
+        try
+        {
+            slideshow = _wallpaperService.GetWallpaperSlideshow();
+        }
+        catch
+        {
+            return false;
+        }
+
+        var sourcePaths = slideshow.ImagePaths
+            .Where(path => !string.IsNullOrWhiteSpace(path) && File.Exists(path))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        if (sourcePaths.Length == 0)
+        {
+            return false;
+        }
+
+        var generatedPaths = new List<string>(sourcePaths.Length);
+        for (int i = 0; i < sourcePaths.Length; i++)
+        {
+            var itemConfig = CloneForSlideshowItem(config, sourcePaths[i], BuildSlideshowOutputPath(config, sourcePaths[i], i));
+            generatedPaths.Add(Generate(itemConfig));
+        }
+
+        if (generatedPaths.Count == 0)
+        {
+            return false;
+        }
+
+        outputPath = generatedPaths[0];
+        if (config.Target.HasFlag(BgInfoTarget.Wallpaper))
+        {
+            if (config.ApplyToAllUsers)
+            {
+                _wallpaperService.SetWallpaperForAllUsers(outputPath, config.WallpaperFit, config.IncludeDefaultUserProfile);
+            }
+
+            _wallpaperService.StartWallpaperSlideshow(generatedPaths, config.WallpaperFit, slideshow.Options, slideshow.SlideshowTick);
+        }
+
+        if (config.Target.HasFlag(BgInfoTarget.LogonScreen))
+        {
+            _wallpaperService.SetLogonWallpaper(outputPath);
+        }
+
+        return true;
+    }
+
+    private static bool ShouldPreserveWallpaperSlideshow(BgInfoConfiguration config)
+    {
+        return config.PreserveWallpaperSlideshow
+            && config.Target.HasFlag(BgInfoTarget.Wallpaper)
+            && string.IsNullOrWhiteSpace(config.FilePath);
+    }
+
+    private static BgInfoConfiguration CloneForSlideshowItem(BgInfoConfiguration source, string filePath, string outputPath)
+    {
+        var clone = new BgInfoConfiguration {
+            ChartLayout = source.ChartLayout,
+            ChartStackAnchor = source.ChartStackAnchor,
+            ChartStackDirection = source.ChartStackDirection,
+            ChartStackSpacing = source.ChartStackSpacing,
+            ChartStackOffsetX = source.ChartStackOffsetX,
+            ChartStackOffsetY = source.ChartStackOffsetY,
+            ChartStackAlignToTextBlock = source.ChartStackAlignToTextBlock,
+            ChartStackOutsideTextBlock = source.ChartStackOutsideTextBlock,
+            FilePath = filePath,
+            OutputFileName = outputPath,
+            ConfigurationDirectory = source.ConfigurationDirectory,
+            FontFamilyName = source.FontFamilyName,
+            Color = source.Color,
+            FontSize = source.FontSize,
+            ValueColor = source.ValueColor,
+            ValueFontSize = source.ValueFontSize,
+            ValueFontFamilyName = source.ValueFontFamilyName,
+            ValueWrapWidth = source.ValueWrapWidth,
+            BackgroundColor = source.BackgroundColor,
+            SpaceBetweenLines = source.SpaceBetweenLines,
+            SpaceBetweenColumns = source.SpaceBetweenColumns,
+            PositionX = source.PositionX,
+            PositionY = source.PositionY,
+            MonitorIndex = source.MonitorIndex,
+            SpaceX = source.SpaceX,
+            SpaceY = source.SpaceY,
+            WallpaperFit = source.WallpaperFit,
+            TextPosition = source.TextPosition,
+            Target = BgInfoTarget.File,
+            ForceWallpaperRefresh = false,
+            PreserveWallpaperSlideshow = false,
+            ApplyToAllUsers = false,
+            IncludeDefaultUserProfile = source.IncludeDefaultUserProfile,
+            UseScreenCoordinates = source.UseScreenCoordinates
+        };
+
+        clone.Variables.AddRange(source.Variables);
+        clone.Entries.AddRange(source.Entries);
+        clone.Charts.AddRange(source.Charts);
+        clone.Topologies.AddRange(source.Topologies);
+        clone.VisualCanvases.AddRange(source.VisualCanvases);
+        clone.Images.AddRange(source.Images);
+        return clone;
+    }
+
     private Image LoadBaseImage(string imagePath, string outputPath)
     {
         if (!PathsEqual(imagePath, outputPath))
@@ -347,6 +465,44 @@ public class BgInfoGenerator
         }
 
         return Path.Combine(config.ConfigurationDirectory, "PowerBgInfo.png");
+    }
+
+    private static string BuildSlideshowOutputPath(BgInfoConfiguration config, string sourcePath, int index)
+    {
+        var sourceExtension = Path.GetExtension(sourcePath);
+        if (string.IsNullOrWhiteSpace(sourceExtension))
+        {
+            sourceExtension = ".png";
+        }
+
+        if (!string.IsNullOrWhiteSpace(config.OutputFileName))
+        {
+            var configuredPath = Path.IsPathRooted(config.OutputFileName)
+                ? config.OutputFileName
+                : Path.Combine(config.ConfigurationDirectory, config.OutputFileName);
+            var directory = Path.GetDirectoryName(configuredPath) ?? config.ConfigurationDirectory;
+            var name = Path.GetFileNameWithoutExtension(configuredPath);
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                name = "PowerBgInfo";
+            }
+
+            var extension = Path.GetExtension(configuredPath);
+            if (string.IsNullOrWhiteSpace(extension))
+            {
+                extension = sourceExtension;
+            }
+
+            return Path.Combine(directory, $"{name}_{index + 1:D3}{extension}");
+        }
+
+        var sourceName = Path.GetFileNameWithoutExtension(sourcePath);
+        if (string.IsNullOrWhiteSpace(sourceName))
+        {
+            sourceName = "PowerBgInfo";
+        }
+
+        return Path.Combine(config.ConfigurationDirectory, $"{sourceName}_PowerBgInfo_{index + 1:D3}{sourceExtension}");
     }
 
     private void ApplyWallpaper(BgInfoConfiguration config, string outputPath)

--- a/Sources/PowerBGInfo/PowerBGInfo.csproj
+++ b/Sources/PowerBGInfo/PowerBGInfo.csproj
@@ -18,14 +18,14 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="DesktopManager" Version="3.6.1" />
+        <PackageReference Include="DesktopManager" Version="3.6.3" />
         <PackageReference Include="ImagePlayground.Gdi" Version="2.0.0" />
     </ItemGroup>
     <ItemGroup Condition="'$(ChartForgeXProjectPath)' != ''">
         <ProjectReference Include="$(ChartForgeXProjectPath)" />
     </ItemGroup>
     <ItemGroup Condition="'$(ChartForgeXProjectPath)' == ''">
-        <PackageReference Include="ChartForgeX" Version="0.1.2" />
+        <PackageReference Include="ChartForgeX" Version="0.1.3" />
     </ItemGroup>
     <ItemGroup>
         <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">

--- a/Sources/PowerBGInfo/WallpaperService.cs
+++ b/Sources/PowerBGInfo/WallpaperService.cs
@@ -31,6 +31,19 @@ public interface IWallpaperService
     /// <param name="position">Wallpaper fit mode.</param>
     /// <param name="includeDefaultUserProfile">Whether to include the default user profile.</param>
     void SetWallpaperForAllUsers(string filePath, DesktopWallpaperPosition position, bool includeDefaultUserProfile);
+    /// <summary>
+    /// Gets the current desktop wallpaper slideshow configuration.
+    /// </summary>
+    /// <returns>Current slideshow state, options, tick interval, and source image paths.</returns>
+    DesktopWallpaperSlideshow GetWallpaperSlideshow();
+    /// <summary>
+    /// Starts a wallpaper slideshow with generated images while preserving slideshow options.
+    /// </summary>
+    /// <param name="filePaths">Generated slideshow image paths.</param>
+    /// <param name="position">Wallpaper fit mode.</param>
+    /// <param name="options">Slideshow options to apply.</param>
+    /// <param name="slideshowTick">Slideshow interval in milliseconds.</param>
+    void StartWallpaperSlideshow(IEnumerable<string> filePaths, DesktopWallpaperPosition position, DesktopSlideshowOptions options, uint slideshowTick);
 }
 
 /// <summary>
@@ -79,6 +92,28 @@ public class WallpaperService : IWallpaperService
     public void SetWallpaperForAllUsers(string filePath, DesktopWallpaperPosition position, bool includeDefaultUserProfile)
     {
         Monitors.SetWallpaperForAllUsers(filePath, position, includeDefaultUserProfile);
+    }
+
+    /// <summary>
+    /// Gets the current desktop wallpaper slideshow configuration.
+    /// </summary>
+    /// <returns>Current slideshow state, options, tick interval, and source image paths.</returns>
+    public DesktopWallpaperSlideshow GetWallpaperSlideshow()
+    {
+        return Monitors.GetWallpaperSlideshow();
+    }
+
+    /// <summary>
+    /// Starts a wallpaper slideshow with generated images while preserving slideshow options.
+    /// </summary>
+    /// <param name="filePaths">Generated slideshow image paths.</param>
+    /// <param name="position">Wallpaper fit mode.</param>
+    /// <param name="options">Slideshow options to apply.</param>
+    /// <param name="slideshowTick">Slideshow interval in milliseconds.</param>
+    public void StartWallpaperSlideshow(IEnumerable<string> filePaths, DesktopWallpaperPosition position, DesktopSlideshowOptions options, uint slideshowTick)
+    {
+        Monitors.SetWallpaperPosition(position);
+        Monitors.StartWallpaperSlideshow(filePaths, options, slideshowTick);
     }
 
     private static bool IsWinRtMissing(InvalidOperationException ex)


### PR DESCRIPTION
## Summary
- Bumps PowerBGInfo to DesktopManager 3.6.3 and uses the new slideshow inspection/start APIs.
- Preserves active Windows wallpaper slideshows by rendering one BGInfo image per slideshow source, then reapplying the slideshow with the original options and tick interval.
- Adds opt-out switches for PowerShell, JSON, and CLI, plus tests and documentation for the slideshow behavior.
- Bumps ChartForgeX to 0.1.3 so the existing VisualCanvas renderer resolves during clean restore/build.
- Hardens the CLI PowerShell script loader so explicit script-side module imports do not collide with auto-loaded commands.

## Validation
- dotnet test .\Sources\PowerBGInfo.sln
- pwsh -NoProfile -Command "Invoke-Pester -Path .\Sources\PowerBGInfo.Tests\Cmdlet.Tests.ps1 -Output Detailed"
- .\Sources\PowerBGInfo.Cli\bin\Debug\net8.0-windows\PowerBGInfo.Cli.exe --help
- git diff --check
