### PR TITLE
Add visual canvas tile sizing controls

### DIFF
--- a/Examples/Scripts/PowerBGInfo.VisualCanvas.ContrastBox.ps1
+++ b/Examples/Scripts/PowerBGInfo.VisualCanvas.ContrastBox.ps1
@@ -24,7 +24,7 @@ $palette = @{
 $tiles = @(
     New-BGInfoVisualCanvasTile -Side Left -IconKind Computer -SurfaceStyle Raised -Label HOSTNAME -Value '{{HostName}}' -Detail 'production desktop' -Accent '#0F766EFF'
     New-BGInfoVisualCanvasTile -Side Left -IconKind Network -SurfaceStyle Raised -Label 'IP ADDRESS' -Value '{{IPv4Address}}' -Detail 'primary adapter' -Accent '#2563EBFF'
-    New-BGInfoVisualCanvasTile -Side Left -IconKind OperatingSystem -SurfaceStyle Raised -Label 'OPERATING SYSTEM' -Value '{{OSName}}' -Detail '{{OSVersion}}' -Accent '#7C3AEDFF'
+    New-BGInfoVisualCanvasTile -Side Left -IconKind OperatingSystem -SurfaceStyle Raised -Label 'OPERATING SYSTEM' -Value '{{OSName}}' -Detail '{{OSVersion}}' -TextFitPolicy WrapThenShrink -Accent '#7C3AEDFF'
     New-BGInfoVisualCanvasTile -Side Left -IconKind Shield -SurfaceStyle Raised -Label 'PATCH STATUS' -Value '94% compliant' -Detail 'last scan 08:42' -Progress 0.94 -Accent '#16A34AFF'
     New-BGInfoVisualCanvasTile -Side Right -IconKind Cpu -SurfaceStyle Raised -Label 'CPU LOAD' -Value '31% active' -Detail '{{CpuCores}} cores / {{CpuLogicalCores}} threads' -MiniChartKind Area -MiniChartValues 22,28,25,36,31,42,38,34,31 -MiniChartMaximum 100 -Accent '#F97316FF'
     New-BGInfoVisualCanvasTile -Side Right -IconKind Memory -SurfaceStyle Raised -Label 'MEMORY USE' -Value '11.8 GB used' -Detail '{{RAMSize}} installed' -MiniChartKind Bars -MiniChartValues 36,38,42,41,45,43,39 -MiniChartMaximum 100 -Accent '#DB2777FF'
@@ -56,10 +56,16 @@ New-BGInfo -MonitorIndex 0 -Target File {
         -HeroBadgeTop $palette.HeroBadgeTop `
         -HeroBadgeBottom $palette.HeroBadgeBottom `
         -HeroBadgeTextColor $palette.HeroBadgeTextColor `
+        -LayoutPreset WideRails `
         -FeatureAnchor BottomRight `
         -FeatureWidth 610 `
         -FeatureOffsetX 165 `
         -FeatureOffsetY 120 `
+        -TileWidth 420 `
+        -TileHeight 132 `
+        -TileGap 22 `
+        -RightTileWidth 390 `
+        -TileTextFitPolicy WrapThenShrink `
         -Tile $tiles `
         -Feature $features
 } -FilePath '..\Samples\TapC-Evotec-2560x1080.jpg' `

--- a/PowerBGInfo.psm1
+++ b/PowerBGInfo.psm1
@@ -83,6 +83,13 @@ if ($Development) {
     )
 }
 
+$AssemblyLoadSkip = @(
+    'PowerBGInfo.PowerShell.dll',
+    'System.Management.Automation.dll',
+    'System.Management.dll'
+)
+$Assembly = @($Assembly | Where-Object { $AssemblyLoadSkip -notcontains $_.Name })
+
 $FoundErrors = @(
     if ($Development) {
         foreach ($BinaryModule in $BinaryDev) {

--- a/Sources/PowerBGInfo.PowerShell/CmdletNewBGInfoVisualCanvas.cs
+++ b/Sources/PowerBGInfo.PowerShell/CmdletNewBGInfoVisualCanvas.cs
@@ -29,6 +29,10 @@ public class CmdletNewBGInfoVisualCanvas : PSCmdlet {
     [Parameter]
     public BgInfoVisualCanvasTemplate Template { get; set; } = BgInfoVisualCanvasTemplate.PowerBgInfoHero;
 
+    /// <para>Responsive side-rail sizing preset.</para>
+    [Parameter]
+    public BgInfoVisualCanvasLayoutPreset LayoutPreset { get; set; }
+
     /// <para>Canvas title or brand text.</para>
     [Parameter]
     public string Title { get; set; } = "PowerBGInfo";
@@ -133,6 +137,46 @@ public class CmdletNewBGInfoVisualCanvas : PSCmdlet {
     [Parameter]
     public int FeatureHeight { get; set; }
 
+    /// <para>Default side-rail tile width in pixels. Zero uses the template default width.</para>
+    [Parameter]
+    public int TileWidth { get; set; }
+
+    /// <para>Default side-rail tile height in pixels. Zero uses the template default height.</para>
+    [Parameter]
+    public int TileHeight { get; set; }
+
+    /// <para>Default vertical gap between side-rail tiles in pixels. Zero uses the template default gap.</para>
+    [Parameter]
+    public int TileGap { get; set; }
+
+    /// <para>Default left side-rail tile width in pixels. Zero uses TileWidth or the template default.</para>
+    [Parameter]
+    public int LeftTileWidth { get; set; }
+
+    /// <para>Default right side-rail tile width in pixels. Zero uses TileWidth or the template default.</para>
+    [Parameter]
+    public int RightTileWidth { get; set; }
+
+    /// <para>Horizontal left side-rail offset in pixels.</para>
+    [Parameter]
+    public int LeftTileOffsetX { get; set; }
+
+    /// <para>Vertical left side-rail offset in pixels.</para>
+    [Parameter]
+    public int LeftTileOffsetY { get; set; }
+
+    /// <para>Horizontal right side-rail inset in pixels.</para>
+    [Parameter]
+    public int RightTileOffsetX { get; set; }
+
+    /// <para>Vertical right side-rail offset in pixels.</para>
+    [Parameter]
+    public int RightTileOffsetY { get; set; }
+
+    /// <para>Default side-rail tile text fitting policy.</para>
+    [Parameter]
+    public BgInfoVisualCanvasTileTextFitPolicy TileTextFitPolicy { get; set; }
+
     /// <para>Horizontal feature-strip offset. For right anchors, positive values inset from the right edge.</para>
     [Parameter]
     public int FeatureOffsetX { get; set; }
@@ -161,6 +205,7 @@ public class CmdletNewBGInfoVisualCanvas : PSCmdlet {
     protected override void EndProcessing() {
         var visual = new BgInfoVisualCanvas {
             Template = Template,
+            LayoutPreset = LayoutPreset,
             Title = Title,
             Subtitle = Subtitle,
             Width = Width,
@@ -187,6 +232,16 @@ public class CmdletNewBGInfoVisualCanvas : PSCmdlet {
             FeatureAnchor = MyInvocation.BoundParameters.ContainsKey(nameof(FeatureAnchor)) ? FeatureAnchor : null,
             FeatureWidth = FeatureWidth,
             FeatureHeight = FeatureHeight,
+            TileWidth = TileWidth,
+            TileHeight = TileHeight,
+            TileGap = TileGap,
+            LeftTileWidth = LeftTileWidth,
+            RightTileWidth = RightTileWidth,
+            LeftTileOffsetX = LeftTileOffsetX,
+            LeftTileOffsetY = LeftTileOffsetY,
+            RightTileOffsetX = RightTileOffsetX,
+            RightTileOffsetY = RightTileOffsetY,
+            TileTextFitPolicy = TileTextFitPolicy,
             FeatureOffsetX = FeatureOffsetX,
             FeatureOffsetY = FeatureOffsetY,
             Transparent = !Opaque.IsPresent,

--- a/Sources/PowerBGInfo.PowerShell/CmdletNewBGInfoVisualCanvasTile.cs
+++ b/Sources/PowerBGInfo.PowerShell/CmdletNewBGInfoVisualCanvasTile.cs
@@ -39,6 +39,14 @@ public class CmdletNewBGInfoVisualCanvasTile : PSCmdlet {
     [Parameter]
     public string Detail { get; set; } = string.Empty;
 
+    /// <para>Optional tile width in pixels. Zero uses the visual canvas default or template default.</para>
+    [Parameter]
+    public int Width { get; set; }
+
+    /// <para>Optional tile height in pixels. Zero uses the visual canvas default or template default.</para>
+    [Parameter]
+    public int Height { get; set; }
+
     /// <para>Optional accent color.</para>
     [Parameter]
     public object? Accent { get; set; }
@@ -59,6 +67,10 @@ public class CmdletNewBGInfoVisualCanvasTile : PSCmdlet {
     [Parameter]
     public BgInfoVisualCanvasTileMiniChartKind MiniChartKind { get; set; }
 
+    /// <para>Tile-specific text fitting policy. Auto inherits the visual canvas setting.</para>
+    [Parameter]
+    public BgInfoVisualCanvasTileTextFitPolicy TextFitPolicy { get; set; }
+
     /// <para>Compact chart values rendered inside the tile.</para>
     [Parameter]
     public double[] MiniChartValues { get; set; } = Array.Empty<double>();
@@ -75,11 +87,14 @@ public class CmdletNewBGInfoVisualCanvasTile : PSCmdlet {
             Label = Label,
             Value = Value,
             Detail = Detail,
+            Width = Width,
+            Height = Height,
             Accent = PowerShellColorConverter.ConvertOptional(Accent, nameof(Accent)),
             Progress = Progress,
             SurfaceStyle = SurfaceStyle,
             IconKind = IconKind,
             MiniChartKind = MiniChartKind,
+            TextFitPolicy = TextFitPolicy,
             MiniChartValues = MiniChartValues ?? Array.Empty<double>(),
             MiniChartMaximum = MiniChartMaximum
         });

--- a/Sources/PowerBGInfo.Tests/BgInfoConfigurationJsonTests.cs
+++ b/Sources/PowerBGInfo.Tests/BgInfoConfigurationJsonTests.cs
@@ -272,6 +272,7 @@ public class BgInfoConfigurationJsonTests
             ConfigurationDirectory = tempDirectory
         };
         var visual = new BgInfoVisualCanvas {
+            LayoutPreset = BgInfoVisualCanvasLayoutPreset.WideRails,
             Title = "PowerBGInfo",
             Subtitle = "Desktop background insights",
             Width = 1200,
@@ -298,6 +299,16 @@ public class BgInfoConfigurationJsonTests
             FeatureAnchor = BgInfoTextPosition.BottomRight,
             FeatureWidth = 610,
             FeatureHeight = 52,
+            TileWidth = 420,
+            TileHeight = 132,
+            TileGap = 24,
+            LeftTileWidth = 430,
+            RightTileWidth = 460,
+            LeftTileOffsetX = 8,
+            LeftTileOffsetY = 10,
+            RightTileOffsetX = 12,
+            RightTileOffsetY = 14,
+            TileTextFitPolicy = BgInfoVisualCanvasTileTextFitPolicy.WrapThenShrink,
             FeatureOffsetX = 165,
             FeatureOffsetY = 120,
             TechBackdrop = false
@@ -308,11 +319,14 @@ public class BgInfoConfigurationJsonTests
             Label = "HOSTNAME",
             Value = "{{HostName}}",
             Detail = "{{OSName}}",
+            Width = 460,
+            Height = 144,
             Accent = Color.DodgerBlue,
             Progress = 0.42,
             SurfaceStyle = BgInfoVisualCanvasTileSurfaceStyle.Raised,
             IconKind = BgInfoVisualCanvasTileIconKind.Computer,
             MiniChartKind = BgInfoVisualCanvasTileMiniChartKind.Area,
+            TextFitPolicy = BgInfoVisualCanvasTileTextFitPolicy.SingleLineEllipsis,
             MiniChartValues = new[] { 18d, 26d, 22d, 37d },
             MiniChartMaximum = 100
         });
@@ -326,6 +340,7 @@ public class BgInfoConfigurationJsonTests
 
         var roundTripped = BgInfoConfigurationJson.Load(path);
         var loaded = Assert.Single(roundTripped.VisualCanvases);
+        Assert.Equal(BgInfoVisualCanvasLayoutPreset.WideRails, loaded.LayoutPreset);
         Assert.Equal("PowerBGInfo", loaded.Title);
         Assert.Equal("Desktop background insights", loaded.Subtitle);
         Assert.Equal(1200, loaded.Width);
@@ -350,6 +365,16 @@ public class BgInfoConfigurationJsonTests
         Assert.Equal(BgInfoTextPosition.BottomRight, loaded.FeatureAnchor);
         Assert.Equal(610, loaded.FeatureWidth);
         Assert.Equal(52, loaded.FeatureHeight);
+        Assert.Equal(420, loaded.TileWidth);
+        Assert.Equal(132, loaded.TileHeight);
+        Assert.Equal(24, loaded.TileGap);
+        Assert.Equal(430, loaded.LeftTileWidth);
+        Assert.Equal(460, loaded.RightTileWidth);
+        Assert.Equal(8, loaded.LeftTileOffsetX);
+        Assert.Equal(10, loaded.LeftTileOffsetY);
+        Assert.Equal(12, loaded.RightTileOffsetX);
+        Assert.Equal(14, loaded.RightTileOffsetY);
+        Assert.Equal(BgInfoVisualCanvasTileTextFitPolicy.WrapThenShrink, loaded.TileTextFitPolicy);
         Assert.Equal(165, loaded.FeatureOffsetX);
         Assert.Equal(120, loaded.FeatureOffsetY);
         Assert.False(loaded.TechBackdrop);
@@ -360,11 +385,14 @@ public class BgInfoConfigurationJsonTests
         Assert.Equal("HOSTNAME", tile.Label);
         Assert.Equal("{{HostName}}", tile.Value);
         Assert.Equal("{{OSName}}", tile.Detail);
+        Assert.Equal(460, tile.Width);
+        Assert.Equal(144, tile.Height);
         Assert.Equal(Color.DodgerBlue.ToArgb(), tile.Accent!.Value.ToArgb());
         Assert.Equal(0.42, tile.Progress);
         Assert.Equal(BgInfoVisualCanvasTileSurfaceStyle.Raised, tile.SurfaceStyle);
         Assert.Equal(BgInfoVisualCanvasTileIconKind.Computer, tile.IconKind);
         Assert.Equal(BgInfoVisualCanvasTileMiniChartKind.Area, tile.MiniChartKind);
+        Assert.Equal(BgInfoVisualCanvasTileTextFitPolicy.SingleLineEllipsis, tile.TextFitPolicy);
         Assert.Equal(new[] { 18d, 26d, 22d, 37d }, tile.MiniChartValues);
         Assert.Equal(100, tile.MiniChartMaximum);
 

--- a/Sources/PowerBGInfo.Tests/BgInfoVisualCanvasRendererTests.cs
+++ b/Sources/PowerBGInfo.Tests/BgInfoVisualCanvasRendererTests.cs
@@ -35,6 +35,77 @@ public class BgInfoVisualCanvasRendererTests
         Assert.Equal(0, CountOpaquePixels(pixels, 538, 157, 124, 88));
     }
 
+    [Fact]
+    public void RenderUsesConfiguredVisualCanvasTileSize()
+    {
+        var visual = new BgInfoVisualCanvas {
+            Width = 1000,
+            Height = 520,
+            Title = string.Empty,
+            Subtitle = string.Empty,
+            TileWidth = 360,
+            TileHeight = 132,
+            HeroBadgeVisible = false
+        };
+        visual.Tiles.Add(new BgInfoVisualCanvasTile {
+            Side = BgInfoVisualCanvasSide.Left,
+            IconKind = BgInfoVisualCanvasTileIconKind.Computer,
+            SurfaceStyle = BgInfoVisualCanvasTileSurfaceStyle.Raised,
+            Label = "OPERATING SYSTEM",
+            Value = "Windows 11 Enterprise with compliance data",
+            Detail = "cross-site monitoring window"
+        });
+
+        using var image = BgInfoVisualCanvasRenderer.Render(visual, new BgInfoConfiguration(), 1000, 520);
+        var pixels = image.ToRgbaImage();
+
+        Assert.True(CountOpaquePixels(pixels, 360, 88, 28, 72) > 0);
+    }
+
+    [Fact]
+    public void RenderUsesVisualCanvasRailControls()
+    {
+        var visual = new BgInfoVisualCanvas {
+            Width = 1000,
+            Height = 520,
+            Title = string.Empty,
+            Subtitle = string.Empty,
+            LayoutPreset = BgInfoVisualCanvasLayoutPreset.WideRails,
+            TileHeight = 112,
+            TileGap = 36,
+            LeftTileWidth = 420,
+            RightTileWidth = 310,
+            LeftTileOffsetX = 40,
+            LeftTileOffsetY = 20,
+            RightTileOffsetX = 30,
+            RightTileOffsetY = 12,
+            TileTextFitPolicy = BgInfoVisualCanvasTileTextFitPolicy.WrapThenShrink,
+            HeroBadgeVisible = false
+        };
+        visual.Tiles.Add(new BgInfoVisualCanvasTile {
+            Side = BgInfoVisualCanvasSide.Left,
+            IconKind = BgInfoVisualCanvasTileIconKind.OperatingSystem,
+            SurfaceStyle = BgInfoVisualCanvasTileSurfaceStyle.Raised,
+            Label = "OPERATING SYSTEM",
+            Value = "Windows 11 Enterprise with a very long compliance value",
+            Detail = "tenant status and policy drift"
+        });
+        visual.Tiles.Add(new BgInfoVisualCanvasTile {
+            Side = BgInfoVisualCanvasSide.Right,
+            IconKind = BgInfoVisualCanvasTileIconKind.Cpu,
+            SurfaceStyle = BgInfoVisualCanvasTileSurfaceStyle.Raised,
+            Label = "CPU",
+            Value = "31% active",
+            TextFitPolicy = BgInfoVisualCanvasTileTextFitPolicy.SingleLineEllipsis
+        });
+
+        using var image = BgInfoVisualCanvasRenderer.Render(visual, new BgInfoConfiguration(), 1000, 520);
+        var pixels = image.ToRgbaImage();
+
+        Assert.True(CountOpaquePixels(pixels, 450, 108, 24, 72) > 0);
+        Assert.True(CountOpaquePixels(pixels, 640, 100, 24, 72) > 0);
+    }
+
     private static int CountOpaquePixels(ChartForgeX.Raster.RgbaImage image, int x, int y, int width, int height)
     {
         var count = 0;

--- a/Sources/PowerBGInfo.Tests/BgInfoVisualCanvasRendererTests.cs
+++ b/Sources/PowerBGInfo.Tests/BgInfoVisualCanvasRendererTests.cs
@@ -106,6 +106,53 @@ public class BgInfoVisualCanvasRendererTests
         Assert.True(CountOpaquePixels(pixels, 640, 100, 24, 72) > 0);
     }
 
+    [Fact]
+    public void TransparentCenterBoundsAccountForRailOffsets()
+    {
+        var visual = new BgInfoVisualCanvas {
+            LeftTileWidth = 300,
+            RightTileWidth = 300,
+            LeftTileOffsetX = 80,
+            RightTileOffsetX = 64
+        };
+
+        var bounds = BgInfoVisualCanvasRenderer.ResolveDefaultTransparentCenterBounds(visual, 1000, 520);
+
+        Assert.Equal(473, Math.Round(bounds.X));
+        Assert.Equal(70, Math.Round(bounds.Width));
+    }
+
+    [Fact]
+    public void PerTileWidthDoesNotResizeSiblingTiles()
+    {
+        var visual = new BgInfoVisualCanvas {
+            Width = 1000,
+            Height = 520,
+            Title = string.Empty,
+            Subtitle = string.Empty,
+            HeroBadgeVisible = false
+        };
+        visual.Tiles.Add(new BgInfoVisualCanvasTile {
+            Side = BgInfoVisualCanvasSide.Left,
+            Width = 460,
+            Label = "WIDE",
+            Value = "wide tile",
+            SurfaceStyle = BgInfoVisualCanvasTileSurfaceStyle.Raised
+        });
+        visual.Tiles.Add(new BgInfoVisualCanvasTile {
+            Side = BgInfoVisualCanvasSide.Left,
+            Label = "DEFAULT",
+            Value = "default tile",
+            SurfaceStyle = BgInfoVisualCanvasTileSurfaceStyle.Raised
+        });
+
+        using var image = BgInfoVisualCanvasRenderer.Render(visual, new BgInfoConfiguration(), 1000, 520);
+        var pixels = image.ToRgbaImage();
+
+        Assert.True(CountOpaquePixels(pixels, 430, 95, 24, 40) > 0);
+        Assert.Equal(0, CountOpaquePixels(pixels, 430, 210, 24, 40));
+    }
+
     private static int CountOpaquePixels(ChartForgeX.Raster.RgbaImage image, int x, int y, int width, int height)
     {
         var count = 0;

--- a/Sources/PowerBGInfo.Tests/Cmdlet.Tests.ps1
+++ b/Sources/PowerBGInfo.Tests/Cmdlet.Tests.ps1
@@ -152,19 +152,30 @@ Describe 'New-BGInfo cmdlet parameters' {
         $command.Parameters.Keys | Should -Contain 'TileValueColor'
         $command.Parameters.Keys | Should -Contain 'HeroBadgeTextColor'
         $command.Parameters.Keys | Should -Contain 'NoHeroBadge'
+        $command.Parameters.Keys | Should -Contain 'LayoutPreset'
+        $command.Parameters.Keys | Should -Contain 'TileWidth'
+        $command.Parameters.Keys | Should -Contain 'TileHeight'
+        $command.Parameters.Keys | Should -Contain 'TileGap'
+        $command.Parameters.Keys | Should -Contain 'LeftTileWidth'
+        $command.Parameters.Keys | Should -Contain 'RightTileWidth'
+        $command.Parameters.Keys | Should -Contain 'TileTextFitPolicy'
         (Get-Command New-BGInfoVisualCanvasTile).Parameters.Keys | Should -Contain 'MiniChartKind'
+        (Get-Command New-BGInfoVisualCanvasTile).Parameters.Keys | Should -Contain 'Width'
+        (Get-Command New-BGInfoVisualCanvasTile).Parameters.Keys | Should -Contain 'Height'
+        (Get-Command New-BGInfoVisualCanvasTile).Parameters.Keys | Should -Contain 'TextFitPolicy'
     }
 }
 
 Describe 'New-BGInfoVisualCanvas cmdlets' {
     It 'creates a visual canvas model' {
-        $tile = New-BGInfoVisualCanvasTile -Side Left -Icon PC -Label HOSTNAME -Value '{{HostName}}' -Detail '{{OSName}}' -Progress 0.25 -SurfaceStyle Raised -IconKind Computer -MiniChartKind Sparkline -MiniChartValues 18,26,22 -MiniChartMaximum 100
+        $tile = New-BGInfoVisualCanvasTile -Side Left -Icon PC -Label HOSTNAME -Value '{{HostName}}' -Detail '{{OSName}}' -Width 460 -Height 144 -Progress 0.25 -SurfaceStyle Raised -IconKind Computer -MiniChartKind Sparkline -TextFitPolicy SingleLineEllipsis -MiniChartValues 18,26,22 -MiniChartMaximum 100
         $feature = New-BGInfoVisualCanvasFeature -Icon PS -Label 'LIGHTWEIGHT'
 
-        $visual = New-BGInfoVisualCanvas -Title PowerBGInfo -Subtitle 'Desktop insights' -Width 1200 -Height 630 -TitleColor White -TileValueColor '#F8FAFC' -HeroBadgeTextColor AliceBlue -FeatureAnchor BottomRight -FeatureWidth 610 -FeatureOffsetX 165 -FeatureOffsetY 120 -Tile $tile -Feature $feature
+        $visual = New-BGInfoVisualCanvas -Title PowerBGInfo -Subtitle 'Desktop insights' -Width 1200 -Height 630 -TitleColor White -TileValueColor '#F8FAFC' -HeroBadgeTextColor AliceBlue -FeatureAnchor BottomRight -FeatureWidth 610 -FeatureOffsetX 165 -FeatureOffsetY 120 -LayoutPreset WideRails -TileWidth 420 -TileHeight 132 -TileGap 24 -LeftTileWidth 430 -RightTileWidth 460 -LeftTileOffsetX 8 -LeftTileOffsetY 10 -RightTileOffsetX 12 -RightTileOffsetY 14 -TileTextFitPolicy WrapThenShrink -Tile $tile -Feature $feature
 
         $visual.GetType().FullName | Should -Be 'PowerBGInfo.BgInfoVisualCanvas'
         $visual.Title | Should -Be 'PowerBGInfo'
+        $visual.LayoutPreset.ToString() | Should -Be 'WideRails'
         $visual.TitleColor | Should -Not -BeNullOrEmpty
         $visual.TileValueColor | Should -Not -BeNullOrEmpty
         $visual.HeroBadgeTextColor | Should -Not -BeNullOrEmpty
@@ -173,11 +184,24 @@ Describe 'New-BGInfoVisualCanvas cmdlets' {
         $visual.FeatureWidth | Should -Be 610
         $visual.FeatureOffsetX | Should -Be 165
         $visual.FeatureOffsetY | Should -Be 120
+        $visual.TileWidth | Should -Be 420
+        $visual.TileHeight | Should -Be 132
+        $visual.TileGap | Should -Be 24
+        $visual.LeftTileWidth | Should -Be 430
+        $visual.RightTileWidth | Should -Be 460
+        $visual.LeftTileOffsetX | Should -Be 8
+        $visual.LeftTileOffsetY | Should -Be 10
+        $visual.RightTileOffsetX | Should -Be 12
+        $visual.RightTileOffsetY | Should -Be 14
+        $visual.TileTextFitPolicy.ToString() | Should -Be 'WrapThenShrink'
         $visual.Tiles.Count | Should -Be 1
         $visual.Tiles[0].Value | Should -Be '{{HostName}}'
+        $visual.Tiles[0].Width | Should -Be 460
+        $visual.Tiles[0].Height | Should -Be 144
         $visual.Tiles[0].SurfaceStyle.ToString() | Should -Be 'Raised'
         $visual.Tiles[0].IconKind.ToString() | Should -Be 'Computer'
         $visual.Tiles[0].MiniChartKind.ToString() | Should -Be 'Sparkline'
+        $visual.Tiles[0].TextFitPolicy.ToString() | Should -Be 'SingleLineEllipsis'
         $visual.Tiles[0].MiniChartValues.Count | Should -Be 3
         $visual.Tiles[0].MiniChartMaximum | Should -Be 100
         $visual.Features.Count | Should -Be 1

--- a/Sources/PowerBGInfo/BgInfoConfigurationJson.cs
+++ b/Sources/PowerBGInfo/BgInfoConfigurationJson.cs
@@ -390,6 +390,7 @@ public static class BgInfoConfigurationJson {
                 }
                 model.VisualCanvases.Add(new BgInfoVisualCanvasFile {
                     Template = visual.Template.ToString(),
+                    LayoutPreset = visual.LayoutPreset == BgInfoVisualCanvasLayoutPreset.Default ? null : visual.LayoutPreset.ToString(),
                     Title = visual.Title,
                     Subtitle = visual.Subtitle,
                     Width = visual.Width,
@@ -416,6 +417,16 @@ public static class BgInfoConfigurationJson {
                     FeatureAnchor = visual.FeatureAnchor?.ToString(),
                     FeatureWidth = visual.FeatureWidth == 0 ? null : visual.FeatureWidth,
                     FeatureHeight = visual.FeatureHeight == 0 ? null : visual.FeatureHeight,
+                    TileWidth = visual.TileWidth == 0 ? null : visual.TileWidth,
+                    TileHeight = visual.TileHeight == 0 ? null : visual.TileHeight,
+                    TileGap = visual.TileGap == 0 ? null : visual.TileGap,
+                    LeftTileWidth = visual.LeftTileWidth == 0 ? null : visual.LeftTileWidth,
+                    RightTileWidth = visual.RightTileWidth == 0 ? null : visual.RightTileWidth,
+                    LeftTileOffsetX = visual.LeftTileOffsetX == 0 ? null : visual.LeftTileOffsetX,
+                    LeftTileOffsetY = visual.LeftTileOffsetY == 0 ? null : visual.LeftTileOffsetY,
+                    RightTileOffsetX = visual.RightTileOffsetX == 0 ? null : visual.RightTileOffsetX,
+                    RightTileOffsetY = visual.RightTileOffsetY == 0 ? null : visual.RightTileOffsetY,
+                    TileTextFitPolicy = visual.TileTextFitPolicy == BgInfoVisualCanvasTileTextFitPolicy.Auto ? null : visual.TileTextFitPolicy.ToString(),
                     FeatureOffsetX = visual.FeatureOffsetX == 0 ? null : visual.FeatureOffsetX,
                     FeatureOffsetY = visual.FeatureOffsetY == 0 ? null : visual.FeatureOffsetY,
                     Transparent = visual.Transparent,
@@ -821,6 +832,10 @@ public static class BgInfoConfigurationJson {
             Enum.TryParse(model.Template, true, out BgInfoVisualCanvasTemplate template)) {
             visual.Template = template;
         }
+        if (!string.IsNullOrWhiteSpace(model.LayoutPreset) &&
+            Enum.TryParse(model.LayoutPreset, true, out BgInfoVisualCanvasLayoutPreset layoutPreset)) {
+            visual.LayoutPreset = layoutPreset;
+        }
         if (model.Width.HasValue) visual.Width = model.Width.Value;
         if (model.Height.HasValue) visual.Height = model.Height.Value;
         if (model.PositionX.HasValue) visual.PositionX = model.PositionX.Value;
@@ -834,6 +849,19 @@ public static class BgInfoConfigurationJson {
         }
         if (model.FeatureWidth.HasValue) visual.FeatureWidth = model.FeatureWidth.Value;
         if (model.FeatureHeight.HasValue) visual.FeatureHeight = model.FeatureHeight.Value;
+        if (model.TileWidth.HasValue) visual.TileWidth = model.TileWidth.Value;
+        if (model.TileHeight.HasValue) visual.TileHeight = model.TileHeight.Value;
+        if (model.TileGap.HasValue) visual.TileGap = model.TileGap.Value;
+        if (model.LeftTileWidth.HasValue) visual.LeftTileWidth = model.LeftTileWidth.Value;
+        if (model.RightTileWidth.HasValue) visual.RightTileWidth = model.RightTileWidth.Value;
+        if (model.LeftTileOffsetX.HasValue) visual.LeftTileOffsetX = model.LeftTileOffsetX.Value;
+        if (model.LeftTileOffsetY.HasValue) visual.LeftTileOffsetY = model.LeftTileOffsetY.Value;
+        if (model.RightTileOffsetX.HasValue) visual.RightTileOffsetX = model.RightTileOffsetX.Value;
+        if (model.RightTileOffsetY.HasValue) visual.RightTileOffsetY = model.RightTileOffsetY.Value;
+        if (!string.IsNullOrWhiteSpace(model.TileTextFitPolicy) &&
+            Enum.TryParse(model.TileTextFitPolicy, true, out BgInfoVisualCanvasTileTextFitPolicy tileTextFitPolicy)) {
+            visual.TileTextFitPolicy = tileTextFitPolicy;
+        }
         if (model.FeatureOffsetX.HasValue) visual.FeatureOffsetX = model.FeatureOffsetX.Value;
         if (model.FeatureOffsetY.HasValue) visual.FeatureOffsetY = model.FeatureOffsetY.Value;
         ApplyColor(model.BackgroundTop, value => visual.BackgroundTop = value);
@@ -872,7 +900,9 @@ public static class BgInfoConfigurationJson {
             Icon = model.Icon ?? string.Empty,
             Label = model.Label ?? string.Empty,
             Value = model.Value ?? string.Empty,
-            Detail = model.Detail ?? string.Empty
+            Detail = model.Detail ?? string.Empty,
+            Width = model.Width ?? 0,
+            Height = model.Height ?? 0
         };
         if (!string.IsNullOrWhiteSpace(model.Side) &&
             Enum.TryParse(model.Side, true, out BgInfoVisualCanvasSide side)) {
@@ -889,6 +919,10 @@ public static class BgInfoConfigurationJson {
         if (!string.IsNullOrWhiteSpace(model.MiniChartKind) &&
             Enum.TryParse(model.MiniChartKind, true, out BgInfoVisualCanvasTileMiniChartKind miniChartKind)) {
             tile.MiniChartKind = miniChartKind;
+        }
+        if (!string.IsNullOrWhiteSpace(model.TextFitPolicy) &&
+            Enum.TryParse(model.TextFitPolicy, true, out BgInfoVisualCanvasTileTextFitPolicy textFitPolicy)) {
+            tile.TextFitPolicy = textFitPolicy;
         }
         ApplyColor(model.Accent, value => tile.Accent = value);
         if (model.Progress.HasValue) tile.Progress = model.Progress.Value;
@@ -908,11 +942,14 @@ public static class BgInfoConfigurationJson {
         Label = tile.Label,
         Value = tile.Value,
         Detail = tile.Detail,
+        Width = tile.Width == 0 ? null : tile.Width,
+        Height = tile.Height == 0 ? null : tile.Height,
         Accent = tile.Accent.HasValue ? BgInfoColorParser.ToHex(tile.Accent.Value) : null,
         Progress = tile.Progress,
         SurfaceStyle = tile.SurfaceStyle.ToString(),
         IconKind = tile.IconKind.ToString(),
         MiniChartKind = tile.MiniChartKind.ToString(),
+        TextFitPolicy = tile.TextFitPolicy == BgInfoVisualCanvasTileTextFitPolicy.Auto ? null : tile.TextFitPolicy.ToString(),
         MiniChartValues = tile.MiniChartValues is null ? null : new List<double>(tile.MiniChartValues).ToArray(),
         MiniChartMaximum = tile.MiniChartMaximum
     };
@@ -1164,6 +1201,7 @@ public static class BgInfoConfigurationJson {
 
     internal sealed class BgInfoVisualCanvasFile {
         public string? Template { get; set; }
+        public string? LayoutPreset { get; set; }
         public string? Title { get; set; }
         public string? Subtitle { get; set; }
         public int? Width { get; set; }
@@ -1190,6 +1228,16 @@ public static class BgInfoConfigurationJson {
         public string? FeatureAnchor { get; set; }
         public int? FeatureWidth { get; set; }
         public int? FeatureHeight { get; set; }
+        public int? TileWidth { get; set; }
+        public int? TileHeight { get; set; }
+        public int? TileGap { get; set; }
+        public int? LeftTileWidth { get; set; }
+        public int? RightTileWidth { get; set; }
+        public int? LeftTileOffsetX { get; set; }
+        public int? LeftTileOffsetY { get; set; }
+        public int? RightTileOffsetX { get; set; }
+        public int? RightTileOffsetY { get; set; }
+        public string? TileTextFitPolicy { get; set; }
         public int? FeatureOffsetX { get; set; }
         public int? FeatureOffsetY { get; set; }
         public bool? Transparent { get; set; }
@@ -1204,11 +1252,14 @@ public static class BgInfoConfigurationJson {
         public string? Label { get; set; }
         public string? Value { get; set; }
         public string? Detail { get; set; }
+        public int? Width { get; set; }
+        public int? Height { get; set; }
         public string? Accent { get; set; }
         public double? Progress { get; set; }
         public string? SurfaceStyle { get; set; }
         public string? IconKind { get; set; }
         public string? MiniChartKind { get; set; }
+        public string? TextFitPolicy { get; set; }
         public double[]? MiniChartValues { get; set; }
         public double? MiniChartMaximum { get; set; }
     }

--- a/Sources/PowerBGInfo/BgInfoVisualCanvas.cs
+++ b/Sources/PowerBGInfo/BgInfoVisualCanvas.cs
@@ -65,10 +65,40 @@ public enum BgInfoVisualCanvasTileMiniChartKind {
     Bars
 }
 
+/// <summary>Built-in sizing density for visual canvas side rails.</summary>
+public enum BgInfoVisualCanvasLayoutPreset {
+    /// <summary>Use the default responsive PowerBGInfo template sizing.</summary>
+    Default,
+    /// <summary>Use smaller tiles and tighter vertical spacing.</summary>
+    Compact,
+    /// <summary>Use larger tiles and more breathing room.</summary>
+    Comfortable,
+    /// <summary>Favor wider side rails for longer values.</summary>
+    WideRails,
+    /// <summary>Favor fitting more tiles vertically.</summary>
+    Dense
+}
+
+/// <summary>Text fitting policy for visual canvas tiles.</summary>
+public enum BgInfoVisualCanvasTileTextFitPolicy {
+    /// <summary>Use the balanced ChartForgeX default.</summary>
+    Auto,
+    /// <summary>Keep each text role on one line and trim overflowing text.</summary>
+    SingleLineEllipsis,
+    /// <summary>Wrap text across available tile lines.</summary>
+    Wrap,
+    /// <summary>Shrink one-line text before trimming.</summary>
+    ShrinkToFit,
+    /// <summary>Wrap first, then shrink before trimming.</summary>
+    WrapThenShrink
+}
+
 /// <summary>Defines a reusable ChartForgeX visual canvas overlay.</summary>
 public sealed class BgInfoVisualCanvas {
     /// <summary>Template used to build the canvas.</summary>
     public BgInfoVisualCanvasTemplate Template { get; set; } = BgInfoVisualCanvasTemplate.PowerBgInfoHero;
+    /// <summary>Responsive side-rail sizing preset.</summary>
+    public BgInfoVisualCanvasLayoutPreset LayoutPreset { get; set; }
     /// <summary>Canvas title or brand text.</summary>
     public string Title { get; set; } = "PowerBGInfo";
     /// <summary>Canvas subtitle text.</summary>
@@ -121,6 +151,26 @@ public sealed class BgInfoVisualCanvas {
     public int FeatureWidth { get; set; }
     /// <summary>Optional feature-strip height in pixels. Zero uses the template default height.</summary>
     public int FeatureHeight { get; set; }
+    /// <summary>Default tile width in pixels. Zero uses the template default width.</summary>
+    public int TileWidth { get; set; }
+    /// <summary>Default tile height in pixels. Zero uses the template default height.</summary>
+    public int TileHeight { get; set; }
+    /// <summary>Default vertical gap between tiles in pixels. Zero uses the template default gap.</summary>
+    public int TileGap { get; set; }
+    /// <summary>Default left side-rail tile width in pixels. Zero uses TileWidth or the template default.</summary>
+    public int LeftTileWidth { get; set; }
+    /// <summary>Default right side-rail tile width in pixels. Zero uses TileWidth or the template default.</summary>
+    public int RightTileWidth { get; set; }
+    /// <summary>Horizontal left side-rail offset in pixels.</summary>
+    public int LeftTileOffsetX { get; set; }
+    /// <summary>Vertical left side-rail offset in pixels.</summary>
+    public int LeftTileOffsetY { get; set; }
+    /// <summary>Horizontal right side-rail inset in pixels.</summary>
+    public int RightTileOffsetX { get; set; }
+    /// <summary>Vertical right side-rail offset in pixels.</summary>
+    public int RightTileOffsetY { get; set; }
+    /// <summary>Default tile text fitting policy.</summary>
+    public BgInfoVisualCanvasTileTextFitPolicy TileTextFitPolicy { get; set; }
     /// <summary>Horizontal feature-strip offset. For right anchors, positive values inset from the right edge.</summary>
     public int FeatureOffsetX { get; set; }
     /// <summary>Vertical feature-strip offset. For bottom anchors, positive values inset from the bottom edge.</summary>
@@ -147,6 +197,10 @@ public sealed class BgInfoVisualCanvasTile {
     public string Value { get; set; } = string.Empty;
     /// <summary>Optional detail text. Templates are resolved at render time.</summary>
     public string Detail { get; set; } = string.Empty;
+    /// <summary>Optional tile width in pixels. Zero uses the visual canvas default or template default.</summary>
+    public int Width { get; set; }
+    /// <summary>Optional tile height in pixels. Zero uses the visual canvas default or template default.</summary>
+    public int Height { get; set; }
     /// <summary>Optional tile accent color.</summary>
     public Color? Accent { get; set; }
     /// <summary>Optional progress value from zero to one.</summary>
@@ -157,6 +211,8 @@ public sealed class BgInfoVisualCanvasTile {
     public BgInfoVisualCanvasTileIconKind IconKind { get; set; }
     /// <summary>Compact tile chart kind.</summary>
     public BgInfoVisualCanvasTileMiniChartKind MiniChartKind { get; set; }
+    /// <summary>Tile-specific text fitting policy. Auto inherits the visual canvas setting.</summary>
+    public BgInfoVisualCanvasTileTextFitPolicy TextFitPolicy { get; set; }
     /// <summary>Compact tile chart values.</summary>
     public IReadOnlyList<double> MiniChartValues { get; set; } = System.Array.Empty<double>();
     /// <summary>Optional compact tile chart maximum.</summary>

--- a/Sources/PowerBGInfo/BgInfoVisualCanvasRenderer.cs
+++ b/Sources/PowerBGInfo/BgInfoVisualCanvasRenderer.cs
@@ -45,8 +45,15 @@ internal static class BgInfoVisualCanvasRenderer {
         var scaleX = width / 1200.0;
         var scaleY = height / 630.0;
         var accent = ToChartColor(visual.Accent);
-        AddTiles(canvas, visual.Tiles, BgInfoVisualCanvasSide.Left, 48 * scaleX, 92 * scaleY, 300 * scaleX, 82 * scaleY, 16 * scaleY);
-        AddTiles(canvas, visual.Tiles, BgInfoVisualCanvasSide.Right, 852 * scaleX, 70 * scaleY, 300 * scaleX, 96 * scaleY, 18 * scaleY);
+        var defaultTileWidth = ApplyTileWidthPreset(visual.LayoutPreset, 300 * scaleX);
+        var leftTileWidth = ResolveRailWidth(visual, BgInfoVisualCanvasSide.Left, defaultTileWidth);
+        var rightTileWidth = ResolveRailWidth(visual, BgInfoVisualCanvasSide.Right, defaultTileWidth);
+        var leftTileHeight = ApplyTileHeightPreset(visual.LayoutPreset, 82 * scaleY);
+        var rightTileHeight = ApplyTileHeightPreset(visual.LayoutPreset, 96 * scaleY);
+        var leftGap = ResolveTileGap(visual, ApplyTileGapPreset(visual.LayoutPreset, 16 * scaleY));
+        var rightGap = ResolveTileGap(visual, ApplyTileGapPreset(visual.LayoutPreset, 18 * scaleY));
+        AddTiles(canvas, visual, BgInfoVisualCanvasSide.Left, 48 * scaleX + visual.LeftTileOffsetX, 92 * scaleY + visual.LeftTileOffsetY, leftTileWidth, leftTileHeight, leftGap);
+        AddTiles(canvas, visual, BgInfoVisualCanvasSide.Right, width - 48 * scaleX - rightTileWidth - visual.RightTileOffsetX, 70 * scaleY + visual.RightTileOffsetY, rightTileWidth, rightTileHeight, rightGap);
         AddHeroBadge(canvas, visual, 538 * scaleX, 157 * scaleY, 124 * scaleX, 88 * scaleY, accent);
         canvas
             .AddHeroTitle(312 * scaleX, 296 * scaleY, 576 * scaleX, 82 * scaleY, SplitTitle(Resolve(visual.Title), canvas.Theme))
@@ -67,15 +74,17 @@ internal static class BgInfoVisualCanvasRenderer {
         var accent = ToChartColor(visual.Accent);
         var marginX = Clamp(width * 0.045, Math.Min(24, width * 0.04), Math.Min(132, width * 0.08));
         var railBudget = Math.Max(1, (width - (marginX * 2) - 96) / 2);
-        var tileWidth = Math.Min(Clamp(width * 0.18, Math.Min(180, railBudget), Math.Min(470, railBudget)), railBudget);
-        var tileHeight = Clamp(height * 0.092, Math.Min(56, height * 0.18), Math.Min(106, height * 0.22));
-        var tileGap = Clamp(height * 0.018, Math.Min(8, height * 0.02), Math.Min(24, height * 0.04));
+        var tileWidth = Math.Min(Clamp(ApplyTileWidthPreset(visual.LayoutPreset, width * 0.18), Math.Min(180, railBudget), Math.Min(560, railBudget)), railBudget);
+        var tileHeight = Clamp(ApplyTileHeightPreset(visual.LayoutPreset, height * 0.092), Math.Min(56, height * 0.18), Math.Min(140, height * 0.26));
+        var tileGap = ResolveTileGap(visual, Clamp(ApplyTileGapPreset(visual.LayoutPreset, height * 0.018), Math.Min(8, height * 0.02), Math.Min(28, height * 0.045)));
         var railY = Clamp(height * 0.16, Math.Min(32, height * 0.08), Math.Min(190, height * 0.25));
-        AddTiles(canvas, visual.Tiles, BgInfoVisualCanvasSide.Left, marginX, railY, tileWidth, tileHeight, tileGap);
-        AddTiles(canvas, visual.Tiles, BgInfoVisualCanvasSide.Right, width - marginX - tileWidth, railY, tileWidth, tileHeight, tileGap);
+        var leftTileWidth = ResolveRailWidth(visual, BgInfoVisualCanvasSide.Left, tileWidth);
+        var rightTileWidth = ResolveRailWidth(visual, BgInfoVisualCanvasSide.Right, tileWidth);
+        AddTiles(canvas, visual, BgInfoVisualCanvasSide.Left, marginX + visual.LeftTileOffsetX, railY + visual.LeftTileOffsetY, leftTileWidth, tileHeight, tileGap);
+        AddTiles(canvas, visual, BgInfoVisualCanvasSide.Right, width - marginX - rightTileWidth - visual.RightTileOffsetX, railY + visual.RightTileOffsetY, rightTileWidth, tileHeight, tileGap);
 
-        var centerLeft = marginX + tileWidth + 48;
-        var centerRight = width - marginX - tileWidth - 48;
+        var centerLeft = marginX + leftTileWidth + 48;
+        var centerRight = width - marginX - rightTileWidth - 48;
         var centerWidth = Math.Max(1, centerRight - centerLeft);
         var badgeWidth = Math.Min(centerWidth, Clamp(width * 0.065, Math.Min(64, centerWidth), Math.Min(144, centerWidth)));
         var badgeHeight = Clamp(height * 0.085, Math.Min(42, height * 0.16), Math.Min(100, height * 0.22));
@@ -104,15 +113,18 @@ internal static class BgInfoVisualCanvasRenderer {
         }
     }
 
-    private static void AddTiles(VisualCanvas canvas, IReadOnlyList<BgInfoVisualCanvasTile> tiles, BgInfoVisualCanvasSide side, double x, double y, double width, double height, double gap) {
-        var index = 0;
-        foreach (var tile in tiles) {
+    private static void AddTiles(VisualCanvas canvas, BgInfoVisualCanvas visual, BgInfoVisualCanvasSide side, double x, double y, double width, double height, double gap) {
+        var cursorY = y;
+        foreach (var tile in visual.Tiles) {
             if (tile.Side != side) continue;
+            var tileWidth = ResolveTileWidth(visual, tile, width);
+            var tileHeight = ResolveTileHeight(visual, tile, height);
+            var tileX = side == BgInfoVisualCanvasSide.Right ? x + width - tileWidth : x;
             canvas.AddInfoTile(
-                x,
-                y + index * (height + gap),
-                width,
-                height,
+                tileX,
+                cursorY,
+                tileWidth,
+                tileHeight,
                 Resolve(tile.Icon),
                 Resolve(tile.Label),
                 Resolve(tile.Value),
@@ -123,8 +135,65 @@ internal static class BgInfoVisualCanvasRenderer {
                 MapIconKind(tile.IconKind),
                 MapMiniChartKind(tile.MiniChartKind),
                 tile.MiniChartValues,
-                tile.MiniChartMaximum);
-            index++;
+                tile.MiniChartMaximum,
+                ResolveTextFitPolicy(visual, tile));
+            cursorY += tileHeight + gap;
+        }
+    }
+
+    private static double ResolveRailWidth(BgInfoVisualCanvas visual, BgInfoVisualCanvasSide side, double defaultWidth) {
+        var width = ResolveSideTileWidth(visual, side, defaultWidth);
+        foreach (var tile in visual.Tiles) {
+            if (tile.Side == side && tile.Width > width) width = tile.Width;
+        }
+
+        return width;
+    }
+
+    private static double ResolveTileWidth(BgInfoVisualCanvas visual, BgInfoVisualCanvasTile tile, double defaultWidth) {
+        if (tile.Width > 0) return tile.Width;
+        return ResolveSideTileWidth(visual, tile.Side, defaultWidth);
+    }
+
+    private static double ResolveTileHeight(BgInfoVisualCanvas visual, BgInfoVisualCanvasTile tile, double defaultHeight) {
+        if (tile.Height > 0) return tile.Height;
+        return visual.TileHeight > 0 ? visual.TileHeight : defaultHeight;
+    }
+
+    private static double ResolveSideTileWidth(BgInfoVisualCanvas visual, BgInfoVisualCanvasSide side, double defaultWidth) {
+        if (side == BgInfoVisualCanvasSide.Left && visual.LeftTileWidth > 0) return visual.LeftTileWidth;
+        if (side == BgInfoVisualCanvasSide.Right && visual.RightTileWidth > 0) return visual.RightTileWidth;
+        return visual.TileWidth > 0 ? visual.TileWidth : defaultWidth;
+    }
+
+    private static double ResolveTileGap(BgInfoVisualCanvas visual, double defaultGap) => visual.TileGap > 0 ? visual.TileGap : defaultGap;
+
+    private static double ApplyTileWidthPreset(BgInfoVisualCanvasLayoutPreset preset, double value) {
+        switch (preset) {
+            case BgInfoVisualCanvasLayoutPreset.Compact: return value * 0.86;
+            case BgInfoVisualCanvasLayoutPreset.Comfortable: return value * 1.12;
+            case BgInfoVisualCanvasLayoutPreset.WideRails: return value * 1.28;
+            case BgInfoVisualCanvasLayoutPreset.Dense: return value * 0.92;
+            default: return value;
+        }
+    }
+
+    private static double ApplyTileHeightPreset(BgInfoVisualCanvasLayoutPreset preset, double value) {
+        switch (preset) {
+            case BgInfoVisualCanvasLayoutPreset.Compact: return value * 0.88;
+            case BgInfoVisualCanvasLayoutPreset.Comfortable: return value * 1.18;
+            case BgInfoVisualCanvasLayoutPreset.WideRails: return value * 1.08;
+            case BgInfoVisualCanvasLayoutPreset.Dense: return value * 0.76;
+            default: return value;
+        }
+    }
+
+    private static double ApplyTileGapPreset(BgInfoVisualCanvasLayoutPreset preset, double value) {
+        switch (preset) {
+            case BgInfoVisualCanvasLayoutPreset.Compact: return value * 0.72;
+            case BgInfoVisualCanvasLayoutPreset.Comfortable: return value * 1.22;
+            case BgInfoVisualCanvasLayoutPreset.Dense: return value * 0.55;
+            default: return value;
         }
     }
 
@@ -191,6 +260,17 @@ internal static class BgInfoVisualCanvasRenderer {
             case BgInfoVisualCanvasTileMiniChartKind.Area: return VisualCanvasInfoTileMiniChartKind.Area;
             case BgInfoVisualCanvasTileMiniChartKind.Bars: return VisualCanvasInfoTileMiniChartKind.Bars;
             default: return VisualCanvasInfoTileMiniChartKind.None;
+        }
+    }
+
+    private static VisualCanvasTextFitPolicy ResolveTextFitPolicy(BgInfoVisualCanvas visual, BgInfoVisualCanvasTile tile) {
+        var policy = tile.TextFitPolicy == BgInfoVisualCanvasTileTextFitPolicy.Auto ? visual.TileTextFitPolicy : tile.TextFitPolicy;
+        switch (policy) {
+            case BgInfoVisualCanvasTileTextFitPolicy.SingleLineEllipsis: return VisualCanvasTextFitPolicy.SingleLineEllipsis;
+            case BgInfoVisualCanvasTileTextFitPolicy.Wrap: return VisualCanvasTextFitPolicy.Wrap;
+            case BgInfoVisualCanvasTileTextFitPolicy.ShrinkToFit: return VisualCanvasTextFitPolicy.ShrinkToFit;
+            case BgInfoVisualCanvasTileTextFitPolicy.WrapThenShrink: return VisualCanvasTextFitPolicy.WrapThenShrink;
+            default: return VisualCanvasTextFitPolicy.Auto;
         }
     }
 

--- a/Sources/PowerBGInfo/BgInfoVisualCanvasRenderer.cs
+++ b/Sources/PowerBGInfo/BgInfoVisualCanvasRenderer.cs
@@ -46,14 +46,16 @@ internal static class BgInfoVisualCanvasRenderer {
         var scaleY = height / 630.0;
         var accent = ToChartColor(visual.Accent);
         var defaultTileWidth = ApplyTileWidthPreset(visual.LayoutPreset, 300 * scaleX);
+        var leftDefaultTileWidth = ResolveSideTileWidth(visual, BgInfoVisualCanvasSide.Left, defaultTileWidth);
+        var rightDefaultTileWidth = ResolveSideTileWidth(visual, BgInfoVisualCanvasSide.Right, defaultTileWidth);
         var leftTileWidth = ResolveRailWidth(visual, BgInfoVisualCanvasSide.Left, defaultTileWidth);
         var rightTileWidth = ResolveRailWidth(visual, BgInfoVisualCanvasSide.Right, defaultTileWidth);
         var leftTileHeight = ApplyTileHeightPreset(visual.LayoutPreset, 82 * scaleY);
         var rightTileHeight = ApplyTileHeightPreset(visual.LayoutPreset, 96 * scaleY);
         var leftGap = ResolveTileGap(visual, ApplyTileGapPreset(visual.LayoutPreset, 16 * scaleY));
         var rightGap = ResolveTileGap(visual, ApplyTileGapPreset(visual.LayoutPreset, 18 * scaleY));
-        AddTiles(canvas, visual, BgInfoVisualCanvasSide.Left, 48 * scaleX + visual.LeftTileOffsetX, 92 * scaleY + visual.LeftTileOffsetY, leftTileWidth, leftTileHeight, leftGap);
-        AddTiles(canvas, visual, BgInfoVisualCanvasSide.Right, width - 48 * scaleX - rightTileWidth - visual.RightTileOffsetX, 70 * scaleY + visual.RightTileOffsetY, rightTileWidth, rightTileHeight, rightGap);
+        AddTiles(canvas, visual, BgInfoVisualCanvasSide.Left, 48 * scaleX + visual.LeftTileOffsetX, 92 * scaleY + visual.LeftTileOffsetY, leftTileWidth, leftDefaultTileWidth, leftTileHeight, leftGap);
+        AddTiles(canvas, visual, BgInfoVisualCanvasSide.Right, width - 48 * scaleX - rightTileWidth - visual.RightTileOffsetX, 70 * scaleY + visual.RightTileOffsetY, rightTileWidth, rightDefaultTileWidth, rightTileHeight, rightGap);
         AddHeroBadge(canvas, visual, 538 * scaleX, 157 * scaleY, 124 * scaleX, 88 * scaleY, accent);
         canvas
             .AddHeroTitle(312 * scaleX, 296 * scaleY, 576 * scaleX, 82 * scaleY, SplitTitle(Resolve(visual.Title), canvas.Theme))
@@ -72,20 +74,12 @@ internal static class BgInfoVisualCanvasRenderer {
 
     private static void BuildPowerBgInfoOverlay(VisualCanvas canvas, BgInfoVisualCanvas visual, int width, int height) {
         var accent = ToChartColor(visual.Accent);
-        var marginX = Clamp(width * 0.045, Math.Min(24, width * 0.04), Math.Min(132, width * 0.08));
-        var railBudget = Math.Max(1, (width - (marginX * 2) - 96) / 2);
-        var tileWidth = Math.Min(Clamp(ApplyTileWidthPreset(visual.LayoutPreset, width * 0.18), Math.Min(180, railBudget), Math.Min(560, railBudget)), railBudget);
-        var tileHeight = Clamp(ApplyTileHeightPreset(visual.LayoutPreset, height * 0.092), Math.Min(56, height * 0.18), Math.Min(140, height * 0.26));
-        var tileGap = ResolveTileGap(visual, Clamp(ApplyTileGapPreset(visual.LayoutPreset, height * 0.018), Math.Min(8, height * 0.02), Math.Min(28, height * 0.045)));
-        var railY = Clamp(height * 0.16, Math.Min(32, height * 0.08), Math.Min(190, height * 0.25));
-        var leftTileWidth = ResolveRailWidth(visual, BgInfoVisualCanvasSide.Left, tileWidth);
-        var rightTileWidth = ResolveRailWidth(visual, BgInfoVisualCanvasSide.Right, tileWidth);
-        AddTiles(canvas, visual, BgInfoVisualCanvasSide.Left, marginX + visual.LeftTileOffsetX, railY + visual.LeftTileOffsetY, leftTileWidth, tileHeight, tileGap);
-        AddTiles(canvas, visual, BgInfoVisualCanvasSide.Right, width - marginX - rightTileWidth - visual.RightTileOffsetX, railY + visual.RightTileOffsetY, rightTileWidth, tileHeight, tileGap);
+        var layout = ResolveOverlayRailLayout(visual, width, height);
+        AddTiles(canvas, visual, BgInfoVisualCanvasSide.Left, layout.LeftRailX, layout.RailY + visual.LeftTileOffsetY, layout.LeftRailWidth, layout.LeftTileWidth, layout.TileHeight, layout.TileGap);
+        AddTiles(canvas, visual, BgInfoVisualCanvasSide.Right, layout.RightRailX, layout.RailY + visual.RightTileOffsetY, layout.RightRailWidth, layout.RightTileWidth, layout.TileHeight, layout.TileGap);
 
-        var centerLeft = marginX + leftTileWidth + 48;
-        var centerRight = width - marginX - rightTileWidth - 48;
-        var centerWidth = Math.Max(1, centerRight - centerLeft);
+        var centerLeft = layout.CenterLeft;
+        var centerWidth = layout.CenterWidth;
         var badgeWidth = Math.Min(centerWidth, Clamp(width * 0.065, Math.Min(64, centerWidth), Math.Min(144, centerWidth)));
         var badgeHeight = Clamp(height * 0.085, Math.Min(42, height * 0.16), Math.Min(100, height * 0.22));
         var badgeY = Clamp(height * 0.23, Math.Min(24, height * 0.08), Math.Max(24, height - badgeHeight - 24));
@@ -113,11 +107,11 @@ internal static class BgInfoVisualCanvasRenderer {
         }
     }
 
-    private static void AddTiles(VisualCanvas canvas, BgInfoVisualCanvas visual, BgInfoVisualCanvasSide side, double x, double y, double width, double height, double gap) {
+    private static void AddTiles(VisualCanvas canvas, BgInfoVisualCanvas visual, BgInfoVisualCanvasSide side, double x, double y, double width, double defaultTileWidth, double height, double gap) {
         var cursorY = y;
         foreach (var tile in visual.Tiles) {
             if (tile.Side != side) continue;
-            var tileWidth = ResolveTileWidth(visual, tile, width);
+            var tileWidth = ResolveTileWidth(visual, tile, defaultTileWidth);
             var tileHeight = ResolveTileHeight(visual, tile, height);
             var tileX = side == BgInfoVisualCanvasSide.Right ? x + width - tileWidth : x;
             canvas.AddInfoTile(
@@ -167,6 +161,57 @@ internal static class BgInfoVisualCanvasRenderer {
     }
 
     private static double ResolveTileGap(BgInfoVisualCanvas visual, double defaultGap) => visual.TileGap > 0 ? visual.TileGap : defaultGap;
+
+    internal static (double X, double Y, double Width, double Height) ResolveDefaultTransparentCenterBounds(BgInfoVisualCanvas visual, int width, int height) {
+        var layout = ResolveOverlayRailLayout(visual, width, height);
+        return (layout.CenterLeft, layout.RailY, layout.CenterWidth, height - layout.RailY);
+    }
+
+    private static OverlayRailLayout ResolveOverlayRailLayout(BgInfoVisualCanvas visual, int width, int height) {
+        var marginX = Clamp(width * 0.045, Math.Min(24, width * 0.04), Math.Min(132, width * 0.08));
+        var railBudget = Math.Max(1, (width - (marginX * 2) - 96) / 2);
+        var templateTileWidth = Math.Min(Clamp(ApplyTileWidthPreset(visual.LayoutPreset, width * 0.18), Math.Min(180, railBudget), Math.Min(560, railBudget)), railBudget);
+        var tileHeight = Clamp(ApplyTileHeightPreset(visual.LayoutPreset, height * 0.092), Math.Min(56, height * 0.18), Math.Min(140, height * 0.26));
+        var tileGap = ResolveTileGap(visual, Clamp(ApplyTileGapPreset(visual.LayoutPreset, height * 0.018), Math.Min(8, height * 0.02), Math.Min(28, height * 0.045)));
+        var railY = Clamp(height * 0.16, Math.Min(32, height * 0.08), Math.Min(190, height * 0.25));
+        var leftTileWidth = ResolveSideTileWidth(visual, BgInfoVisualCanvasSide.Left, templateTileWidth);
+        var rightTileWidth = ResolveSideTileWidth(visual, BgInfoVisualCanvasSide.Right, templateTileWidth);
+        var leftRailWidth = ResolveRailWidth(visual, BgInfoVisualCanvasSide.Left, templateTileWidth);
+        var rightRailWidth = ResolveRailWidth(visual, BgInfoVisualCanvasSide.Right, templateTileWidth);
+        var leftRailX = marginX + visual.LeftTileOffsetX;
+        var rightRailX = width - marginX - rightRailWidth - visual.RightTileOffsetX;
+        var centerLeft = leftRailX + leftRailWidth + 48;
+        var centerRight = rightRailX - 48;
+        return new OverlayRailLayout(leftRailX, rightRailX, railY, leftRailWidth, rightRailWidth, leftTileWidth, rightTileWidth, tileHeight, tileGap, centerLeft, Math.Max(1, centerRight - centerLeft));
+    }
+
+    private readonly struct OverlayRailLayout {
+        public OverlayRailLayout(double leftRailX, double rightRailX, double railY, double leftRailWidth, double rightRailWidth, double leftTileWidth, double rightTileWidth, double tileHeight, double tileGap, double centerLeft, double centerWidth) {
+            LeftRailX = leftRailX;
+            RightRailX = rightRailX;
+            RailY = railY;
+            LeftRailWidth = leftRailWidth;
+            RightRailWidth = rightRailWidth;
+            LeftTileWidth = leftTileWidth;
+            RightTileWidth = rightTileWidth;
+            TileHeight = tileHeight;
+            TileGap = tileGap;
+            CenterLeft = centerLeft;
+            CenterWidth = centerWidth;
+        }
+
+        public double LeftRailX { get; }
+        public double RightRailX { get; }
+        public double RailY { get; }
+        public double LeftRailWidth { get; }
+        public double RightRailWidth { get; }
+        public double LeftTileWidth { get; }
+        public double RightTileWidth { get; }
+        public double TileHeight { get; }
+        public double TileGap { get; }
+        public double CenterLeft { get; }
+        public double CenterWidth { get; }
+    }
 
     private static double ApplyTileWidthPreset(BgInfoVisualCanvasLayoutPreset preset, double value) {
         switch (preset) {

--- a/Sources/PowerBGInfo/PowerBGInfo.csproj
+++ b/Sources/PowerBGInfo/PowerBGInfo.csproj
@@ -24,7 +24,7 @@
         <ProjectReference Include="$(ChartForgeXProjectPath)" />
     </ItemGroup>
     <ItemGroup Condition="'$(ChartForgeXProjectPath)' == ''">
-        <PackageReference Include="ChartForgeX" Version="0.1.4" />
+        <PackageReference Include="ChartForgeX" Version="0.1.9" />
     </ItemGroup>
     <ItemGroup>
         <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">


### PR DESCRIPTION
## Summary
- fix EvotecIT/PowerBGInfo#52 by adding visual canvas tile sizing, rail, spacing, and text-fit controls
- expose layout presets plus left/right rail width and offset options in the PowerShell cmdlets
- persist the new visual canvas fields through JSON save/load
- update the contrast-box example to show wide rails and wrap-then-shrink tile text
- fix script-mode CLI loading when authoring scripts import the development module manifest directly
- consume the released `ChartForgeX` 0.1.9 package for default package builds

## Dependency
- Uses the released `ChartForgeX` 0.1.9 package, which contains the shared text-fit policy and layout diagnostics API from EvotecIT/ChartForgeX#100.

## Validation
- `dotnet test .\Sources\PowerBGInfo.sln -c Release`
- `Invoke-Pester -Path .\Sources\PowerBGInfo.Tests\Cmdlet.Tests.ps1 -Output Detailed`