### PR TITLE
Use direct ChartForgeX RGBA rendering

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,9 @@ updates:
     open-pull-requests-limit: 10
     ignore:
       - dependency-name: "ChartForgeX"
+      - dependency-name: "System.Management"
+        update-types:
+          - "version-update:semver-major"
     groups:
       nuget-minor-patch:
         applies-to: version-updates

--- a/.github/workflows/test-dotnet.yml
+++ b/.github/workflows/test-dotnet.yml
@@ -61,6 +61,11 @@ jobs:
           $config.ConfigurationDirectory = $outputDir
           $config.OutputFileName = 'interop.png'
           $config.Entries.Add((New-BGInfoValue -BuiltinValue HostName))
+          $osEntry = New-BGInfoValue -BuiltinValue OSName
+          if ([string]::IsNullOrWhiteSpace($osEntry.Value)) {
+              throw 'Expected the PowerShell host to resolve the WMI-backed OSName value.'
+          }
+          $config.Entries.Add($osEntry)
           Export-BGInfoConfiguration -InputObject $config -Path $configPath -Force
           if (-not (Test-Path -LiteralPath $configPath)) {
               throw "Expected exported config at $configPath"

--- a/Sources/PowerBGInfo.Tests/Cmdlet.Tests.ps1
+++ b/Sources/PowerBGInfo.Tests/Cmdlet.Tests.ps1
@@ -46,6 +46,13 @@ Describe 'New-BGInfoValue cmdlet' {
         $entry.BuiltinValue | Should -Be 'HostName'
     }
 
+    It 'resolves WMI-backed builtin values in the PowerShell host' {
+        $entry = New-BGInfoValue -BuiltinValue 'OSName'
+        $entry.Name | Should -Be 'OSName'
+        $entry.Value | Should -Not -BeNullOrEmpty
+        $entry.BuiltinValue | Should -Be 'OSName'
+    }
+
     It 'creates template entries for foreach variables' {
         $entry = New-BGInfoValue -ForEach 'Volumes' -Name 'Drive {{DriveLetter}}' -Value '{{SizeRemaining}}'
         $entry.ForEach | Should -Be 'Volumes'

--- a/Sources/PowerBGInfo/BgInfoChartRenderer.cs
+++ b/Sources/PowerBGInfo/BgInfoChartRenderer.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using ChartForgeX;
 using ChartForgeX.Core;
 using ChartForgeX.Primitives;
-using ChartForgeX.Raster;
 using ChartForgeX.Themes;
 using ChartForgeX.Typography;
 
@@ -60,7 +59,7 @@ internal static class BgInfoChartRenderer {
         }
 
         var plot = BuildChartForgeXChart(chart, values, config, (int)Math.Round(plotWidth), (int)Math.Round(plotHeight));
-        DrawPng(image, plot.ToPng(), plotLeft, plotTop, plotWidth, plotHeight);
+        image.DrawImage(plot.ToRgbaImage(), plotLeft, plotTop, plotWidth, plotHeight);
         return image;
     }
 
@@ -309,10 +308,6 @@ internal static class BgInfoChartRenderer {
             default:
                 return ChartPictorialShape.Circle;
         }
-    }
-
-    private static void DrawPng(BgInfoRasterImage image, byte[] png, double x, double y, double width, double height) {
-        image.DrawImage(RasterImageDecoder.Decode(png), x, y, width, height);
     }
 
     private static ChartColor WithAlpha(ChartColor color, byte alpha) => ChartColor.FromRgba(color.R, color.G, color.B, alpha);

--- a/Sources/PowerBGInfo/BgInfoTopologyRenderer.cs
+++ b/Sources/PowerBGInfo/BgInfoTopologyRenderer.cs
@@ -1,6 +1,5 @@
 using System;
 using Color = ChartForgeX.Primitives.ChartColor;
-using ChartForgeX.Raster;
 using ChartForgeX.Topology;
 
 namespace PowerBGInfo;
@@ -21,7 +20,7 @@ internal static class BgInfoTopologyRenderer {
 
         var image = new BgInfoRasterImage();
         image.Create(string.Empty, width, height, Color.Transparent);
-        DrawPng(image, chart.ToPng(options), 0, 0, width, height);
+        image.DrawImage(chart.ToRgbaImage(options), 0, 0, width, height);
         return image;
     }
 
@@ -73,7 +72,4 @@ internal static class BgInfoTopologyRenderer {
         return theme;
     }
 
-    private static void DrawPng(BgInfoRasterImage image, byte[] png, double x, double y, double width, double height) {
-        image.DrawImage(RasterImageDecoder.Decode(png), x, y, width, height);
-    }
 }

--- a/Sources/PowerBGInfo/BgInfoVisualCanvasRenderer.cs
+++ b/Sources/PowerBGInfo/BgInfoVisualCanvasRenderer.cs
@@ -5,7 +5,6 @@ using System.IO;
 using ChartForgeX;
 using ChartForgeX.Composition;
 using ChartForgeX.Primitives;
-using ChartForgeX.Raster;
 using ChartForgeX.Typography;
 
 namespace PowerBGInfo;
@@ -18,7 +17,7 @@ internal static class BgInfoVisualCanvasRenderer {
         var chartCanvas = BuildCanvas(visual, width, height);
         var image = new BgInfoRasterImage();
         image.Create(string.Empty, width, height, Color.Transparent);
-        DrawPng(image, chartCanvas.ToPng(), 0, 0, width, height);
+        image.DrawImage(chartCanvas.ToRgbaImage(), 0, 0, width, height);
         return image;
     }
 
@@ -390,7 +389,4 @@ internal static class BgInfoVisualCanvasRenderer {
         return Math.Max(min, Math.Min(max, value));
     }
 
-    private static void DrawPng(BgInfoRasterImage image, byte[] png, double x, double y, double width, double height) {
-        image.DrawImage(RasterImageDecoder.Decode(png), x, y, width, height);
-    }
 }

--- a/Sources/PowerBGInfo/PowerBGInfo.csproj
+++ b/Sources/PowerBGInfo/PowerBGInfo.csproj
@@ -11,7 +11,7 @@
         <Nullable>enable</Nullable>
         <LangVersion>Latest</LangVersion>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
-        <ChartForgeXVersion>1.0.0</ChartForgeXVersion>
+        <ChartForgeXVersion>1.0.3</ChartForgeXVersion>
     </PropertyGroup>
     <PropertyGroup Condition="'$(PublishAot)' == 'true'">
         <TargetFrameworks>net8.0-windows</TargetFrameworks>
@@ -32,7 +32,10 @@
         </AssemblyAttribute>
     </ItemGroup>
     <ItemGroup Condition="'$(TargetFramework)' != 'net472'">
-        <PackageReference Include="System.Management" Version="10.0.10" />
+        <!-- Keep the reference identity at the .NET 8 contract so PowerShell 7 hosts can satisfy it
+             with their already-loaded System.Management assembly. Newer compile-time identities fail
+             in older hosts before PowerBGInfo can execute its WMI-backed built-in values. -->
+        <PackageReference Include="System.Management" Version="8.0.0" />
     </ItemGroup>
     <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
         <Reference Include="System.Management" />


### PR DESCRIPTION
## What changed

- consumes ChartForgeX 1.0.3 and renders charts, topology, and visual canvases through direct RGBA surfaces
- removes the PNG encode/decode round-trip from PowerBGInfo composition paths
- restores the .NET 8 `System.Management` reference identity required by hosted PowerShell 7 runtimes and prevents automatic major upgrades from reintroducing the load-context break
- adds a real WMI-backed PowerShell-host regression to both the focused suite and CI interop path

## Compatibility

- no PowerShell command, parameter, manifest, or public behavior changes
- the deliberate ApexCharts version/licensing pin is untouched
- Windows PowerShell 5.1 continues to use the .NET Framework `System.Management` reference

## Validation

- full Release validator passed from a clean nuget.org-only restore of public ChartForgeX 1.0.3
- 41/41 PowerShell/cmdlet/CLI interoperability tests passed, including WMI-backed `OSName`
- script, JSON, and PowerShell rendering remained pixel-equivalent
- normal CLI, single-file CLI, and NativeAOT file-generation paths passed
- Windows PowerShell 5.1 smoke passed and package audit found no vulnerable direct or transitive packages
- independent local review found no actionable issues