### PR TITLE
Adopt shared adaptive ChartForgeX rendering

### DIFF
--- a/Build/Validate-PowerBGInfo.ps1
+++ b/Build/Validate-PowerBGInfo.ps1
@@ -101,8 +101,8 @@ try {
     Assert-NativeCommandSucceeded -ExitCode $LASTEXITCODE -Description 'Solution test run'
 
     $pesterResult = Invoke-Pester -Path (Join-Path -Path $repositoryRoot -ChildPath 'Sources\PowerBGInfo.Tests\Cmdlet.Tests.ps1') -Output Detailed -PassThru
-    if ($pesterResult.FailedCount -gt 0) {
-        throw "$($pesterResult.FailedCount) PowerBGInfo Pester test(s) failed."
+    if ($pesterResult.Result -ne 'Passed') {
+        throw "PowerBGInfo Pester validation failed with result '$($pesterResult.Result)' (tests: $($pesterResult.FailedCount), blocks: $($pesterResult.FailedBlocksCount), containers: $($pesterResult.FailedContainersCount))."
     }
 
     Assert-PathExists -Path $modulePath -Description 'PowerBGInfo.PowerShell module'

--- a/Build/Validate-PowerBGInfo.ps1
+++ b/Build/Validate-PowerBGInfo.ps1
@@ -20,6 +20,17 @@ function Assert-PathExists {
     }
 }
 
+function Assert-NativeCommandSucceeded {
+    param(
+        [int] $ExitCode,
+        [string] $Description
+    )
+
+    if ($ExitCode -ne 0) {
+        throw "$Description failed with exit code $ExitCode."
+    }
+}
+
 function Get-ImagePixelHash {
     param(
         [string] $Path
@@ -77,25 +88,35 @@ $singleFileOutputPath = Join-Path -Path $renderDirectory -ChildPath 'singlefile.
 $aotOutputPath = Join-Path -Path $renderDirectory -ChildPath 'aot.png'
 $singleFileDirectory = Join-Path -Path $validationRoot -ChildPath 'cli-singlefile'
 $aotDirectory = Join-Path -Path $validationRoot -ChildPath 'cli-aot'
+$hadDevelopmentConfiguration = Test-Path -LiteralPath Env:PowerBGInfoDevelopmentConfiguration
+$previousDevelopmentConfiguration = $Env:PowerBGInfoDevelopmentConfiguration
 
 try {
+    $Env:PowerBGInfoDevelopmentConfiguration = $Configuration
     New-Item -ItemType Directory -Path $renderDirectory -Force | Out-Null
 
     dotnet build $solutionPath -c $Configuration | Out-Null
+    Assert-NativeCommandSucceeded -ExitCode $LASTEXITCODE -Description 'Solution build'
     dotnet test $solutionPath -c $Configuration --no-build | Out-Null
+    Assert-NativeCommandSucceeded -ExitCode $LASTEXITCODE -Description 'Solution test run'
 
-    Invoke-Pester -Path (Join-Path -Path $repositoryRoot -ChildPath 'Sources\PowerBGInfo.Tests\Cmdlet.Tests.ps1') -Output Detailed | Out-Null
+    $pesterResult = Invoke-Pester -Path (Join-Path -Path $repositoryRoot -ChildPath 'Sources\PowerBGInfo.Tests\Cmdlet.Tests.ps1') -Output Detailed -PassThru
+    if ($pesterResult.FailedCount -gt 0) {
+        throw "$($pesterResult.FailedCount) PowerBGInfo Pester test(s) failed."
+    }
 
     Assert-PathExists -Path $modulePath -Description 'PowerBGInfo.PowerShell module'
     Assert-PathExists -Path $cliPath -Description 'PowerBGInfo CLI'
     Assert-PathExists -Path $validationScriptPath -Description 'validation script'
 
     & $cliPath --script $validationScriptPath --module $modulePath --directory $renderDirectory --output (Split-Path -Path $scriptOutputPath -Leaf) --export-json $validationJsonPath --no-apply | Out-Null
+    Assert-NativeCommandSucceeded -ExitCode $LASTEXITCODE -Description 'Script-backed CLI validation'
 
     Assert-PathExists -Path $scriptOutputPath -Description 'script-backed CLI output'
     Assert-PathExists -Path $validationJsonPath -Description 'exported validation json'
 
     & $cliPath --config $validationJsonPath --directory $renderDirectory --output (Split-Path -Path $jsonOutputPath -Leaf) --no-apply | Out-Null
+    Assert-NativeCommandSucceeded -ExitCode $LASTEXITCODE -Description 'JSON-backed CLI validation'
     Assert-PathExists -Path $jsonOutputPath -Description 'json-backed CLI output'
 
     @"
@@ -104,6 +125,7 @@ Invoke-BGInfo -Path '$($validationJsonPath.Replace("'", "''"))' -ConfigurationDi
 "@ | Set-Content -LiteralPath $powerShellRunnerPath -Encoding UTF8
 
     pwsh -NoLogo -NoProfile -File $powerShellRunnerPath | Out-Null
+    Assert-NativeCommandSucceeded -ExitCode $LASTEXITCODE -Description 'PowerShell module validation'
     Assert-PathExists -Path $powerShellOutputPath -Description 'Invoke-BGInfo output'
 
     Assert-ImageEquivalent -ReferencePath $scriptOutputPath -CandidatePath $jsonOutputPath -Description 'CLI script vs CLI json'
@@ -111,18 +133,22 @@ Invoke-BGInfo -Path '$($validationJsonPath.Replace("'", "''"))' -ConfigurationDi
 
     if (-not $SkipPublishSingleFile.IsPresent) {
         dotnet publish $cliProjectPath -c $Configuration -f net8.0-windows -r win-x64 --self-contained false -p:PublishSingleFile=true -o $singleFileDirectory | Out-Null
+        Assert-NativeCommandSucceeded -ExitCode $LASTEXITCODE -Description 'Single-file CLI publish'
         $singleFileCliPath = Join-Path -Path $singleFileDirectory -ChildPath 'PowerBGInfo.Cli.exe'
         Assert-PathExists -Path $singleFileCliPath -Description 'single-file CLI'
         & $singleFileCliPath --config $validationJsonPath --directory $renderDirectory --output (Split-Path -Path $singleFileOutputPath -Leaf) --no-apply | Out-Null
+        Assert-NativeCommandSucceeded -ExitCode $LASTEXITCODE -Description 'Single-file CLI validation'
         Assert-PathExists -Path $singleFileOutputPath -Description 'single-file CLI output'
         Assert-ImageEquivalent -ReferencePath $jsonOutputPath -CandidatePath $singleFileOutputPath -Description 'single-file CLI vs normal CLI'
     }
 
     if (-not $SkipPublishAot.IsPresent) {
         dotnet publish $cliProjectPath -c $Configuration -f net8.0-windows -r win-x64 -p:PublishAot=true -o $aotDirectory | Out-Null
+        Assert-NativeCommandSucceeded -ExitCode $LASTEXITCODE -Description 'NativeAOT CLI publish'
         $aotCliPath = Join-Path -Path $aotDirectory -ChildPath 'PowerBGInfo.Cli.exe'
         Assert-PathExists -Path $aotCliPath -Description 'NativeAOT CLI'
         & $aotCliPath --config $validationJsonPath --directory $renderDirectory --output (Split-Path -Path $aotOutputPath -Leaf) --no-apply | Out-Null
+        Assert-NativeCommandSucceeded -ExitCode $LASTEXITCODE -Description 'NativeAOT CLI validation'
         Assert-PathExists -Path $aotOutputPath -Description 'NativeAOT CLI output'
         if ((Get-ImagePixelHash -Path $jsonOutputPath) -ne (Get-ImagePixelHash -Path $aotOutputPath)) {
             Write-Warning 'NativeAOT CLI output differs from the normal CLI output on this machine. NativeAOT remains a smoke-tested file-generation path rather than a strict parity path.'
@@ -144,6 +170,11 @@ Invoke-BGInfo -Path '$($validationJsonPath.Replace("'", "''"))' -ConfigurationDi
         Write-Host "Artifacts kept at : $validationRoot"
     }
 } finally {
+    if ($hadDevelopmentConfiguration) {
+        $Env:PowerBGInfoDevelopmentConfiguration = $previousDevelopmentConfiguration
+    } else {
+        Remove-Item -LiteralPath Env:PowerBGInfoDevelopmentConfiguration -ErrorAction SilentlyContinue
+    }
     if (-not $KeepArtifacts.IsPresent -and (Test-Path -LiteralPath $validationRoot)) {
         Remove-Item -LiteralPath $validationRoot -Recurse -Force
     }

--- a/PowerBGInfo.psd1
+++ b/PowerBGInfo.psd1
@@ -9,7 +9,7 @@
     DotNetFrameworkVersion = '4.7.2'
     FunctionsToExport      = @()
     GUID                   = '91b9c52d-6a39-4a65-a276-409b9390ee04'
-    ModuleVersion          = '2.0.0'
+    ModuleVersion          = '2.0.1'
     PowerShellVersion      = '5.1'
     PrivateData            = @{
         PSData = @{

--- a/PowerBGInfo.psm1
+++ b/PowerBGInfo.psm1
@@ -1,6 +1,13 @@
 ﻿# to speed up development adding direct path to binaries, instead of the the Lib folder
 $Development = $true
-$DevelopmentPath = "$PSScriptRoot\Sources\PowerBGInfo.PowerShell\bin\Debug"
+$DevelopmentConfiguration = if ([string]::IsNullOrWhiteSpace($Env:PowerBGInfoDevelopmentConfiguration)) {
+    'Debug'
+} elseif ($Env:PowerBGInfoDevelopmentConfiguration -in @('Debug', 'Release')) {
+    $Env:PowerBGInfoDevelopmentConfiguration
+} else {
+    throw "PowerBGInfoDevelopmentConfiguration must be Debug or Release. Received '$Env:PowerBGInfoDevelopmentConfiguration'."
+}
+$DevelopmentPath = "$PSScriptRoot\Sources\PowerBGInfo.PowerShell\bin\$DevelopmentConfiguration"
 $DevelopmentFolderCore = "net8.0-windows"
 $DevelopmentFolderDefault = "net472"
 $BinaryModules = @(

--- a/Sources/PowerBGInfo.PowerShell/PowerBGInfo.PowerShell.csproj
+++ b/Sources/PowerBGInfo.PowerShell/PowerBGInfo.PowerShell.csproj
@@ -7,7 +7,7 @@
         <Description>PowerShell module for generating BGInfo-style desktop overlays on Windows.</Description>
         <AssemblyName>PowerBGInfo.PowerShell</AssemblyName>
         <AssemblyTitle>PowerBGInfo.PowerShell</AssemblyTitle>
-        <VersionPrefix>2.0.0</VersionPrefix>
+        <VersionPrefix>2.0.1</VersionPrefix>
         <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
         <Company>Evotec</Company>
         <Authors>Przemyslaw Klys</Authors>

--- a/Sources/PowerBGInfo.Tests/BgInfoChartRendererTests.cs
+++ b/Sources/PowerBGInfo.Tests/BgInfoChartRendererTests.cs
@@ -1,0 +1,83 @@
+using ChartForgeX.Core;
+
+namespace PowerBGInfo.Tests;
+
+public class BgInfoChartRendererTests
+{
+    [Theory]
+    [InlineData(BgInfoChartKind.Line, false)]
+    [InlineData(BgInfoChartKind.Area, true)]
+    [InlineData(BgInfoChartKind.Sparkline, true)]
+    public void DenseTrendSeriesUseWidthAwareDecimationWithoutChangingTheirStyle(BgInfoChartKind kind, bool expectedSmooth)
+    {
+        const int sourcePointCount = 10_000;
+        const int spikeIndex = sourcePointCount / 2;
+        var values = new double[sourcePointCount];
+        values[spikeIndex] = 1000;
+        var chart = new BgInfoChart {
+            Kind = kind,
+            Width = 240,
+            Height = 90
+        };
+
+        var rendered = BgInfoChartRenderer.BuildChartForgeXChart(chart, values, new BgInfoConfiguration(), chart.Width, chart.Height);
+
+        var series = Assert.Single(rendered.Series);
+        Assert.True(series.IsDecimated);
+        Assert.Equal(sourcePointCount, series.SourcePointCount);
+        Assert.Equal(ChartDecimationMode.LargestTriangleThreeBuckets, series.DecimationMode);
+        Assert.True(series.Points.Count <= BgInfoChartRenderer.ResolveTrendPointBudget(chart.Width));
+        Assert.Equal(0, series.SourcePointIndices[0]);
+        Assert.Equal(sourcePointCount - 1, series.SourcePointIndices[series.SourcePointIndices.Count - 1]);
+        Assert.Contains(spikeIndex, series.SourcePointIndices);
+        Assert.Equal(expectedSmooth, series.Smooth);
+    }
+
+    [Fact]
+    public void DenseCategoricalSeriesKeepEveryExactValue()
+    {
+        var values = Enumerable.Range(0, 2_000).Select(value => (double)value).ToArray();
+        var chart = new BgInfoChart {
+            Kind = BgInfoChartKind.Bar,
+            Width = 240,
+            Height = 90
+        };
+
+        var rendered = BgInfoChartRenderer.BuildChartForgeXChart(chart, values, new BgInfoConfiguration(), chart.Width, chart.Height);
+
+        var series = Assert.Single(rendered.Series);
+        Assert.False(series.IsDecimated);
+        Assert.Null(series.DecimationMode);
+        Assert.Equal(values.Length, series.Points.Count);
+        Assert.Equal(values.Length, series.SourcePointCount);
+    }
+
+    [Fact]
+    public void ShortTrendSeriesKeepEveryExactValue()
+    {
+        var values = Enumerable.Range(0, 30).Select(value => Math.Sin(value / 3d)).ToArray();
+        var chart = new BgInfoChart {
+            Kind = BgInfoChartKind.Area,
+            Width = 240,
+            Height = 90
+        };
+
+        var rendered = BgInfoChartRenderer.BuildChartForgeXChart(chart, values, new BgInfoConfiguration(), chart.Width, chart.Height);
+
+        var series = Assert.Single(rendered.Series);
+        Assert.False(series.IsDecimated);
+        Assert.Null(series.DecimationMode);
+        Assert.Equal(values.Length, series.Points.Count);
+        Assert.True(series.Smooth);
+    }
+
+    [Theory]
+    [InlineData(-10, 64)]
+    [InlineData(1, 64)]
+    [InlineData(240, 480)]
+    [InlineData(int.MaxValue, int.MaxValue)]
+    public void TrendPointBudgetIsBoundedAndWidthAware(int width, int expected)
+    {
+        Assert.Equal(expected, BgInfoChartRenderer.ResolveTrendPointBudget(width));
+    }
+}

--- a/Sources/PowerBGInfo.Tests/BgInfoChartRendererTests.cs
+++ b/Sources/PowerBGInfo.Tests/BgInfoChartRendererTests.cs
@@ -26,7 +26,7 @@ public class BgInfoChartRendererTests
         Assert.True(series.IsDecimated);
         Assert.Equal(sourcePointCount, series.SourcePointCount);
         Assert.Equal(ChartDecimationMode.LargestTriangleThreeBuckets, series.DecimationMode);
-        Assert.True(series.Points.Count <= BgInfoChartRenderer.ResolveTrendPointBudget(chart.Width));
+        Assert.True(series.Points.Count <= ChartResolutionPolicy.Trend().ResolvePointBudget(chart.Width));
         Assert.Equal(0, series.SourcePointIndices[0]);
         Assert.Equal(sourcePointCount - 1, series.SourcePointIndices[series.SourcePointIndices.Count - 1]);
         Assert.Contains(spikeIndex, series.SourcePointIndices);
@@ -69,15 +69,5 @@ public class BgInfoChartRendererTests
         Assert.Null(series.DecimationMode);
         Assert.Equal(values.Length, series.Points.Count);
         Assert.True(series.Smooth);
-    }
-
-    [Theory]
-    [InlineData(-10, 64)]
-    [InlineData(1, 64)]
-    [InlineData(240, 480)]
-    [InlineData(int.MaxValue, int.MaxValue)]
-    public void TrendPointBudgetIsBoundedAndWidthAware(int width, int expected)
-    {
-        Assert.Equal(expected, BgInfoChartRenderer.ResolveTrendPointBudget(width));
     }
 }

--- a/Sources/PowerBGInfo.Tests/Cmdlet.Tests.ps1
+++ b/Sources/PowerBGInfo.Tests/Cmdlet.Tests.ps1
@@ -1,10 +1,15 @@
-$modulePath = Join-Path -Path $PSScriptRoot -ChildPath '..\PowerBGInfo.PowerShell\bin\Debug\net8.0-windows\PowerBGInfo.PowerShell.dll'
+$discoveryConfiguration = if ([string]::IsNullOrWhiteSpace($Env:PowerBGInfoDevelopmentConfiguration)) { 'Debug' } else { $Env:PowerBGInfoDevelopmentConfiguration }
+$discoveryFallbackConfiguration = if ($discoveryConfiguration -eq 'Debug') { 'Release' } else { 'Debug' }
+$modulePath = Join-Path -Path $PSScriptRoot -ChildPath "..\PowerBGInfo.PowerShell\bin\$discoveryConfiguration\net8.0-windows\PowerBGInfo.PowerShell.dll"
 if (-not (Test-Path -LiteralPath $modulePath)) {
-    $modulePath = Join-Path -Path $PSScriptRoot -ChildPath '..\PowerBGInfo.PowerShell\bin\Release\net8.0-windows\PowerBGInfo.PowerShell.dll'
+    $modulePath = Join-Path -Path $PSScriptRoot -ChildPath "..\PowerBGInfo.PowerShell\bin\$discoveryFallbackConfiguration\net8.0-windows\PowerBGInfo.PowerShell.dll"
 }
 Import-Module -Name $modulePath -Force
 
 BeforeAll {
+$testConfiguration = if ([string]::IsNullOrWhiteSpace($Env:PowerBGInfoDevelopmentConfiguration)) { 'Debug' } else { $Env:PowerBGInfoDevelopmentConfiguration }
+$fallbackConfiguration = if ($testConfiguration -eq 'Debug') { 'Release' } else { 'Debug' }
+
 function Get-ImagePixelHash {
     param(
         [string] $Path
@@ -411,9 +416,9 @@ Describe 'CLI interoperability' {
         $sampleImage = (Resolve-Path -Path $sampleImage).Path
         $outputDir = Join-Path -Path $TestDrive -ChildPath 'interop'
         $configPath = Join-Path -Path $TestDrive -ChildPath 'interop.json'
-        $cliPath = Join-Path -Path $PSScriptRoot -ChildPath '..\PowerBGInfo.Cli\bin\Debug\net8.0-windows\PowerBGInfo.Cli.exe'
+        $cliPath = Join-Path -Path $PSScriptRoot -ChildPath "..\PowerBGInfo.Cli\bin\$testConfiguration\net8.0-windows\PowerBGInfo.Cli.exe"
         if (-not (Test-Path -LiteralPath $cliPath)) {
-            $cliPath = Join-Path -Path $PSScriptRoot -ChildPath '..\PowerBGInfo.Cli\bin\Release\net8.0-windows\PowerBGInfo.Cli.exe'
+            $cliPath = Join-Path -Path $PSScriptRoot -ChildPath "..\PowerBGInfo.Cli\bin\$fallbackConfiguration\net8.0-windows\PowerBGInfo.Cli.exe"
         }
 
         $config = New-BGInfoConfiguration -Target File
@@ -435,9 +440,9 @@ Describe 'CLI interoperability' {
         $sampleImage = (Resolve-Path -Path $sampleImage).Path
         $outputDir = Join-Path -Path $TestDrive -ChildPath 'inline-cli'
         $configPath = Join-Path -Path $TestDrive -ChildPath 'inline-cli.json'
-        $cliPath = Join-Path -Path $PSScriptRoot -ChildPath '..\PowerBGInfo.Cli\bin\Debug\net8.0-windows\PowerBGInfo.Cli.exe'
+        $cliPath = Join-Path -Path $PSScriptRoot -ChildPath "..\PowerBGInfo.Cli\bin\$testConfiguration\net8.0-windows\PowerBGInfo.Cli.exe"
         if (-not (Test-Path -LiteralPath $cliPath)) {
-            $cliPath = Join-Path -Path $PSScriptRoot -ChildPath '..\PowerBGInfo.Cli\bin\Release\net8.0-windows\PowerBGInfo.Cli.exe'
+            $cliPath = Join-Path -Path $PSScriptRoot -ChildPath "..\PowerBGInfo.Cli\bin\$fallbackConfiguration\net8.0-windows\PowerBGInfo.Cli.exe"
         }
 
         New-BGInfo {
@@ -453,9 +458,9 @@ Describe 'CLI interoperability' {
         $sampleImage = (Resolve-Path -Path $sampleImage).Path
         $outputDir = Join-Path -Path $TestDrive -ChildPath 'volume-cli'
         $configPath = Join-Path -Path $TestDrive -ChildPath 'volume-cli.json'
-        $cliPath = Join-Path -Path $PSScriptRoot -ChildPath '..\PowerBGInfo.Cli\bin\Debug\net8.0-windows\PowerBGInfo.Cli.exe'
+        $cliPath = Join-Path -Path $PSScriptRoot -ChildPath "..\PowerBGInfo.Cli\bin\$testConfiguration\net8.0-windows\PowerBGInfo.Cli.exe"
         if (-not (Test-Path -LiteralPath $cliPath)) {
-            $cliPath = Join-Path -Path $PSScriptRoot -ChildPath '..\PowerBGInfo.Cli\bin\Release\net8.0-windows\PowerBGInfo.Cli.exe'
+            $cliPath = Join-Path -Path $PSScriptRoot -ChildPath "..\PowerBGInfo.Cli\bin\$fallbackConfiguration\net8.0-windows\PowerBGInfo.Cli.exe"
         }
 
         New-BGInfo {
@@ -477,9 +482,9 @@ Describe 'CLI interoperability' {
         $outputDir = Join-Path -Path $TestDrive -ChildPath 'script-cli'
         $scriptPath = Join-Path -Path $TestDrive -ChildPath 'bginfo-script.ps1'
         $moduleManifestPath = (Resolve-Path -Path (Join-Path -Path $PSScriptRoot -ChildPath '..\..\PowerBGInfo.psd1')).Path
-        $cliPath = Join-Path -Path $PSScriptRoot -ChildPath '..\PowerBGInfo.Cli\bin\Debug\net8.0-windows\PowerBGInfo.Cli.exe'
+        $cliPath = Join-Path -Path $PSScriptRoot -ChildPath "..\PowerBGInfo.Cli\bin\$testConfiguration\net8.0-windows\PowerBGInfo.Cli.exe"
         if (-not (Test-Path -LiteralPath $cliPath)) {
-            $cliPath = Join-Path -Path $PSScriptRoot -ChildPath '..\PowerBGInfo.Cli\bin\Release\net8.0-windows\PowerBGInfo.Cli.exe'
+            $cliPath = Join-Path -Path $PSScriptRoot -ChildPath "..\PowerBGInfo.Cli\bin\$fallbackConfiguration\net8.0-windows\PowerBGInfo.Cli.exe"
         }
 
         @"
@@ -497,9 +502,9 @@ New-BGInfo {
         $scriptPath = Join-Path -Path $TestDrive -ChildPath 'bginfo-export-script.ps1'
         $moduleManifestPath = (Resolve-Path -Path (Join-Path -Path $PSScriptRoot -ChildPath '..\..\PowerBGInfo.psd1')).Path
         $exportPath = Join-Path -Path $TestDrive -ChildPath 'script-export.json'
-        $cliPath = Join-Path -Path $PSScriptRoot -ChildPath '..\PowerBGInfo.Cli\bin\Debug\net8.0-windows\PowerBGInfo.Cli.exe'
+        $cliPath = Join-Path -Path $PSScriptRoot -ChildPath "..\PowerBGInfo.Cli\bin\$testConfiguration\net8.0-windows\PowerBGInfo.Cli.exe"
         if (-not (Test-Path -LiteralPath $cliPath)) {
-            $cliPath = Join-Path -Path $PSScriptRoot -ChildPath '..\PowerBGInfo.Cli\bin\Release\net8.0-windows\PowerBGInfo.Cli.exe'
+            $cliPath = Join-Path -Path $PSScriptRoot -ChildPath "..\PowerBGInfo.Cli\bin\$fallbackConfiguration\net8.0-windows\PowerBGInfo.Cli.exe"
         }
 
         @"
@@ -521,13 +526,13 @@ New-BGInfo {
         $sampleImage = (Resolve-Path -Path $sampleImage).Path
         $outputDir = Join-Path -Path $TestDrive -ChildPath 'script-cli-module'
         $scriptPath = Join-Path -Path $TestDrive -ChildPath 'bginfo-script-module.ps1'
-        $modulePath = Join-Path -Path $PSScriptRoot -ChildPath '..\PowerBGInfo.PowerShell\bin\Debug\net8.0-windows\PowerBGInfo.PowerShell.dll'
+        $modulePath = Join-Path -Path $PSScriptRoot -ChildPath "..\PowerBGInfo.PowerShell\bin\$testConfiguration\net8.0-windows\PowerBGInfo.PowerShell.dll"
         if (-not (Test-Path -LiteralPath $modulePath)) {
-            $modulePath = Join-Path -Path $PSScriptRoot -ChildPath '..\PowerBGInfo.PowerShell\bin\Release\net8.0-windows\PowerBGInfo.PowerShell.dll'
+            $modulePath = Join-Path -Path $PSScriptRoot -ChildPath "..\PowerBGInfo.PowerShell\bin\$fallbackConfiguration\net8.0-windows\PowerBGInfo.PowerShell.dll"
         }
-        $cliPath = Join-Path -Path $PSScriptRoot -ChildPath '..\PowerBGInfo.Cli\bin\Debug\net8.0-windows\PowerBGInfo.Cli.exe'
+        $cliPath = Join-Path -Path $PSScriptRoot -ChildPath "..\PowerBGInfo.Cli\bin\$testConfiguration\net8.0-windows\PowerBGInfo.Cli.exe"
         if (-not (Test-Path -LiteralPath $cliPath)) {
-            $cliPath = Join-Path -Path $PSScriptRoot -ChildPath '..\PowerBGInfo.Cli\bin\Release\net8.0-windows\PowerBGInfo.Cli.exe'
+            $cliPath = Join-Path -Path $PSScriptRoot -ChildPath "..\PowerBGInfo.Cli\bin\$fallbackConfiguration\net8.0-windows\PowerBGInfo.Cli.exe"
         }
 
         @"

--- a/Sources/PowerBGInfo/BgInfoChartRenderer.cs
+++ b/Sources/PowerBGInfo/BgInfoChartRenderer.cs
@@ -11,8 +11,6 @@ using ChartForgeX.Typography;
 namespace PowerBGInfo;
 
 internal static class BgInfoChartRenderer {
-    private const int MinimumTrendPointBudget = 64;
-
     public static BgInfoRasterImage Render(BgInfoChart chart, IReadOnlyList<double> values, BgInfoConfiguration config) {
         if (chart == null) throw new ArgumentNullException(nameof(chart));
         if (config == null) throw new ArgumentNullException(nameof(config));
@@ -138,29 +136,12 @@ internal static class BgInfoChartRenderer {
 
     private static void AddTrendSeries(Chart plot, string name, IReadOnlyList<double> values, int width, ChartColor color, bool smooth, bool area) {
         var points = BuildIndexedPoints(values);
-        var pointBudget = ResolveTrendPointBudget(width);
-        if (values.Count > pointBudget) {
-            if (area) {
-                plot.AddDecimatedArea(name, points, pointBudget, ChartDecimationMode.LargestTriangleThreeBuckets, color);
-            } else {
-                plot.AddDecimatedLine(name, points, pointBudget, ChartDecimationMode.LargestTriangleThreeBuckets, color);
-            }
-            plot.Series[plot.Series.Count - 1].WithSmooth(smooth);
-            return;
-        }
-
         if (area) {
-            if (smooth) plot.AddSmoothArea(name, points, color);
-            else plot.AddArea(name, points, color);
+            plot.AddAdaptiveArea(name, points, width, ChartResolutionPolicy.Trend(), color);
         } else {
-            if (smooth) plot.AddSmoothLine(name, points, color);
-            else plot.AddLine(name, points, color);
+            plot.AddAdaptiveLine(name, points, width, ChartResolutionPolicy.Trend(), color);
         }
-    }
-
-    internal static int ResolveTrendPointBudget(int width) {
-        var pixelBudget = Math.Max(1L, width) * 2L;
-        return (int)Math.Min(int.MaxValue, Math.Max(MinimumTrendPointBudget, pixelBudget));
+        plot.Series[plot.Series.Count - 1].WithSmooth(smooth);
     }
 
     private static void ApplyChartOptions(Chart plot, BgInfoChart chart) {

--- a/Sources/PowerBGInfo/BgInfoChartRenderer.cs
+++ b/Sources/PowerBGInfo/BgInfoChartRenderer.cs
@@ -11,6 +11,8 @@ using ChartForgeX.Typography;
 namespace PowerBGInfo;
 
 internal static class BgInfoChartRenderer {
+    private const int MinimumTrendPointBudget = 64;
+
     public static BgInfoRasterImage Render(BgInfoChart chart, IReadOnlyList<double> values, BgInfoConfiguration config) {
         if (chart == null) throw new ArgumentNullException(nameof(chart));
         if (config == null) throw new ArgumentNullException(nameof(config));
@@ -63,7 +65,7 @@ internal static class BgInfoChartRenderer {
         return image;
     }
 
-    private static Chart BuildChartForgeXChart(BgInfoChart chart, IReadOnlyList<double> values, BgInfoConfiguration config, int width, int height) {
+    internal static Chart BuildChartForgeXChart(BgInfoChart chart, IReadOnlyList<double> values, BgInfoConfiguration config, int width, int height) {
         var accent = chart.LineColor ?? config.ValueColor;
         var plot = Chart.Create()
             .WithSize(Math.Max(1, width), Math.Max(1, height))
@@ -95,10 +97,10 @@ internal static class BgInfoChartRenderer {
                 plot.AddHorizontalBar(chart.Title, BuildIndexedPoints(values), accent);
                 break;
             case BgInfoChartKind.Line:
-                plot.AddLine(chart.Title, BuildIndexedPoints(values), accent);
+                AddTrendSeries(plot, chart.Title, values, width, accent, smooth: false, area: false);
                 break;
             case BgInfoChartKind.Area:
-                plot.AddSmoothArea(chart.Title, BuildIndexedPoints(values), chart.FillColor ?? chart.LineColor ?? config.ValueColor);
+                AddTrendSeries(plot, chart.Title, values, width, chart.FillColor ?? chart.LineColor ?? config.ValueColor, smooth: true, area: true);
                 break;
             case BgInfoChartKind.Gauge:
                 AddGauge(plot, chart, values, accent);
@@ -127,11 +129,38 @@ internal static class BgInfoChartRenderer {
                 plot.AddPictorial(chart.Title, BuildPictorialItems(chart, values), ResolvePictorialShape(chart.PictorialSymbol), accent);
                 break;
             default:
-                plot.AddSmoothLine(chart.Title, BuildIndexedPoints(values), accent);
+                AddTrendSeries(plot, chart.Title, values, width, accent, smooth: true, area: false);
                 break;
         }
 
         return plot;
+    }
+
+    private static void AddTrendSeries(Chart plot, string name, IReadOnlyList<double> values, int width, ChartColor color, bool smooth, bool area) {
+        var points = BuildIndexedPoints(values);
+        var pointBudget = ResolveTrendPointBudget(width);
+        if (values.Count > pointBudget) {
+            if (area) {
+                plot.AddDecimatedArea(name, points, pointBudget, ChartDecimationMode.LargestTriangleThreeBuckets, color);
+            } else {
+                plot.AddDecimatedLine(name, points, pointBudget, ChartDecimationMode.LargestTriangleThreeBuckets, color);
+            }
+            plot.Series[plot.Series.Count - 1].WithSmooth(smooth);
+            return;
+        }
+
+        if (area) {
+            if (smooth) plot.AddSmoothArea(name, points, color);
+            else plot.AddArea(name, points, color);
+        } else {
+            if (smooth) plot.AddSmoothLine(name, points, color);
+            else plot.AddLine(name, points, color);
+        }
+    }
+
+    internal static int ResolveTrendPointBudget(int width) {
+        var pixelBudget = Math.Max(1L, width) * 2L;
+        return (int)Math.Min(int.MaxValue, Math.Max(MinimumTrendPointBudget, pixelBudget));
     }
 
     private static void ApplyChartOptions(Chart plot, BgInfoChart chart) {

--- a/Sources/PowerBGInfo/PowerBGInfo.csproj
+++ b/Sources/PowerBGInfo/PowerBGInfo.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <Company>Evotec</Company>
         <Authors>Przemyslaw Klys</Authors>
-        <VersionPrefix>2.0.0</VersionPrefix>
+        <VersionPrefix>2.0.1</VersionPrefix>
         <AssemblyName>PowerBGInfo</AssemblyName>
         <Copyright>(c) 2011 - 2025 Przemyslaw Klys @ Evotec. All rights reserved.</Copyright>
         <TargetFrameworks>net472;net8.0-windows;net9.0-windows</TargetFrameworks>
@@ -11,7 +11,7 @@
         <Nullable>enable</Nullable>
         <LangVersion>Latest</LangVersion>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
-        <ChartForgeXVersion>1.0.3</ChartForgeXVersion>
+        <ChartForgeXVersion>1.1.0</ChartForgeXVersion>
     </PropertyGroup>
     <PropertyGroup Condition="'$(PublishAot)' == 'true'">
         <TargetFrameworks>net8.0-windows</TargetFrameworks>


### PR DESCRIPTION
## Summary

- moves dense trend resolution and marker decisions out of PowerBGInfo into ChartForgeX `AddAdaptiveLine` and `AddAdaptiveArea`
- upgrades the PowerBGInfo and PowerShell surfaces to the ChartForgeX 1.1.0 contract while keeping the product layer focused on wallpaper/report composition
- adds regression coverage for shared adaptive rendering and material-spike preservation
- hardens the end-to-end validator so Release really validates Release, native command failures cannot be hidden, and Pester container/setup failures cannot produce a false-green result

## Dependency order

Requires [ChartForgeX #120](https://github.com/EvotecIT/ChartForgeX/pull/120) and its public 1.1.0 package. This PR deliberately contains no downstream decimation shim or temporary feed. No package is published by this PR.

## Validation

The full Release validator passes: 41 PowerShell/API/CLI tests, script/JSON/PowerShell image parity, single-file generation, and NativeAOT file-generation smoke. NativeAOT remains an explicitly warned smoke path on this machine because its pixels differ from the normal CLI output.