### PR TITLE
Add responsive centered visual canvas lanes

### DIFF
--- a/Examples/Scripts/PowerBGInfo.VisualCanvas.CenterRight.ps1
+++ b/Examples/Scripts/PowerBGInfo.VisualCanvas.CenterRight.ps1
@@ -1,0 +1,38 @@
+param(
+    [string] $SampleFileName = 'TapC-Evotec-2560x1080.jpg',
+    [string] $OutputFileName = 'PowerBGInfo.VisualCanvas.CenterRight.jpg'
+)
+
+Import-Module (Join-Path -Path $PSScriptRoot -ChildPath '..\..\PowerBGInfo.psd1') -Force
+
+$examplesPath = (Resolve-Path (Join-Path -Path $PSScriptRoot -ChildPath '..')).Path
+$sampleImage = Join-Path -Path $examplesPath -ChildPath "Samples\$SampleFileName"
+$outputDirectory = Join-Path -Path $examplesPath -ChildPath 'Output'
+
+$tiles = @(
+    New-BGInfoVisualCanvasTile -Lane Center -IconKind Computer -SurfaceStyle Raised -Label HOSTNAME -Value '{{HostName}}' -Detail 'primary workstation' -Accent '#2DD4BFFF'
+    New-BGInfoVisualCanvasTile -Lane Center -IconKind Network -SurfaceStyle Raised -Label 'IP ADDRESS' -Value '{{IPv4Address}}' -Detail 'primary adapter' -Accent '#60A5FAFF'
+    New-BGInfoVisualCanvasTile -Lane Center -IconKind OperatingSystem -SurfaceStyle Raised -Label 'OPERATING SYSTEM' -Value '{{OSName}}' -Detail '{{OSVersion}}' -Accent '#A78BFAFF'
+    New-BGInfoVisualCanvasTile -Lane Right -IconKind Cpu -SurfaceStyle Raised -Label CPU -Value '{{CpuCores}} cores / {{CpuLogicalCores}} threads' -Accent '#F97316FF'
+    New-BGInfoVisualCanvasTile -Lane Right -IconKind Memory -SurfaceStyle Raised -Label RAM -Value '{{RAMSize}}' -Accent '#EC4899FF'
+    New-BGInfoVisualCanvasTile -Lane Right -IconKind User -SurfaceStyle Raised -Label USER -Value '{{UserName}}' -Detail '{{UserDNSDomain}}' -Accent '#38BDF8FF'
+)
+
+New-BGInfo -MonitorIndex 0 -Target File {
+    New-BGInfoVisualCanvas `
+        -NoHeroContent `
+        -Tile $tiles `
+        -TileHeight 118 `
+        -TileGap 24 `
+        -CenterTileWidth 460 `
+        -RightTileWidth 460 `
+        -TileGlassTop '#E807152C' `
+        -TileGlassBottom '#DC030A17' `
+        -TileLabelColor '#C4D4EC' `
+        -TileValueColor '#F8FAFC' `
+        -TileDetailColor '#A8BAD4'
+} -FilePath $sampleImage `
+    -ConfigurationDirectory $outputDirectory `
+    -OutputFileName $OutputFileName `
+    -WallpaperFit Fill `
+    -BackgroundColor Black

--- a/README.MD
+++ b/README.MD
@@ -322,6 +322,23 @@ New-BGInfo -Target File {
 
 `Examples\Scripts\PowerBGInfo.VisualCanvas.ps1` renders three variants: glass panels with text badges, outline-only panels with text badges, and outline-only panels with built-in icons. `Examples\Scripts\PowerBGInfo.VisualCanvas.ContrastBox.ps1` shows light high-contrast boxes over a dark wallpaper, moves the feature strip to the bottom-right so it does not cover the Evotec logo, and exports the same layout to `Examples\Configuration\PowerBGInfo.VisualCanvas.ContrastBox.json`. `Examples\Scripts\PowerBGInfo.VisualCanvas.RaisedSections.ps1` shows a stronger glass treatment with icon tiles and progress rails for a more raised section look over the same wallpaper. `Examples\Scripts\PowerBGInfo.VisualCanvas.Raised3D.ps1` uses the reusable `Raised` surface style on a black operational background. `Examples\Scripts\PowerBGInfo.VisualCanvas.MiniCharts.ps1` combines the same visual canvas with purpose-matched mini charts inside the CPU, RAM, disk, and patching sections plus a logo inside the central hero badge. Tile `-SurfaceStyle` supports `Glass`, `Outline`, and `Raised`; tile `-IconKind` can render built-in icons such as `Computer`, `Network`, `OperatingSystem`, `Cpu`, `Memory`, `User`, `Domain`, `Terminal`, `Storage`, and `Shield`.
 
+When Windows desktop icons occupy the left side, place one tile lane in the center and another on the right. `-Lane` is an alias for the existing `-Side` parameter, and `-NoHeroContent` removes the badge, title, and subtitle so the centered tiles have a clear working area:
+
+```powershell
+$tiles = @(
+    New-BGInfoVisualCanvasTile -Lane Center -IconKind Computer -SurfaceStyle Raised -Label HOSTNAME -Value '{{HostName}}'
+    New-BGInfoVisualCanvasTile -Lane Center -IconKind Network -SurfaceStyle Raised -Label 'IP ADDRESS' -Value '{{IPv4Address}}'
+    New-BGInfoVisualCanvasTile -Lane Right -IconKind Cpu -SurfaceStyle Raised -Label CPU -Value '{{CpuCores}} cores'
+    New-BGInfoVisualCanvasTile -Lane Right -IconKind Memory -SurfaceStyle Raised -Label RAM -Value '{{RAMSize}}'
+)
+
+New-BGInfo -Target File {
+    New-BGInfoVisualCanvas -NoHeroContent -Tile $tiles -CenterTileWidth 460 -RightTileWidth 460
+} -FilePath .\Examples\Samples\TapC-Evotec-2560x1080.jpg -ConfigurationDirectory .\Examples\Output -OutputFileName 'PowerBGInfo.VisualCanvas.CenterRight.jpg' -WallpaperFit Fill
+```
+
+Use `-CenterTileOffsetX` and `-CenterTileOffsetY` when the wallpaper needs the centered lane moved away from a logo or another focal point. `Examples\Scripts\PowerBGInfo.VisualCanvas.CenterRight.ps1` contains the complete example.
+
 The visual canvas palette is data-driven. `New-BGInfoVisualCanvas` accepts color parameters for the hero title, subtitle, tile label/value/detail text, glass tile fill, progress track, badge fill, badge text, and primary/secondary accents. Use `-HeroBadgeText` for a text mark, `-HeroBadgeImagePath` for a logo inside the central badge, or `-NoHeroBadge` when the badge should be omitted entirely. Badge text, logo path, image fit, padding, opacity, colors, and visibility are preserved in JSON exports, so a consumer can brand the same reusable ChartForgeX template without changing renderer code. Standalone image overlays also accept `-Fit Stretch|Contain|Cover|Center|Tile`; `Stretch` remains the default for existing configurations.
 
 For a high-contrast color box treatment, use a light translucent tile fill, dark tile text, the `Raised` surface style, and per-tile accents:

--- a/Sources/PowerBGInfo.PowerShell/CmdletNewBGInfoVisualCanvas.cs
+++ b/Sources/PowerBGInfo.PowerShell/CmdletNewBGInfoVisualCanvas.cs
@@ -125,6 +125,10 @@ public class CmdletNewBGInfoVisualCanvas : PSCmdlet {
     [Parameter]
     public SwitchParameter NoHeroBadge { get; set; }
 
+    /// <para>Hide the central hero badge, title, and subtitle while keeping tiles and the feature strip.</para>
+    [Parameter]
+    public SwitchParameter NoHeroContent { get; set; }
+
     /// <para>Text rendered in the central hero badge when no image is configured.</para>
     [Parameter]
     [Alias("HeroBadgeSymbol")]
@@ -158,15 +162,15 @@ public class CmdletNewBGInfoVisualCanvas : PSCmdlet {
     [Parameter]
     public int FeatureHeight { get; set; }
 
-    /// <para>Default side-rail tile width in pixels. Zero uses the template default width.</para>
+    /// <para>Default tile width in pixels. Zero uses the template default width.</para>
     [Parameter]
     public int TileWidth { get; set; }
 
-    /// <para>Default side-rail tile height in pixels. Zero uses the template default height.</para>
+    /// <para>Default tile height in pixels. Zero uses the template default height.</para>
     [Parameter]
     public int TileHeight { get; set; }
 
-    /// <para>Default vertical gap between side-rail tiles in pixels. Zero uses the template default gap.</para>
+    /// <para>Default vertical gap between tiles in pixels. Zero uses the template default gap.</para>
     [Parameter]
     public int TileGap { get; set; }
 
@@ -177,6 +181,10 @@ public class CmdletNewBGInfoVisualCanvas : PSCmdlet {
     /// <para>Default right side-rail tile width in pixels. Zero uses TileWidth or the template default.</para>
     [Parameter]
     public int RightTileWidth { get; set; }
+
+    /// <para>Default centered-lane tile width in pixels. Zero uses TileWidth or the template default.</para>
+    [Parameter]
+    public int CenterTileWidth { get; set; }
 
     /// <para>Horizontal left side-rail offset in pixels.</para>
     [Parameter]
@@ -194,7 +202,15 @@ public class CmdletNewBGInfoVisualCanvas : PSCmdlet {
     [Parameter]
     public int RightTileOffsetY { get; set; }
 
-    /// <para>Default side-rail tile text fitting policy.</para>
+    /// <para>Horizontal centered-lane offset in pixels. Positive values move the lane to the right.</para>
+    [Parameter]
+    public int CenterTileOffsetX { get; set; }
+
+    /// <para>Vertical centered-lane offset in pixels.</para>
+    [Parameter]
+    public int CenterTileOffsetY { get; set; }
+
+    /// <para>Default tile text fitting policy.</para>
     [Parameter]
     public BgInfoVisualCanvasTileTextFitPolicy TileTextFitPolicy { get; set; }
 
@@ -214,7 +230,7 @@ public class CmdletNewBGInfoVisualCanvas : PSCmdlet {
     [Parameter]
     public SwitchParameter Opaque { get; set; }
 
-    /// <para>Side rail tile definitions.</para>
+    /// <para>Tile lane definitions.</para>
     [Parameter]
     public BgInfoVisualCanvasTile[] Tile { get; set; } = Array.Empty<BgInfoVisualCanvasTile>();
 
@@ -259,6 +275,7 @@ public class CmdletNewBGInfoVisualCanvas : PSCmdlet {
             HeroBadgeBottom = PowerShellColorConverter.ConvertOptional(HeroBadgeBottom, nameof(HeroBadgeBottom)),
             HeroBadgeTextColor = PowerShellColorConverter.ConvertOptional(HeroBadgeTextColor, nameof(HeroBadgeTextColor)),
             HeroBadgeVisible = !NoHeroBadge.IsPresent,
+            HeroContentVisible = !NoHeroContent.IsPresent,
             HeroBadgeText = HeroBadgeText,
             HeroBadgeImagePath = string.IsNullOrWhiteSpace(HeroBadgeImagePath) ? string.Empty : SessionState.Path.GetUnresolvedProviderPathFromPSPath(HeroBadgeImagePath),
             HeroBadgeImageFit = HeroBadgeImageFit,
@@ -272,10 +289,13 @@ public class CmdletNewBGInfoVisualCanvas : PSCmdlet {
             TileGap = TileGap,
             LeftTileWidth = LeftTileWidth,
             RightTileWidth = RightTileWidth,
+            CenterTileWidth = CenterTileWidth,
             LeftTileOffsetX = LeftTileOffsetX,
             LeftTileOffsetY = LeftTileOffsetY,
             RightTileOffsetX = RightTileOffsetX,
             RightTileOffsetY = RightTileOffsetY,
+            CenterTileOffsetX = CenterTileOffsetX,
+            CenterTileOffsetY = CenterTileOffsetY,
             TileTextFitPolicy = TileTextFitPolicy,
             FeatureOffsetX = FeatureOffsetX,
             FeatureOffsetY = FeatureOffsetY,
@@ -284,6 +304,12 @@ public class CmdletNewBGInfoVisualCanvas : PSCmdlet {
         };
         foreach (var tile in Tile ?? Array.Empty<BgInfoVisualCanvasTile>()) if (tile != null) visual.Tiles.Add(tile);
         foreach (var feature in Feature ?? Array.Empty<BgInfoVisualCanvasFeature>()) if (feature != null) visual.Features.Add(feature);
+        var hasCenterTiles = visual.Tiles.Exists(tile => tile.Side == BgInfoVisualCanvasSide.Center);
+        var hasVisibleHeroContent = visual.HeroContentVisible &&
+            (visual.HeroBadgeVisible || !string.IsNullOrWhiteSpace(visual.Title) || !string.IsNullOrWhiteSpace(visual.Subtitle));
+        if (hasCenterTiles && hasVisibleHeroContent) {
+            WriteWarning("Centered tiles can overlap the hero badge, title, or subtitle. Use -NoHeroContent for a tile-only layout, or move the lane with -CenterTileOffsetX and -CenterTileOffsetY.");
+        }
         WriteObject(visual);
     }
 

--- a/Sources/PowerBGInfo.PowerShell/CmdletNewBGInfoVisualCanvasTile.cs
+++ b/Sources/PowerBGInfo.PowerShell/CmdletNewBGInfoVisualCanvasTile.cs
@@ -5,7 +5,7 @@ using PowerBGInfo;
 namespace PowerBGInfo.PowerShell;
 
 /// <summary>Creates a BGInfo visual canvas tile definition.</summary>
-/// <para>Tiles are the readable side-rail information boxes used by New-BGInfoVisualCanvas.</para>
+/// <para>Tiles are the readable lane-based information boxes used by New-BGInfoVisualCanvas.</para>
 /// <example>
 /// <code>
 /// New-BGInfoVisualCanvasTile -Side Left -IconKind Computer -SurfaceStyle Raised -Label HOSTNAME -Value '{{HostName}}' -Detail 'production desktop' -Accent '#0F766EFF'
@@ -19,8 +19,9 @@ namespace PowerBGInfo.PowerShell;
 [Cmdlet(VerbsCommon.New, "BGInfoVisualCanvasTile")]
 [OutputType(typeof(BgInfoVisualCanvasTile))]
 public class CmdletNewBGInfoVisualCanvasTile : PSCmdlet {
-    /// <para>Side rail placement.</para>
+    /// <para>Tile lane placement.</para>
     [Parameter]
+    [Alias("Lane")]
     public BgInfoVisualCanvasSide Side { get; set; }
 
     /// <para>Compact tile icon or symbol.</para>

--- a/Sources/PowerBGInfo.Tests/BgInfoConfigurationJsonTests.cs
+++ b/Sources/PowerBGInfo.Tests/BgInfoConfigurationJsonTests.cs
@@ -297,6 +297,7 @@ public class BgInfoConfigurationJsonTests
             HeroBadgeBottom = Color.Black,
             HeroBadgeTextColor = Color.AliceBlue,
             HeroBadgeVisible = false,
+            HeroContentVisible = false,
             HeroBadgeText = "EV",
             HeroBadgeImagePath = @"Images\Evotec.png",
             HeroBadgeImageFit = BgInfoImageFit.Cover,
@@ -310,17 +311,20 @@ public class BgInfoConfigurationJsonTests
             TileGap = 24,
             LeftTileWidth = 430,
             RightTileWidth = 460,
+            CenterTileWidth = 440,
             LeftTileOffsetX = 8,
             LeftTileOffsetY = 10,
             RightTileOffsetX = 12,
             RightTileOffsetY = 14,
+            CenterTileOffsetX = -18,
+            CenterTileOffsetY = 16,
             TileTextFitPolicy = BgInfoVisualCanvasTileTextFitPolicy.WrapThenShrink,
             FeatureOffsetX = 165,
             FeatureOffsetY = 120,
             TechBackdrop = false
         };
         visual.Tiles.Add(new BgInfoVisualCanvasTile {
-            Side = BgInfoVisualCanvasSide.Left,
+            Side = BgInfoVisualCanvasSide.Center,
             Icon = "PC",
             Label = "HOSTNAME",
             Value = "{{HostName}}",
@@ -368,6 +372,7 @@ public class BgInfoConfigurationJsonTests
         Assert.Equal(Color.Black.ToHexRgba(), loaded.HeroBadgeBottom!.Value.ToHexRgba());
         Assert.Equal(Color.AliceBlue.ToHexRgba(), loaded.HeroBadgeTextColor!.Value.ToHexRgba());
         Assert.False(loaded.HeroBadgeVisible);
+        Assert.False(loaded.HeroContentVisible);
         Assert.Equal("EV", loaded.HeroBadgeText);
         Assert.EndsWith(Path.Combine("Images", "Evotec.png"), loaded.HeroBadgeImagePath);
         Assert.Equal(BgInfoImageFit.Cover, loaded.HeroBadgeImageFit);
@@ -381,17 +386,20 @@ public class BgInfoConfigurationJsonTests
         Assert.Equal(24, loaded.TileGap);
         Assert.Equal(430, loaded.LeftTileWidth);
         Assert.Equal(460, loaded.RightTileWidth);
+        Assert.Equal(440, loaded.CenterTileWidth);
         Assert.Equal(8, loaded.LeftTileOffsetX);
         Assert.Equal(10, loaded.LeftTileOffsetY);
         Assert.Equal(12, loaded.RightTileOffsetX);
         Assert.Equal(14, loaded.RightTileOffsetY);
+        Assert.Equal(-18, loaded.CenterTileOffsetX);
+        Assert.Equal(16, loaded.CenterTileOffsetY);
         Assert.Equal(BgInfoVisualCanvasTileTextFitPolicy.WrapThenShrink, loaded.TileTextFitPolicy);
         Assert.Equal(165, loaded.FeatureOffsetX);
         Assert.Equal(120, loaded.FeatureOffsetY);
         Assert.False(loaded.TechBackdrop);
 
         var tile = Assert.Single(loaded.Tiles);
-        Assert.Equal(BgInfoVisualCanvasSide.Left, tile.Side);
+        Assert.Equal(BgInfoVisualCanvasSide.Center, tile.Side);
         Assert.Equal("PC", tile.Icon);
         Assert.Equal("HOSTNAME", tile.Label);
         Assert.Equal("{{HostName}}", tile.Value);
@@ -448,6 +456,33 @@ public class BgInfoConfigurationJsonTests
         var visual = Assert.Single(configuration.VisualCanvases);
         Assert.Single(visual.Tiles);
         Assert.Single(visual.Features);
+    }
+
+    [Theory]
+    [InlineData("Middle")]
+    [InlineData("999")]
+    public void LoadRejectsUnknownVisualCanvasTileSides(string side) {
+        var tempDirectory = Path.Combine(Path.GetTempPath(), "bginfo-json-" + Path.GetRandomFileName());
+        Directory.CreateDirectory(tempDirectory);
+        var path = Path.Combine(tempDirectory, "config.json");
+        File.WriteAllText(path, $$"""
+{
+  "VisualCanvases": [
+    {
+      "Tiles": [
+        {
+          "Side": "{{side}}",
+          "Label": "HOSTNAME",
+          "Value": "DEV-WKS-01"
+        }
+      ]
+    }
+  ]
+}
+""");
+
+        var exception = Assert.Throws<InvalidDataException>(() => BgInfoConfigurationJson.Load(path));
+        Assert.Contains(side, exception.Message);
     }
 
     [Fact]

--- a/Sources/PowerBGInfo.Tests/BgInfoConfigurationJsonTests.cs
+++ b/Sources/PowerBGInfo.Tests/BgInfoConfigurationJsonTests.cs
@@ -461,6 +461,9 @@ public class BgInfoConfigurationJsonTests
     [Theory]
     [InlineData("Middle")]
     [InlineData("999")]
+    [InlineData("1")]
+    [InlineData("Left, Center")]
+    [InlineData("Left, Right")]
     public void LoadRejectsUnknownVisualCanvasTileSides(string side) {
         var tempDirectory = Path.Combine(Path.GetTempPath(), "bginfo-json-" + Path.GetRandomFileName());
         Directory.CreateDirectory(tempDirectory);

--- a/Sources/PowerBGInfo.Tests/BgInfoVisualCanvasRendererTests.cs
+++ b/Sources/PowerBGInfo.Tests/BgInfoVisualCanvasRendererTests.cs
@@ -3,6 +3,14 @@ namespace PowerBGInfo.Tests;
 public class BgInfoVisualCanvasRendererTests
 {
     [Fact]
+    public void CenterPlacementPreservesExistingSideValues()
+    {
+        Assert.Equal(0, (int)BgInfoVisualCanvasSide.Left);
+        Assert.Equal(1, (int)BgInfoVisualCanvasSide.Right);
+        Assert.Equal(2, (int)BgInfoVisualCanvasSide.Center);
+    }
+
+    [Fact]
     public void DefaultOpaqueFeatureStripPlacementPreservesTemplateCenterAndBottomMargin()
     {
         var visual = new BgInfoVisualCanvas {
@@ -33,6 +41,24 @@ public class BgInfoVisualCanvasRendererTests
         var pixels = image.ToRgbaImage();
 
         Assert.Equal(0, CountOpaquePixels(pixels, 538, 157, 124, 88));
+    }
+
+    [Fact]
+    public void RenderSkipsAllHeroLayersWhenHeroContentIsDisabled()
+    {
+        var visual = new BgInfoVisualCanvas {
+            Width = 1200,
+            Height = 630,
+            Title = "PowerBGInfo",
+            Subtitle = "Desktop background insights",
+            HeroBadgeVisible = true,
+            HeroContentVisible = false
+        };
+
+        using var image = BgInfoVisualCanvasRenderer.Render(visual, new BgInfoConfiguration(), 1200, 630);
+        var pixels = image.ToRgbaImage();
+
+        Assert.Equal(0, CountOpaquePixels(pixels, 240, 140, 720, 320));
     }
 
     [Fact]
@@ -141,6 +167,100 @@ public class BgInfoVisualCanvasRendererTests
     }
 
     [Fact]
+    public void CenterLaneCentersTilesWithDifferentWidthsAndHonorsOffsets()
+    {
+        var visual = new BgInfoVisualCanvas {
+            Width = 1000,
+            Height = 520,
+            HeroContentVisible = false,
+            CenterTileWidth = 320,
+            CenterTileOffsetX = 25,
+            CenterTileOffsetY = 10,
+            TileHeight = 80,
+            TileGap = 20
+        };
+        visual.Tiles.Add(new BgInfoVisualCanvasTile {
+            Side = BgInfoVisualCanvasSide.Center,
+            Width = 400,
+            Label = "WIDE",
+            Value = "wide centered tile",
+            SurfaceStyle = BgInfoVisualCanvasTileSurfaceStyle.Raised
+        });
+        visual.Tiles.Add(new BgInfoVisualCanvasTile {
+            Side = BgInfoVisualCanvasSide.Center,
+            Label = "DEFAULT",
+            Value = "default centered tile",
+            SurfaceStyle = BgInfoVisualCanvasTileSurfaceStyle.Raised
+        });
+
+        using var image = BgInfoVisualCanvasRenderer.Render(visual, new BgInfoConfiguration(), 1000, 520);
+        var pixels = image.ToRgbaImage();
+
+        Assert.True(CountOpaquePixels(pixels, 328, 104, 16, 48) > 0);
+        Assert.Equal(0, CountOpaquePixels(pixels, 328, 204, 16, 48));
+        Assert.True(CountOpaquePixels(pixels, 368, 204, 16, 48) > 0);
+    }
+
+    [Fact]
+    public void CenterAndRightLanesShrinkToRemainSeparatedOnNarrowCanvases()
+    {
+        var visual = new BgInfoVisualCanvas {
+            Width = 1024,
+            Height = 768,
+            HeroContentVisible = false,
+            CenterTileWidth = 460,
+            RightTileWidth = 460,
+            TileHeight = 100
+        };
+        visual.Tiles.Add(new BgInfoVisualCanvasTile {
+            Side = BgInfoVisualCanvasSide.Center,
+            Label = "CENTER",
+            Value = "center lane",
+            SurfaceStyle = BgInfoVisualCanvasTileSurfaceStyle.Raised
+        });
+        visual.Tiles.Add(new BgInfoVisualCanvasTile {
+            Side = BgInfoVisualCanvasSide.Right,
+            Label = "RIGHT",
+            Value = "right lane",
+            SurfaceStyle = BgInfoVisualCanvasTileSurfaceStyle.Raised
+        });
+
+        using var image = BgInfoVisualCanvasRenderer.Render(visual, new BgInfoConfiguration(), 1024, 768);
+        var pixels = image.ToRgbaImage();
+        var opaqueRuns = FindOpaqueRuns(pixels, 150);
+
+        Assert.Equal(2, opaqueRuns.Count);
+        Assert.InRange((opaqueRuns[0].Start + opaqueRuns[0].End) / 2d, 500, 524);
+        Assert.True(opaqueRuns[1].Start - opaqueRuns[0].End >= 20);
+        Assert.True(opaqueRuns[1].End < pixels.Width);
+    }
+
+    [Fact]
+    public void OpaqueCenterLaneRendersWithoutHeroContent()
+    {
+        var visual = new BgInfoVisualCanvas {
+            Width = 1200,
+            Height = 630,
+            Transparent = false,
+            TechBackdrop = false,
+            HeroContentVisible = false,
+            CenterTileWidth = 320,
+            TileHeight = 90
+        };
+        visual.Tiles.Add(new BgInfoVisualCanvasTile {
+            Side = BgInfoVisualCanvasSide.Center,
+            Label = "CENTER",
+            Value = "opaque center lane",
+            SurfaceStyle = BgInfoVisualCanvasTileSurfaceStyle.Raised
+        });
+
+        using var image = BgInfoVisualCanvasRenderer.Render(visual, new BgInfoConfiguration(), 1200, 630);
+        var pixels = image.ToRgbaImage();
+
+        Assert.True(CountOpaquePixels(pixels, 440, 70, 320, 90) > 0);
+    }
+
+    [Fact]
     public void TransparentCenterBoundsAccountForRailOffsets()
     {
         var visual = new BgInfoVisualCanvas {
@@ -211,5 +331,24 @@ public class BgInfoVisualCanvasRendererTests
         }
 
         return count;
+    }
+
+    private static List<(int Start, int End)> FindOpaqueRuns(ChartForgeX.Raster.RgbaImage image, int y)
+    {
+        var runs = new List<(int Start, int End)>();
+        var start = -1;
+        var rowStart = y * image.Width * 4;
+        for (var x = 0; x < image.Width; x++)
+        {
+            var opaque = image.Pixels[rowStart + x * 4 + 3] > 0;
+            if (opaque && start < 0) start = x;
+            if (!opaque && start >= 0)
+            {
+                runs.Add((start, x - 1));
+                start = -1;
+            }
+        }
+        if (start >= 0) runs.Add((start, image.Width - 1));
+        return runs;
     }
 }

--- a/Sources/PowerBGInfo.Tests/BgInfoVisualCanvasRendererTests.cs
+++ b/Sources/PowerBGInfo.Tests/BgInfoVisualCanvasRendererTests.cs
@@ -236,6 +236,64 @@ public class BgInfoVisualCanvasRendererTests
     }
 
     [Fact]
+    public void CenterOnlyLaneShrinksToFitWithinNarrowCanvas()
+    {
+        var visual = new BgInfoVisualCanvas {
+            Width = 320,
+            Height = 480,
+            HeroContentVisible = false,
+            CenterTileWidth = 460,
+            TileHeight = 100
+        };
+        visual.Tiles.Add(new BgInfoVisualCanvasTile {
+            Side = BgInfoVisualCanvasSide.Center,
+            Label = "CENTER",
+            Value = "narrow canvas",
+            SurfaceStyle = BgInfoVisualCanvasTileSurfaceStyle.Raised
+        });
+
+        using var image = BgInfoVisualCanvasRenderer.Render(visual, new BgInfoConfiguration(), 320, 480);
+        var opaqueRuns = FindOpaqueRuns(image.ToRgbaImage(), 80);
+
+        var run = Assert.Single(opaqueRuns);
+        Assert.True(run.Start > 0);
+        Assert.True(run.End < 319);
+    }
+
+    [Fact]
+    public void CenterOffsetIsClampedBeforeOccupiedRightLane()
+    {
+        var visual = new BgInfoVisualCanvas {
+            Width = 1024,
+            Height = 768,
+            HeroContentVisible = false,
+            CenterTileWidth = 460,
+            CenterTileOffsetX = 480,
+            RightTileWidth = 460,
+            TileHeight = 100
+        };
+        visual.Tiles.Add(new BgInfoVisualCanvasTile {
+            Side = BgInfoVisualCanvasSide.Center,
+            Label = "CENTER",
+            Value = "offset lane",
+            SurfaceStyle = BgInfoVisualCanvasTileSurfaceStyle.Raised
+        });
+        visual.Tiles.Add(new BgInfoVisualCanvasTile {
+            Side = BgInfoVisualCanvasSide.Right,
+            Label = "RIGHT",
+            Value = "right lane",
+            SurfaceStyle = BgInfoVisualCanvasTileSurfaceStyle.Raised
+        });
+
+        using var image = BgInfoVisualCanvasRenderer.Render(visual, new BgInfoConfiguration(), 1024, 768);
+        var opaqueRuns = FindOpaqueRuns(image.ToRgbaImage(), 150);
+
+        Assert.Equal(2, opaqueRuns.Count);
+        Assert.True(opaqueRuns[1].Start - opaqueRuns[0].End >= 20);
+        Assert.True(opaqueRuns[1].End < 1024);
+    }
+
+    [Fact]
     public void OpaqueCenterLaneRendersWithoutHeroContent()
     {
         var visual = new BgInfoVisualCanvas {

--- a/Sources/PowerBGInfo.Tests/Cmdlet.Tests.ps1
+++ b/Sources/PowerBGInfo.Tests/Cmdlet.Tests.ps1
@@ -164,6 +164,7 @@ Describe 'New-BGInfo cmdlet parameters' {
         $command.Parameters.Keys | Should -Contain 'TileValueColor'
         $command.Parameters.Keys | Should -Contain 'HeroBadgeTextColor'
         $command.Parameters.Keys | Should -Contain 'NoHeroBadge'
+        $command.Parameters.Keys | Should -Contain 'NoHeroContent'
         $command.Parameters.Keys | Should -Contain 'HeroBadgeText'
         $command.Parameters.Keys | Should -Contain 'HeroBadgeImagePath'
         $command.Parameters.Keys | Should -Contain 'HeroBadgeImageFit'
@@ -173,23 +174,28 @@ Describe 'New-BGInfo cmdlet parameters' {
         $command.Parameters.Keys | Should -Contain 'TileGap'
         $command.Parameters.Keys | Should -Contain 'LeftTileWidth'
         $command.Parameters.Keys | Should -Contain 'RightTileWidth'
+        $command.Parameters.Keys | Should -Contain 'CenterTileWidth'
+        $command.Parameters.Keys | Should -Contain 'CenterTileOffsetX'
+        $command.Parameters.Keys | Should -Contain 'CenterTileOffsetY'
         $command.Parameters.Keys | Should -Contain 'TileTextFitPolicy'
-        (Get-Command New-BGInfoVisualCanvasTile).Parameters.Keys | Should -Contain 'MiniChartKind'
-        (Get-Command New-BGInfoVisualCanvasTile).Parameters.Keys | Should -Contain 'Width'
-        (Get-Command New-BGInfoVisualCanvasTile).Parameters.Keys | Should -Contain 'Height'
-        (Get-Command New-BGInfoVisualCanvasTile).Parameters.Keys | Should -Contain 'TextFitPolicy'
+        $tileCommand = Get-Command New-BGInfoVisualCanvasTile
+        $tileCommand.Parameters.Keys | Should -Contain 'MiniChartKind'
+        $tileCommand.Parameters.Keys | Should -Contain 'Width'
+        $tileCommand.Parameters.Keys | Should -Contain 'Height'
+        $tileCommand.Parameters.Keys | Should -Contain 'TextFitPolicy'
+        $tileCommand.Parameters['Side'].Aliases | Should -Contain 'Lane'
     }
 }
 
 Describe 'New-BGInfoVisualCanvas cmdlets' {
     It 'creates a visual canvas model' {
-        $tile = New-BGInfoVisualCanvasTile -Side Left -Icon PC -Label HOSTNAME -Value '{{HostName}}' -Detail '{{OSName}}' -Width 460 -Height 144 -Progress 0.25 -SurfaceStyle Raised -IconKind Computer -MiniChartKind Sparkline -TextFitPolicy SingleLineEllipsis -MiniChartValues 18,26,22 -MiniChartMaximum 100
+        $tile = New-BGInfoVisualCanvasTile -Lane Center -Icon PC -Label HOSTNAME -Value '{{HostName}}' -Detail '{{OSName}}' -Width 460 -Height 144 -Progress 0.25 -SurfaceStyle Raised -IconKind Computer -MiniChartKind Sparkline -TextFitPolicy SingleLineEllipsis -MiniChartValues 18,26,22 -MiniChartMaximum 100
         $feature = New-BGInfoVisualCanvasFeature -Icon PS -Label 'LIGHTWEIGHT'
 
         $path = Join-Path -Path $TestDrive -ChildPath 'logo.png'
         Set-Content -LiteralPath $path -Value 'not-a-real-rendered-image'
 
-        $visual = New-BGInfoVisualCanvas -Title PowerBGInfo -Subtitle 'Desktop insights' -Width 1200 -Height 630 -TitleColor White -TileValueColor '#F8FAFC' -HeroBadgeTextColor AliceBlue -HeroBadgeText EV -HeroBadgeImagePath $path -HeroBadgeImageFit Cover -HeroBadgeImagePadding 14 -HeroBadgeImageOpacity 0.82 -FeatureAnchor BottomRight -FeatureWidth 610 -FeatureOffsetX 165 -FeatureOffsetY 120 -LayoutPreset WideRails -TileWidth 420 -TileHeight 132 -TileGap 24 -LeftTileWidth 430 -RightTileWidth 460 -LeftTileOffsetX 8 -LeftTileOffsetY 10 -RightTileOffsetX 12 -RightTileOffsetY 14 -TileTextFitPolicy WrapThenShrink -Tile $tile -Feature $feature
+        $visual = New-BGInfoVisualCanvas -Title PowerBGInfo -Subtitle 'Desktop insights' -Width 1200 -Height 630 -TitleColor White -TileValueColor '#F8FAFC' -HeroBadgeTextColor AliceBlue -HeroBadgeText EV -HeroBadgeImagePath $path -HeroBadgeImageFit Cover -HeroBadgeImagePadding 14 -HeroBadgeImageOpacity 0.82 -NoHeroContent -FeatureAnchor BottomRight -FeatureWidth 610 -FeatureOffsetX 165 -FeatureOffsetY 120 -LayoutPreset WideRails -TileWidth 420 -TileHeight 132 -TileGap 24 -LeftTileWidth 430 -RightTileWidth 460 -CenterTileWidth 440 -LeftTileOffsetX 8 -LeftTileOffsetY 10 -RightTileOffsetX 12 -RightTileOffsetY 14 -CenterTileOffsetX -18 -CenterTileOffsetY 16 -TileTextFitPolicy WrapThenShrink -Tile $tile -Feature $feature
 
         $visual.GetType().FullName | Should -Be 'PowerBGInfo.BgInfoVisualCanvas'
         $visual.Title | Should -Be 'PowerBGInfo'
@@ -198,6 +204,7 @@ Describe 'New-BGInfoVisualCanvas cmdlets' {
         $visual.TileValueColor | Should -Not -BeNullOrEmpty
         $visual.HeroBadgeTextColor | Should -Not -BeNullOrEmpty
         $visual.HeroBadgeVisible | Should -BeTrue
+        $visual.HeroContentVisible | Should -BeFalse
         $visual.HeroBadgeText | Should -Be 'EV'
         $visual.HeroBadgeImagePath | Should -Be (Resolve-Path -LiteralPath $path).Path
         $visual.HeroBadgeImageFit.ToString() | Should -Be 'Cover'
@@ -212,10 +219,13 @@ Describe 'New-BGInfoVisualCanvas cmdlets' {
         $visual.TileGap | Should -Be 24
         $visual.LeftTileWidth | Should -Be 430
         $visual.RightTileWidth | Should -Be 460
+        $visual.CenterTileWidth | Should -Be 440
         $visual.LeftTileOffsetX | Should -Be 8
         $visual.LeftTileOffsetY | Should -Be 10
         $visual.RightTileOffsetX | Should -Be 12
         $visual.RightTileOffsetY | Should -Be 14
+        $visual.CenterTileOffsetX | Should -Be -18
+        $visual.CenterTileOffsetY | Should -Be 16
         $visual.TileTextFitPolicy.ToString() | Should -Be 'WrapThenShrink'
         $visual.Tiles.Count | Should -Be 1
         $visual.Tiles[0].Value | Should -Be '{{HostName}}'
@@ -227,6 +237,7 @@ Describe 'New-BGInfoVisualCanvas cmdlets' {
         $visual.Tiles[0].TextFitPolicy.ToString() | Should -Be 'SingleLineEllipsis'
         $visual.Tiles[0].MiniChartValues.Count | Should -Be 3
         $visual.Tiles[0].MiniChartMaximum | Should -Be 100
+        $visual.Tiles[0].Side.ToString() | Should -Be 'Center'
         $visual.Features.Count | Should -Be 1
     }
 
@@ -242,6 +253,22 @@ Describe 'New-BGInfoVisualCanvas cmdlets' {
         $visual = New-BGInfoVisualCanvas -Title PowerBGInfo -NoHeroBadge
 
         $visual.HeroBadgeVisible | Should -BeFalse
+    }
+
+    It 'can disable all hero content' {
+        $visual = New-BGInfoVisualCanvas -NoHeroContent
+
+        $visual.HeroContentVisible | Should -BeFalse
+        $visual.HeroBadgeVisible | Should -BeTrue
+    }
+
+    It 'warns when centered tiles may overlap visible hero content' {
+        $tile = New-BGInfoVisualCanvasTile -Lane Center -Label HOSTNAME -Value '{{HostName}}'
+        $layoutWarnings = @()
+
+        $null = New-BGInfoVisualCanvas -Tile $tile -WarningAction SilentlyContinue -WarningVariable layoutWarnings
+
+        $layoutWarnings | Should -Match 'NoHeroContent'
     }
 }
 

--- a/Sources/PowerBGInfo/BgInfoConfigurationJson.cs
+++ b/Sources/PowerBGInfo/BgInfoConfigurationJson.cs
@@ -927,10 +927,10 @@ public static class BgInfoConfigurationJson {
             Width = model.Width ?? 0,
             Height = model.Height ?? 0
         };
-        if (!string.IsNullOrWhiteSpace(model.Side)) {
-            if (!Enum.TryParse(model.Side, true, out BgInfoVisualCanvasSide side) ||
-                !Enum.IsDefined(typeof(BgInfoVisualCanvasSide), side)) {
-                throw new InvalidDataException("Unknown visual canvas tile side '" + model.Side + "'. Expected Left, Center, or Right.");
+        var sideValue = model.Side;
+        if (!string.IsNullOrWhiteSpace(sideValue)) {
+            if (!TryParseDefinedEnumName(sideValue, out BgInfoVisualCanvasSide side)) {
+                throw new InvalidDataException("Unknown visual canvas tile side '" + sideValue + "'. Expected Left, Center, or Right.");
             }
             tile.Side = side;
         }
@@ -955,6 +955,22 @@ public static class BgInfoConfigurationJson {
         if (model.MiniChartValues != null) tile.MiniChartValues = model.MiniChartValues;
         if (model.MiniChartMaximum.HasValue) tile.MiniChartMaximum = model.MiniChartMaximum.Value;
         return tile;
+    }
+
+    private static bool TryParseDefinedEnumName<TEnum>(string? value, out TEnum parsed) where TEnum : struct, Enum {
+        if (value == null) {
+            parsed = default;
+            return false;
+        }
+
+        var candidate = value.Trim();
+        foreach (var name in Enum.GetNames(typeof(TEnum))) {
+            if (!string.Equals(candidate, name, StringComparison.OrdinalIgnoreCase)) continue;
+            return Enum.TryParse(candidate, true, out parsed);
+        }
+
+        parsed = default;
+        return false;
     }
 
     private static BgInfoVisualCanvasFeature MapVisualCanvasFeature(BgInfoVisualCanvasFeatureFile model) => new() {

--- a/Sources/PowerBGInfo/BgInfoConfigurationJson.cs
+++ b/Sources/PowerBGInfo/BgInfoConfigurationJson.cs
@@ -415,6 +415,7 @@ public static class BgInfoConfigurationJson {
                     HeroBadgeBottom = visual.HeroBadgeBottom.HasValue ? BgInfoColorParser.ToHex(visual.HeroBadgeBottom.Value) : null,
                     HeroBadgeTextColor = visual.HeroBadgeTextColor.HasValue ? BgInfoColorParser.ToHex(visual.HeroBadgeTextColor.Value) : null,
                     HeroBadgeVisible = visual.HeroBadgeVisible,
+                    HeroContentVisible = visual.HeroContentVisible ? null : false,
                     HeroBadgeText = string.Equals(visual.HeroBadgeText, ">_", StringComparison.Ordinal) ? null : visual.HeroBadgeText,
                     HeroBadgeImagePath = string.IsNullOrWhiteSpace(visual.HeroBadgeImagePath) ? null : visual.HeroBadgeImagePath,
                     HeroBadgeImageFit = visual.HeroBadgeImageFit == BgInfoImageFit.Contain ? null : visual.HeroBadgeImageFit.ToString(),
@@ -428,10 +429,13 @@ public static class BgInfoConfigurationJson {
                     TileGap = visual.TileGap == 0 ? null : visual.TileGap,
                     LeftTileWidth = visual.LeftTileWidth == 0 ? null : visual.LeftTileWidth,
                     RightTileWidth = visual.RightTileWidth == 0 ? null : visual.RightTileWidth,
+                    CenterTileWidth = visual.CenterTileWidth == 0 ? null : visual.CenterTileWidth,
                     LeftTileOffsetX = visual.LeftTileOffsetX == 0 ? null : visual.LeftTileOffsetX,
                     LeftTileOffsetY = visual.LeftTileOffsetY == 0 ? null : visual.LeftTileOffsetY,
                     RightTileOffsetX = visual.RightTileOffsetX == 0 ? null : visual.RightTileOffsetX,
                     RightTileOffsetY = visual.RightTileOffsetY == 0 ? null : visual.RightTileOffsetY,
+                    CenterTileOffsetX = visual.CenterTileOffsetX == 0 ? null : visual.CenterTileOffsetX,
+                    CenterTileOffsetY = visual.CenterTileOffsetY == 0 ? null : visual.CenterTileOffsetY,
                     TileTextFitPolicy = visual.TileTextFitPolicy == BgInfoVisualCanvasTileTextFitPolicy.Auto ? null : visual.TileTextFitPolicy.ToString(),
                     FeatureOffsetX = visual.FeatureOffsetX == 0 ? null : visual.FeatureOffsetX,
                     FeatureOffsetY = visual.FeatureOffsetY == 0 ? null : visual.FeatureOffsetY,
@@ -850,6 +854,7 @@ public static class BgInfoConfigurationJson {
         if (model.Transparent.HasValue) visual.Transparent = model.Transparent.Value;
         if (model.TechBackdrop.HasValue) visual.TechBackdrop = model.TechBackdrop.Value;
         if (model.HeroBadgeVisible.HasValue) visual.HeroBadgeVisible = model.HeroBadgeVisible.Value;
+        if (model.HeroContentVisible.HasValue) visual.HeroContentVisible = model.HeroContentVisible.Value;
         if (model.HeroBadgeText != null) visual.HeroBadgeText = model.HeroBadgeText;
         if (!string.IsNullOrWhiteSpace(model.HeroBadgeImagePath)) visual.HeroBadgeImagePath = ResolvePath(model.HeroBadgeImagePath, baseDirectory);
         if (!string.IsNullOrWhiteSpace(model.HeroBadgeImageFit) &&
@@ -869,10 +874,13 @@ public static class BgInfoConfigurationJson {
         if (model.TileGap.HasValue) visual.TileGap = model.TileGap.Value;
         if (model.LeftTileWidth.HasValue) visual.LeftTileWidth = model.LeftTileWidth.Value;
         if (model.RightTileWidth.HasValue) visual.RightTileWidth = model.RightTileWidth.Value;
+        if (model.CenterTileWidth.HasValue) visual.CenterTileWidth = model.CenterTileWidth.Value;
         if (model.LeftTileOffsetX.HasValue) visual.LeftTileOffsetX = model.LeftTileOffsetX.Value;
         if (model.LeftTileOffsetY.HasValue) visual.LeftTileOffsetY = model.LeftTileOffsetY.Value;
         if (model.RightTileOffsetX.HasValue) visual.RightTileOffsetX = model.RightTileOffsetX.Value;
         if (model.RightTileOffsetY.HasValue) visual.RightTileOffsetY = model.RightTileOffsetY.Value;
+        if (model.CenterTileOffsetX.HasValue) visual.CenterTileOffsetX = model.CenterTileOffsetX.Value;
+        if (model.CenterTileOffsetY.HasValue) visual.CenterTileOffsetY = model.CenterTileOffsetY.Value;
         if (!string.IsNullOrWhiteSpace(model.TileTextFitPolicy) &&
             Enum.TryParse(model.TileTextFitPolicy, true, out BgInfoVisualCanvasTileTextFitPolicy tileTextFitPolicy)) {
             visual.TileTextFitPolicy = tileTextFitPolicy;
@@ -919,8 +927,11 @@ public static class BgInfoConfigurationJson {
             Width = model.Width ?? 0,
             Height = model.Height ?? 0
         };
-        if (!string.IsNullOrWhiteSpace(model.Side) &&
-            Enum.TryParse(model.Side, true, out BgInfoVisualCanvasSide side)) {
+        if (!string.IsNullOrWhiteSpace(model.Side)) {
+            if (!Enum.TryParse(model.Side, true, out BgInfoVisualCanvasSide side) ||
+                !Enum.IsDefined(typeof(BgInfoVisualCanvasSide), side)) {
+                throw new InvalidDataException("Unknown visual canvas tile side '" + model.Side + "'. Expected Left, Center, or Right.");
+            }
             tile.Side = side;
         }
         if (!string.IsNullOrWhiteSpace(model.SurfaceStyle) &&
@@ -1252,6 +1263,7 @@ public static class BgInfoConfigurationJson {
         public string? HeroBadgeBottom { get; set; }
         public string? HeroBadgeTextColor { get; set; }
         public bool? HeroBadgeVisible { get; set; }
+        public bool? HeroContentVisible { get; set; }
         public string? HeroBadgeText { get; set; }
         public string? HeroBadgeImagePath { get; set; }
         public string? HeroBadgeImageFit { get; set; }
@@ -1265,10 +1277,13 @@ public static class BgInfoConfigurationJson {
         public int? TileGap { get; set; }
         public int? LeftTileWidth { get; set; }
         public int? RightTileWidth { get; set; }
+        public int? CenterTileWidth { get; set; }
         public int? LeftTileOffsetX { get; set; }
         public int? LeftTileOffsetY { get; set; }
         public int? RightTileOffsetX { get; set; }
         public int? RightTileOffsetY { get; set; }
+        public int? CenterTileOffsetX { get; set; }
+        public int? CenterTileOffsetY { get; set; }
         public string? TileTextFitPolicy { get; set; }
         public int? FeatureOffsetX { get; set; }
         public int? FeatureOffsetY { get; set; }

--- a/Sources/PowerBGInfo/BgInfoVisualCanvas.cs
+++ b/Sources/PowerBGInfo/BgInfoVisualCanvas.cs
@@ -9,12 +9,14 @@ public enum BgInfoVisualCanvasTemplate {
     PowerBgInfoHero
 }
 
-/// <summary>Visual canvas side rail placement.</summary>
+/// <summary>Visual canvas tile lane placement.</summary>
 public enum BgInfoVisualCanvasSide {
     /// <summary>Place the tile on the left side rail.</summary>
-    Left,
+    Left = 0,
     /// <summary>Place the tile on the right side rail.</summary>
-    Right
+    Right = 1,
+    /// <summary>Place the tile on the centered tile lane.</summary>
+    Center = 2
 }
 
 /// <summary>Visual canvas tile surface treatment.</summary>
@@ -145,6 +147,8 @@ public sealed class BgInfoVisualCanvas {
     public Color? HeroBadgeTextColor { get; set; }
     /// <summary>Render the central hero badge.</summary>
     public bool HeroBadgeVisible { get; set; } = true;
+    /// <summary>Render the central hero badge, title, and subtitle.</summary>
+    public bool HeroContentVisible { get; set; } = true;
     /// <summary>Text rendered in the central hero badge when no image is configured.</summary>
     public string HeroBadgeText { get; set; } = ">_";
     /// <summary>Optional image path rendered inside the central hero badge.</summary>
@@ -171,6 +175,8 @@ public sealed class BgInfoVisualCanvas {
     public int LeftTileWidth { get; set; }
     /// <summary>Default right side-rail tile width in pixels. Zero uses TileWidth or the template default.</summary>
     public int RightTileWidth { get; set; }
+    /// <summary>Default centered-lane tile width in pixels. Zero uses TileWidth or the template default.</summary>
+    public int CenterTileWidth { get; set; }
     /// <summary>Horizontal left side-rail offset in pixels.</summary>
     public int LeftTileOffsetX { get; set; }
     /// <summary>Vertical left side-rail offset in pixels.</summary>
@@ -179,6 +185,10 @@ public sealed class BgInfoVisualCanvas {
     public int RightTileOffsetX { get; set; }
     /// <summary>Vertical right side-rail offset in pixels.</summary>
     public int RightTileOffsetY { get; set; }
+    /// <summary>Horizontal centered-lane offset in pixels. Positive values move the lane to the right.</summary>
+    public int CenterTileOffsetX { get; set; }
+    /// <summary>Vertical centered-lane offset in pixels.</summary>
+    public int CenterTileOffsetY { get; set; }
     /// <summary>Default tile text fitting policy.</summary>
     public BgInfoVisualCanvasTileTextFitPolicy TileTextFitPolicy { get; set; }
     /// <summary>Horizontal feature-strip offset. For right anchors, positive values inset from the right edge.</summary>
@@ -189,15 +199,15 @@ public sealed class BgInfoVisualCanvas {
     public bool Transparent { get; set; } = true;
     /// <summary>Render ChartForgeX's built-in technology backdrop when the canvas is not transparent.</summary>
     public bool TechBackdrop { get; set; }
-    /// <summary>Gets side rail tiles.</summary>
+    /// <summary>Gets tile lane definitions.</summary>
     public List<BgInfoVisualCanvasTile> Tiles { get; } = new();
     /// <summary>Gets bottom feature strip items.</summary>
     public List<BgInfoVisualCanvasFeature> Features { get; } = new();
 }
 
-/// <summary>Defines one visual canvas side-rail tile.</summary>
+/// <summary>Defines one visual canvas tile.</summary>
 public sealed class BgInfoVisualCanvasTile {
-    /// <summary>Side rail placement.</summary>
+    /// <summary>Tile lane placement.</summary>
     public BgInfoVisualCanvasSide Side { get; set; }
     /// <summary>Compact tile icon or symbol.</summary>
     public string Icon { get; set; } = string.Empty;

--- a/Sources/PowerBGInfo/BgInfoVisualCanvasRenderer.cs
+++ b/Sources/PowerBGInfo/BgInfoVisualCanvasRenderer.cs
@@ -49,18 +49,30 @@ internal static class BgInfoVisualCanvasRenderer {
         var defaultTileWidth = ApplyTileWidthPreset(visual.LayoutPreset, 300 * scaleX);
         var leftDefaultTileWidth = ResolveSideTileWidth(visual, BgInfoVisualCanvasSide.Left, defaultTileWidth);
         var rightDefaultTileWidth = ResolveSideTileWidth(visual, BgInfoVisualCanvasSide.Right, defaultTileWidth);
+        var centerDefaultTileWidth = ResolveSideTileWidth(visual, BgInfoVisualCanvasSide.Center, defaultTileWidth);
         var leftTileWidth = ResolveRailWidth(visual, BgInfoVisualCanvasSide.Left, defaultTileWidth);
         var rightTileWidth = ResolveRailWidth(visual, BgInfoVisualCanvasSide.Right, defaultTileWidth);
+        var centerTileWidth = ResolveRailWidth(visual, BgInfoVisualCanvasSide.Center, defaultTileWidth);
+        var laneScale = ResolveCenteredLaneWidthScale(visual, width, 48 * scaleX, 48 * scaleX, leftTileWidth, centerTileWidth, rightTileWidth);
+        leftDefaultTileWidth *= laneScale;
+        rightDefaultTileWidth *= laneScale;
+        centerDefaultTileWidth *= laneScale;
+        leftTileWidth *= laneScale;
+        rightTileWidth *= laneScale;
+        centerTileWidth *= laneScale;
         var leftTileHeight = ApplyTileHeightPreset(visual.LayoutPreset, 82 * scaleY);
         var rightTileHeight = ApplyTileHeightPreset(visual.LayoutPreset, 96 * scaleY);
         var leftGap = ResolveTileGap(visual, ApplyTileGapPreset(visual.LayoutPreset, 16 * scaleY));
         var rightGap = ResolveTileGap(visual, ApplyTileGapPreset(visual.LayoutPreset, 18 * scaleY));
         AddTiles(canvas, visual, BgInfoVisualCanvasSide.Left, 48 * scaleX + visual.LeftTileOffsetX, 92 * scaleY + visual.LeftTileOffsetY, leftTileWidth, leftDefaultTileWidth, leftTileHeight, leftGap);
         AddTiles(canvas, visual, BgInfoVisualCanvasSide.Right, width - 48 * scaleX - rightTileWidth - visual.RightTileOffsetX, 70 * scaleY + visual.RightTileOffsetY, rightTileWidth, rightDefaultTileWidth, rightTileHeight, rightGap);
-        AddHeroBadge(canvas, visual, 538 * scaleX, 157 * scaleY, 124 * scaleX, 88 * scaleY, accent);
-        canvas
-            .AddHeroTitle(312 * scaleX, 296 * scaleY, 576 * scaleX, 82 * scaleY, SplitTitle(Resolve(visual.Title), canvas.Theme))
-            .AddText(240 * scaleX, 402 * scaleY, 720 * scaleX, Resolve(visual.Subtitle), 24 * scaleY, canvas.Theme.SubtitleColor, TextAlignment.Center);
+        AddTiles(canvas, visual, BgInfoVisualCanvasSide.Center, ResolveCenteredLaneX(visual, width, 48 * scaleX, centerTileWidth), 70 * scaleY + visual.CenterTileOffsetY, centerTileWidth, centerDefaultTileWidth, rightTileHeight, rightGap);
+        if (visual.HeroContentVisible) {
+            AddHeroBadge(canvas, visual, 538 * scaleX, 157 * scaleY, 124 * scaleX, 88 * scaleY, accent);
+            canvas
+                .AddHeroTitle(312 * scaleX, 296 * scaleY, 576 * scaleX, 82 * scaleY, SplitTitle(Resolve(visual.Title), canvas.Theme))
+                .AddText(240 * scaleX, 402 * scaleY, 720 * scaleX, Resolve(visual.Subtitle), 24 * scaleY, canvas.Theme.SubtitleColor, TextAlignment.Center);
+        }
         if (visual.Features.Count > 0) {
             var stripWidth = ResolveFeatureWidth(visual, 620 * scaleX);
             var stripHeight = ResolveFeatureHeight(visual, 62 * scaleY);
@@ -78,22 +90,27 @@ internal static class BgInfoVisualCanvasRenderer {
         var layout = ResolveOverlayRailLayout(visual, width, height);
         AddTiles(canvas, visual, BgInfoVisualCanvasSide.Left, layout.LeftRailX, layout.RailY + visual.LeftTileOffsetY, layout.LeftRailWidth, layout.LeftTileWidth, layout.TileHeight, layout.TileGap);
         AddTiles(canvas, visual, BgInfoVisualCanvasSide.Right, layout.RightRailX, layout.RailY + visual.RightTileOffsetY, layout.RightRailWidth, layout.RightTileWidth, layout.TileHeight, layout.TileGap);
+        var centerTileWidth = ResolveRailWidth(visual, BgInfoVisualCanvasSide.Center, layout.TemplateTileWidth) * layout.LaneWidthScale;
+        var centerDefaultTileWidth = ResolveSideTileWidth(visual, BgInfoVisualCanvasSide.Center, layout.TemplateTileWidth) * layout.LaneWidthScale;
+        AddTiles(canvas, visual, BgInfoVisualCanvasSide.Center, ResolveCenteredLaneX(visual, width, layout.MarginX, centerTileWidth), layout.RailY + visual.CenterTileOffsetY, centerTileWidth, centerDefaultTileWidth, layout.TileHeight, layout.TileGap);
 
         var centerLeft = layout.CenterLeft;
         var centerWidth = layout.CenterWidth;
-        var badgeWidth = Math.Min(centerWidth, Clamp(width * 0.065, Math.Min(64, centerWidth), Math.Min(144, centerWidth)));
-        var badgeHeight = Clamp(height * 0.085, Math.Min(42, height * 0.16), Math.Min(100, height * 0.22));
-        var badgeY = Clamp(height * 0.23, Math.Min(24, height * 0.08), Math.Max(24, height - badgeHeight - 24));
-        var titleFont = Clamp(width * 0.042, Math.Min(28, height * 0.09), Math.Min(96, height * 0.16));
-        var subtitleFont = Clamp(width * 0.014, Math.Min(12, height * 0.035), Math.Min(30, height * 0.07));
-        var subtitleGap = Clamp(height * 0.035, 8, 32);
-        var titleTopMin = badgeY + badgeHeight + Math.Min(12, height * 0.025);
-        var titleTopMax = Math.Max(titleTopMin, height - titleFont - subtitleFont - subtitleGap - Math.Min(24, height * 0.06));
-        var titleY = Clamp(height * 0.39, titleTopMin, titleTopMax);
-        AddHeroBadge(canvas, visual, centerLeft + (centerWidth - badgeWidth) / 2, badgeY, badgeWidth, badgeHeight, accent);
-        canvas
-            .AddHeroTitle(centerLeft, titleY, centerWidth, titleFont, SplitTitle(Resolve(visual.Title), canvas.Theme))
-            .AddText(centerLeft, titleY + titleFont + subtitleGap, centerWidth, Resolve(visual.Subtitle), subtitleFont, canvas.Theme.SubtitleColor, TextAlignment.Center);
+        if (visual.HeroContentVisible) {
+            var badgeWidth = Math.Min(centerWidth, Clamp(width * 0.065, Math.Min(64, centerWidth), Math.Min(144, centerWidth)));
+            var badgeHeight = Clamp(height * 0.085, Math.Min(42, height * 0.16), Math.Min(100, height * 0.22));
+            var badgeY = Clamp(height * 0.23, Math.Min(24, height * 0.08), Math.Max(24, height - badgeHeight - 24));
+            var titleFont = Clamp(width * 0.042, Math.Min(28, height * 0.09), Math.Min(96, height * 0.16));
+            var subtitleFont = Clamp(width * 0.014, Math.Min(12, height * 0.035), Math.Min(30, height * 0.07));
+            var subtitleGap = Clamp(height * 0.035, 8, 32);
+            var titleTopMin = badgeY + badgeHeight + Math.Min(12, height * 0.025);
+            var titleTopMax = Math.Max(titleTopMin, height - titleFont - subtitleFont - subtitleGap - Math.Min(24, height * 0.06));
+            var titleY = Clamp(height * 0.39, titleTopMin, titleTopMax);
+            AddHeroBadge(canvas, visual, centerLeft + (centerWidth - badgeWidth) / 2, badgeY, badgeWidth, badgeHeight, accent);
+            canvas
+                .AddHeroTitle(centerLeft, titleY, centerWidth, titleFont, SplitTitle(Resolve(visual.Title), canvas.Theme))
+                .AddText(centerLeft, titleY + titleFont + subtitleGap, centerWidth, Resolve(visual.Subtitle), subtitleFont, canvas.Theme.SubtitleColor, TextAlignment.Center);
+        }
         if (visual.Features.Count > 0) {
             var stripHeight = Clamp(height * 0.075, Math.Min(36, height * 0.1), Math.Min(64, height * 0.14));
             var stripWidth = Clamp(centerWidth * 0.72, Math.Min(120, centerWidth), Math.Min(760, centerWidth));
@@ -112,9 +129,20 @@ internal static class BgInfoVisualCanvasRenderer {
         var cursorY = y;
         foreach (var tile in visual.Tiles) {
             if (tile.Side != side) continue;
-            var tileWidth = ResolveTileWidth(visual, tile, defaultTileWidth);
+            var tileWidth = Math.Min(ResolveTileWidth(visual, tile, defaultTileWidth), width);
             var tileHeight = ResolveTileHeight(visual, tile, height);
-            var tileX = side == BgInfoVisualCanvasSide.Right ? x + width - tileWidth : x;
+            double tileX;
+            switch (side) {
+                case BgInfoVisualCanvasSide.Right:
+                    tileX = x + width - tileWidth;
+                    break;
+                case BgInfoVisualCanvasSide.Center:
+                    tileX = x + (width - tileWidth) / 2;
+                    break;
+                default:
+                    tileX = x;
+                    break;
+            }
             canvas.AddInfoTile(
                 tileX,
                 cursorY,
@@ -158,10 +186,42 @@ internal static class BgInfoVisualCanvasRenderer {
     private static double ResolveSideTileWidth(BgInfoVisualCanvas visual, BgInfoVisualCanvasSide side, double defaultWidth) {
         if (side == BgInfoVisualCanvasSide.Left && visual.LeftTileWidth > 0) return visual.LeftTileWidth;
         if (side == BgInfoVisualCanvasSide.Right && visual.RightTileWidth > 0) return visual.RightTileWidth;
+        if (side == BgInfoVisualCanvasSide.Center && visual.CenterTileWidth > 0) return visual.CenterTileWidth;
         return visual.TileWidth > 0 ? visual.TileWidth : defaultWidth;
     }
 
     private static double ResolveTileGap(BgInfoVisualCanvas visual, double defaultGap) => visual.TileGap > 0 ? visual.TileGap : defaultGap;
+
+    private static bool HasTiles(BgInfoVisualCanvas visual, BgInfoVisualCanvasSide side) {
+        foreach (var tile in visual.Tiles) {
+            if (tile.Side == side) return true;
+        }
+
+        return false;
+    }
+
+    private static double ResolveCenteredLaneWidthScale(BgInfoVisualCanvas visual, double width, double marginX, double laneGap, double leftWidth, double centerWidth, double rightWidth) {
+        if (!HasTiles(visual, BgInfoVisualCanvasSide.Center)) return 1;
+
+        var scale = 1d;
+        if (HasTiles(visual, BgInfoVisualCanvasSide.Left)) {
+            var available = width - 2 * marginX - 2 * laneGap + 2 * visual.CenterTileOffsetX - 2 * visual.LeftTileOffsetX;
+            var required = 2 * leftWidth + centerWidth;
+            if (required > 0) scale = Math.Min(scale, Math.Max(1, available) / required);
+        }
+        if (HasTiles(visual, BgInfoVisualCanvasSide.Right)) {
+            var available = width - 2 * marginX - 2 * laneGap - 2 * visual.CenterTileOffsetX - 2 * visual.RightTileOffsetX;
+            var required = centerWidth + 2 * rightWidth;
+            if (required > 0) scale = Math.Min(scale, Math.Max(1, available) / required);
+        }
+
+        return Math.Min(1, scale);
+    }
+
+    private static double ResolveCenteredLaneX(BgInfoVisualCanvas visual, double width, double marginX, double centerWidth) {
+        var requested = (width - centerWidth) / 2 + visual.CenterTileOffsetX;
+        return Clamp(requested, marginX, Math.Max(marginX, width - marginX - centerWidth));
+    }
 
     internal static (double X, double Y, double Width, double Height) ResolveDefaultTransparentCenterBounds(BgInfoVisualCanvas visual, int width, int height) {
         var layout = ResolveOverlayRailLayout(visual, width, height);
@@ -179,15 +239,21 @@ internal static class BgInfoVisualCanvasRenderer {
         var rightTileWidth = ResolveSideTileWidth(visual, BgInfoVisualCanvasSide.Right, templateTileWidth);
         var leftRailWidth = ResolveRailWidth(visual, BgInfoVisualCanvasSide.Left, templateTileWidth);
         var rightRailWidth = ResolveRailWidth(visual, BgInfoVisualCanvasSide.Right, templateTileWidth);
+        var centerRailWidth = ResolveRailWidth(visual, BgInfoVisualCanvasSide.Center, templateTileWidth);
+        var laneWidthScale = ResolveCenteredLaneWidthScale(visual, width, marginX, 48, leftRailWidth, centerRailWidth, rightRailWidth);
+        leftTileWidth *= laneWidthScale;
+        rightTileWidth *= laneWidthScale;
+        leftRailWidth *= laneWidthScale;
+        rightRailWidth *= laneWidthScale;
         var leftRailX = marginX + visual.LeftTileOffsetX;
         var rightRailX = width - marginX - rightRailWidth - visual.RightTileOffsetX;
         var centerLeft = leftRailX + leftRailWidth + 48;
         var centerRight = rightRailX - 48;
-        return new OverlayRailLayout(leftRailX, rightRailX, railY, leftRailWidth, rightRailWidth, leftTileWidth, rightTileWidth, tileHeight, tileGap, centerLeft, Math.Max(1, centerRight - centerLeft));
+        return new OverlayRailLayout(leftRailX, rightRailX, railY, leftRailWidth, rightRailWidth, leftTileWidth, rightTileWidth, templateTileWidth, laneWidthScale, marginX, tileHeight, tileGap, centerLeft, Math.Max(1, centerRight - centerLeft));
     }
 
     private readonly struct OverlayRailLayout {
-        public OverlayRailLayout(double leftRailX, double rightRailX, double railY, double leftRailWidth, double rightRailWidth, double leftTileWidth, double rightTileWidth, double tileHeight, double tileGap, double centerLeft, double centerWidth) {
+        public OverlayRailLayout(double leftRailX, double rightRailX, double railY, double leftRailWidth, double rightRailWidth, double leftTileWidth, double rightTileWidth, double templateTileWidth, double laneWidthScale, double marginX, double tileHeight, double tileGap, double centerLeft, double centerWidth) {
             LeftRailX = leftRailX;
             RightRailX = rightRailX;
             RailY = railY;
@@ -195,6 +261,9 @@ internal static class BgInfoVisualCanvasRenderer {
             RightRailWidth = rightRailWidth;
             LeftTileWidth = leftTileWidth;
             RightTileWidth = rightTileWidth;
+            TemplateTileWidth = templateTileWidth;
+            LaneWidthScale = laneWidthScale;
+            MarginX = marginX;
             TileHeight = tileHeight;
             TileGap = tileGap;
             CenterLeft = centerLeft;
@@ -208,6 +277,9 @@ internal static class BgInfoVisualCanvasRenderer {
         public double RightRailWidth { get; }
         public double LeftTileWidth { get; }
         public double RightTileWidth { get; }
+        public double TemplateTileWidth { get; }
+        public double LaneWidthScale { get; }
+        public double MarginX { get; }
         public double TileHeight { get; }
         public double TileGap { get; }
         public double CenterLeft { get; }

--- a/Sources/PowerBGInfo/BgInfoVisualCanvasRenderer.cs
+++ b/Sources/PowerBGInfo/BgInfoVisualCanvasRenderer.cs
@@ -64,9 +64,11 @@ internal static class BgInfoVisualCanvasRenderer {
         var rightTileHeight = ApplyTileHeightPreset(visual.LayoutPreset, 96 * scaleY);
         var leftGap = ResolveTileGap(visual, ApplyTileGapPreset(visual.LayoutPreset, 16 * scaleY));
         var rightGap = ResolveTileGap(visual, ApplyTileGapPreset(visual.LayoutPreset, 18 * scaleY));
-        AddTiles(canvas, visual, BgInfoVisualCanvasSide.Left, 48 * scaleX + visual.LeftTileOffsetX, 92 * scaleY + visual.LeftTileOffsetY, leftTileWidth, leftDefaultTileWidth, leftTileHeight, leftGap);
-        AddTiles(canvas, visual, BgInfoVisualCanvasSide.Right, width - 48 * scaleX - rightTileWidth - visual.RightTileOffsetX, 70 * scaleY + visual.RightTileOffsetY, rightTileWidth, rightDefaultTileWidth, rightTileHeight, rightGap);
-        AddTiles(canvas, visual, BgInfoVisualCanvasSide.Center, ResolveCenteredLaneX(visual, width, 48 * scaleX, centerTileWidth), 70 * scaleY + visual.CenterTileOffsetY, centerTileWidth, centerDefaultTileWidth, rightTileHeight, rightGap);
+        var leftRailX = 48 * scaleX + visual.LeftTileOffsetX;
+        var rightRailX = width - 48 * scaleX - rightTileWidth - visual.RightTileOffsetX;
+        AddTiles(canvas, visual, BgInfoVisualCanvasSide.Left, leftRailX, 92 * scaleY + visual.LeftTileOffsetY, leftTileWidth, leftDefaultTileWidth, leftTileHeight, leftGap);
+        AddTiles(canvas, visual, BgInfoVisualCanvasSide.Right, rightRailX, 70 * scaleY + visual.RightTileOffsetY, rightTileWidth, rightDefaultTileWidth, rightTileHeight, rightGap);
+        AddTiles(canvas, visual, BgInfoVisualCanvasSide.Center, ResolveCenteredLaneX(visual, width, 48 * scaleX, 48 * scaleX, centerTileWidth, leftRailX, leftTileWidth, rightRailX), 70 * scaleY + visual.CenterTileOffsetY, centerTileWidth, centerDefaultTileWidth, rightTileHeight, rightGap);
         if (visual.HeroContentVisible) {
             AddHeroBadge(canvas, visual, 538 * scaleX, 157 * scaleY, 124 * scaleX, 88 * scaleY, accent);
             canvas
@@ -92,7 +94,7 @@ internal static class BgInfoVisualCanvasRenderer {
         AddTiles(canvas, visual, BgInfoVisualCanvasSide.Right, layout.RightRailX, layout.RailY + visual.RightTileOffsetY, layout.RightRailWidth, layout.RightTileWidth, layout.TileHeight, layout.TileGap);
         var centerTileWidth = ResolveRailWidth(visual, BgInfoVisualCanvasSide.Center, layout.TemplateTileWidth) * layout.LaneWidthScale;
         var centerDefaultTileWidth = ResolveSideTileWidth(visual, BgInfoVisualCanvasSide.Center, layout.TemplateTileWidth) * layout.LaneWidthScale;
-        AddTiles(canvas, visual, BgInfoVisualCanvasSide.Center, ResolveCenteredLaneX(visual, width, layout.MarginX, centerTileWidth), layout.RailY + visual.CenterTileOffsetY, centerTileWidth, centerDefaultTileWidth, layout.TileHeight, layout.TileGap);
+        AddTiles(canvas, visual, BgInfoVisualCanvasSide.Center, ResolveCenteredLaneX(visual, width, layout.MarginX, 48, centerTileWidth, layout.LeftRailX, layout.LeftRailWidth, layout.RightRailX), layout.RailY + visual.CenterTileOffsetY, centerTileWidth, centerDefaultTileWidth, layout.TileHeight, layout.TileGap);
 
         var centerLeft = layout.CenterLeft;
         var centerWidth = layout.CenterWidth;
@@ -203,14 +205,15 @@ internal static class BgInfoVisualCanvasRenderer {
     private static double ResolveCenteredLaneWidthScale(BgInfoVisualCanvas visual, double width, double marginX, double laneGap, double leftWidth, double centerWidth, double rightWidth) {
         if (!HasTiles(visual, BgInfoVisualCanvasSide.Center)) return 1;
 
-        var scale = 1d;
+        var usableWidth = Math.Max(1, width - 2 * marginX);
+        var scale = centerWidth > 0 ? Math.Min(1, usableWidth / centerWidth) : 1;
         if (HasTiles(visual, BgInfoVisualCanvasSide.Left)) {
-            var available = width - 2 * marginX - 2 * laneGap + 2 * visual.CenterTileOffsetX - 2 * visual.LeftTileOffsetX;
+            var available = width - 2 * marginX - 2 * laneGap - 2 * visual.LeftTileOffsetX;
             var required = 2 * leftWidth + centerWidth;
             if (required > 0) scale = Math.Min(scale, Math.Max(1, available) / required);
         }
         if (HasTiles(visual, BgInfoVisualCanvasSide.Right)) {
-            var available = width - 2 * marginX - 2 * laneGap - 2 * visual.CenterTileOffsetX - 2 * visual.RightTileOffsetX;
+            var available = width - 2 * marginX - 2 * laneGap - 2 * visual.RightTileOffsetX;
             var required = centerWidth + 2 * rightWidth;
             if (required > 0) scale = Math.Min(scale, Math.Max(1, available) / required);
         }
@@ -218,9 +221,18 @@ internal static class BgInfoVisualCanvasRenderer {
         return Math.Min(1, scale);
     }
 
-    private static double ResolveCenteredLaneX(BgInfoVisualCanvas visual, double width, double marginX, double centerWidth) {
+    private static double ResolveCenteredLaneX(BgInfoVisualCanvas visual, double width, double marginX, double laneGap, double centerWidth, double leftRailX, double leftRailWidth, double rightRailX) {
         var requested = (width - centerWidth) / 2 + visual.CenterTileOffsetX;
-        return Clamp(requested, marginX, Math.Max(marginX, width - marginX - centerWidth));
+        var minimum = marginX;
+        var maximum = Math.Max(marginX, width - marginX - centerWidth);
+        if (HasTiles(visual, BgInfoVisualCanvasSide.Left)) {
+            minimum = Math.Max(minimum, leftRailX + leftRailWidth + laneGap);
+        }
+        if (HasTiles(visual, BgInfoVisualCanvasSide.Right)) {
+            maximum = Math.Min(maximum, rightRailX - laneGap - centerWidth);
+        }
+
+        return Clamp(requested, Math.Min(minimum, maximum), maximum);
     }
 
     internal static (double X, double Y, double Width, double Height) ResolveDefaultTransparentCenterBounds(BgInfoVisualCanvas visual, int width, int height) {


### PR DESCRIPTION
## Summary

- add a `Center` visual-canvas tile lane while preserving the existing `Left` and `Right` values
- add responsive lane fitting and safe offset clamping so Center can be combined with Left or Right on narrower canvases
- add `-Lane` as an alias for `-Side`, plus centered-lane width/offset controls and `-NoHeroContent`
- round-trip the new layout through JSON and reject unknown lane values instead of silently treating them as Left
- document a complete Center + Right layout that leaves the desktop-icon area clear

## Example

```powershell
$tiles = @(
    New-BGInfoVisualCanvasTile -Lane Center -Label HOSTNAME -Value '{{HostName}}'
    New-BGInfoVisualCanvasTile -Lane Right -Label CPU -Value '{{CpuCores}} cores'
)

New-BGInfoVisualCanvas -NoHeroContent -Tile $tiles -CenterTileWidth 460 -RightTileWidth 460
```

Existing build/version automation remains unchanged.

Closes #60