### PR TITLE
build: 🧹 Use PowerForge native cmdlet documentation

### DIFF
--- a/Build/Build-Module.ps1
+++ b/Build/Build-Module.ps1
@@ -68,7 +68,7 @@ Build-Module -ModuleName 'PowerBGInfo' {
     # when creating PSD1 use special style without comments and with only required parameters
     New-ConfigurationFormat -ApplyTo 'DefaultPSD1', 'OnMergePSD1' -PSD1Style 'Minimal'
     # configuration for documentation, at the same time it enables documentation processing
-    New-ConfigurationDocumentation -Enable:$false -PathReadme 'Docs\Readme.md' -Path 'Docs'
+    New-ConfigurationDocumentation -Enable -PathReadme 'Docs\Readme.md' -Path 'Docs' -SyncExternalHelpToProjectRoot
 
     $newConfigurationBuildSplat = @{
         Enable                            = $true
@@ -88,7 +88,7 @@ Build-Module -ModuleName 'PowerBGInfo' {
         DotSourceClasses                  = $true
         DeleteTargetModuleBeforeBuild     = $true
         NETBinaryModuleDocumentation      = $true
-        RefreshPSD1Only                   = if ([string]::IsNullOrWhiteSpace($Env:RefreshPSD1Only)) { $true } else { [bool]::Parse($Env:RefreshPSD1Only) }
+        RefreshPSD1Only                   = if ([string]::IsNullOrWhiteSpace($Env:RefreshPSD1Only)) { $false } else { [bool]::Parse($Env:RefreshPSD1Only) }
         CertificateThumbprint             = '92e95fb58effa6a4a75e77a33cdd6bfe6dd30f1a'
     }
 

--- a/Docs/Export-BGInfoConfiguration.md
+++ b/Docs/Export-BGInfoConfiguration.md
@@ -4,34 +4,34 @@ Module Name: PowerBGInfo
 online version: https://github.com/EvotecIT/PowerBGInfo
 schema: 2.0.0
 ---
-# New-BGInfoLabel
+# Export-BGInfoConfiguration
 ## SYNOPSIS
-Creates a BGInfo label entry.
+Exports a BGInfo configuration to JSON.
 
 ## SYNTAX
 ### __AllParameterSets
 ```powershell
-New-BGInfoLabel -Name <string> [-ForEach <string>] [-Color <Object>] [-FontSize <float>] [-FontFamilyName <string>] [<CommonParameters>]
+Export-BGInfoConfiguration [-Path] <string> -InputObject <BgInfoConfiguration> [-Force] [-PassThru] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-Creates a BGInfo label entry.
+Writes a JSON file compatible with Invoke-BGInfo and the CLI.
 
 ## EXAMPLES
 
 ### EXAMPLE 1
 ```powershell
-New-BGInfoLabel -Name 'Name'
+Export-BGInfoConfiguration -InputObject 'Value'
 ```
 
 
 ## PARAMETERS
 
-### -Color
-Label color override.
+### -Force
+Overwrite the output file if it exists.
 
 ```yaml
-Type: Object
+Type: SwitchParameter
 Parameter Sets: __AllParameterSets
 Aliases: None
 Possible values:
@@ -43,11 +43,27 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -FontFamilyName
-Label font family override.
+### -InputObject
+Configuration object to export.
 
 ```yaml
-Type: String
+Type: BgInfoConfiguration
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### -PassThru
+Return the output path.
+
+```yaml
+Type: SwitchParameter
 Parameter Sets: __AllParameterSets
 Aliases: None
 Possible values:
@@ -59,40 +75,8 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -FontSize
-Label font size override.
-
-```yaml
-Type: Single
-Parameter Sets: __AllParameterSets
-Aliases: None
-Possible values:
-
-Required: False
-Position: named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -ForEach
-Variable name used to expand this label multiple times.
-
-```yaml
-Type: String
-Parameter Sets: __AllParameterSets
-Aliases: None
-Possible values:
-
-Required: False
-Position: named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -Name
-Label text to render.
+### -Path
+Output path for the JSON configuration file.
 
 ```yaml
 Type: String
@@ -101,7 +85,7 @@ Aliases: None
 Possible values:
 
 Required: True
-Position: named
+Position: 0
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -112,11 +96,11 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## INPUTS
 
-- `None`
+- `PowerBGInfo.BgInfoConfiguration`
 
 ## OUTPUTS
 
-- `PowerBGInfo.BgInfoEntry`
+- `System.String`
 
 ## RELATED LINKS
 

--- a/Docs/Invoke-BGInfo.md
+++ b/Docs/Invoke-BGInfo.md
@@ -4,47 +4,31 @@ Module Name: PowerBGInfo
 online version: https://github.com/EvotecIT/PowerBGInfo
 schema: 2.0.0
 ---
-# New-BGInfoLabel
+# Invoke-BGInfo
 ## SYNOPSIS
-Creates a BGInfo label entry.
+Runs BGInfo from a JSON configuration file.
 
 ## SYNTAX
 ### __AllParameterSets
 ```powershell
-New-BGInfoLabel -Name <string> [-ForEach <string>] [-Color <Object>] [-FontSize <float>] [-FontFamilyName <string>] [<CommonParameters>]
+Invoke-BGInfo [-Path] <string> [-OutputFileName <string>] [-ConfigurationDirectory <string>] [-MonitorIndex <int>] [-Target <BgInfoTarget>] [-NoApply] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-Creates a BGInfo label entry.
+Runs BGInfo from a JSON configuration file.
 
 ## EXAMPLES
 
 ### EXAMPLE 1
 ```powershell
-New-BGInfoLabel -Name 'Name'
+Invoke-BGInfo -Path 'C:\Path'
 ```
 
 
 ## PARAMETERS
 
-### -Color
-Label color override.
-
-```yaml
-Type: Object
-Parameter Sets: __AllParameterSets
-Aliases: None
-Possible values:
-
-Required: False
-Position: named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -FontFamilyName
-Label font family override.
+### -ConfigurationDirectory
+Override configuration output directory.
 
 ```yaml
 Type: String
@@ -59,11 +43,11 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -FontSize
-Label font size override.
+### -MonitorIndex
+Override monitor index.
 
 ```yaml
-Type: Single
+Type: Int32
 Parameter Sets: __AllParameterSets
 Aliases: None
 Possible values:
@@ -75,8 +59,24 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -ForEach
-Variable name used to expand this label multiple times.
+### -NoApply
+Generate the image without applying it to the wallpaper.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -OutputFileName
+Override output file name.
 
 ```yaml
 Type: String
@@ -91,8 +91,8 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -Name
-Label text to render.
+### -Path
+Path to the JSON configuration file.
 
 ```yaml
 Type: String
@@ -101,6 +101,22 @@ Aliases: None
 Possible values:
 
 Required: True
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Target
+Override output target.
+
+```yaml
+Type: BgInfoTarget
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values: Wallpaper, LogonScreen, Both, File
+
+Required: False
 Position: named
 Default value: None
 Accept pipeline input: False
@@ -116,7 +132,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## OUTPUTS
 
-- `PowerBGInfo.BgInfoEntry`
+- `System.String`
 
 ## RELATED LINKS
 

--- a/Docs/New-BGInfoChart.md
+++ b/Docs/New-BGInfoChart.md
@@ -1,0 +1,896 @@
+---
+external help file: PowerBGInfo-help.xml
+Module Name: PowerBGInfo
+online version: https://github.com/EvotecIT/PowerBGInfo
+schema: 2.0.0
+---
+# New-BGInfoChart
+## SYNOPSIS
+Creates a BGInfo chart definition.
+
+## SYNTAX
+### Single (Default)
+```powershell
+New-BGInfoChart [-Title <string>] [-Id <string>] [-Kind <BgInfoChartKind>] [-Value <double>] [-Labels <string[]>] [-Target <double>] [-RangeEnds <double[]>] [-Metric <BgInfoChartMetric>] [-MetricArgument <string>] [-Width <int>] [-Height <int>] [-Anchor <BgInfoTextPosition>] [-OffsetX <int>] [-OffsetY <int>] [-PositionX <int>] [-PositionY <int>] [-MaxPoints <int>] [-NoHistory] [-ReplaceHistory] [-LineColor <Object>] [-FillColor <Object>] [-Palette <Object[]>] [-BackgroundColor <Object>] [-TextColor <Object>] [-FontFamilyName <string>] [-TitleFontSize <float>] [-ValueFontSize <float>] [-ShowLatestValue] [-ValueFormat <string>] [-ValueSuffix <string>] [-BarGap <float>] [-Padding <int>] [-ShowGrid] [-GridColor <Object>] [-GridLineCount <int>] [-ShowLegend] [-ShowPointLegend] [-LegendPosition <BgInfoChartLegendPosition>] [-ShowDataLabels] [-Minimum <double>] [-Maximum <double>] [-NoDonutCenterLabel] [-DonutInnerRadiusRatio <double>] [-DonutCenterValue <string>] [-DonutCenterLabel <string>] [-NoRadialBarCenterLabel] [-NoCircleStatusLabel] [-NoProgressValues] [-NoProgressHandles] [-ProgressBarThicknessRatio <double>] [-PictorialSymbol <BgInfoChartPictorialSymbol>] [-PictorialColumns <int>] [<CommonParameters>]
+```
+
+### Multiple
+```powershell
+New-BGInfoChart [-Title <string>] [-Id <string>] [-Kind <BgInfoChartKind>] [-Values <double[]>] [-Labels <string[]>] [-Target <double>] [-RangeEnds <double[]>] [-Metric <BgInfoChartMetric>] [-MetricArgument <string>] [-Width <int>] [-Height <int>] [-Anchor <BgInfoTextPosition>] [-OffsetX <int>] [-OffsetY <int>] [-PositionX <int>] [-PositionY <int>] [-MaxPoints <int>] [-NoHistory] [-ReplaceHistory] [-LineColor <Object>] [-FillColor <Object>] [-Palette <Object[]>] [-BackgroundColor <Object>] [-TextColor <Object>] [-FontFamilyName <string>] [-TitleFontSize <float>] [-ValueFontSize <float>] [-ShowLatestValue] [-ValueFormat <string>] [-ValueSuffix <string>] [-BarGap <float>] [-Padding <int>] [-ShowGrid] [-GridColor <Object>] [-GridLineCount <int>] [-ShowLegend] [-ShowPointLegend] [-LegendPosition <BgInfoChartLegendPosition>] [-ShowDataLabels] [-Minimum <double>] [-Maximum <double>] [-NoDonutCenterLabel] [-DonutInnerRadiusRatio <double>] [-DonutCenterValue <string>] [-DonutCenterLabel <string>] [-NoRadialBarCenterLabel] [-NoCircleStatusLabel] [-NoProgressValues] [-NoProgressHandles] [-ProgressBarThicknessRatio <double>] [-PictorialSymbol <BgInfoChartPictorialSymbol>] [-PictorialColumns <int>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Creates a BGInfo chart definition.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+New-BGInfoChart -Anchor 'Value'
+```
+
+
+## PARAMETERS
+
+### -Anchor
+Anchor position for placement.
+
+```yaml
+Type: BgInfoTextPosition
+Parameter Sets: Single, Multiple
+Aliases: None
+Possible values: TopLeft, TopCenter, TopRight, MiddleLeft, MiddleCenter, MiddleRight, BottomLeft, BottomCenter, BottomRight
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -BackgroundColor
+Background color for the chart block.
+
+```yaml
+Type: Object
+Parameter Sets: Single, Multiple
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -BarGap
+Gap between bars (0-1).
+
+```yaml
+Type: Single
+Parameter Sets: Single, Multiple
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DonutCenterLabel
+Donut center label text.
+
+```yaml
+Type: String
+Parameter Sets: Single, Multiple
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DonutCenterValue
+Donut center value text.
+
+```yaml
+Type: String
+Parameter Sets: Single, Multiple
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DonutInnerRadiusRatio
+Donut inner radius ratio.
+
+```yaml
+Type: Double
+Parameter Sets: Single, Multiple
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -FillColor
+Fill color for sparklines.
+
+```yaml
+Type: Object
+Parameter Sets: Single, Multiple
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -FontFamilyName
+Font family for title and value.
+
+```yaml
+Type: String
+Parameter Sets: Single, Multiple
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -GridColor
+Grid line color.
+
+```yaml
+Type: Object
+Parameter Sets: Single, Multiple
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -GridLineCount
+Number of horizontal grid lines.
+
+```yaml
+Type: Int32
+Parameter Sets: Single, Multiple
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Height
+Chart height in pixels.
+
+```yaml
+Type: Int32
+Parameter Sets: Single, Multiple
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Id
+Chart identifier used for history storage.
+
+```yaml
+Type: String
+Parameter Sets: Single, Multiple
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Kind
+Chart kind to render, such as Sparkline, Line, Area, Bar, HorizontalBar, Gauge, Circle, RadialBar, Bullet, Pie, Donut, ProgressBar, or Pictorial.
+
+```yaml
+Type: BgInfoChartKind
+Parameter Sets: Single, Multiple
+Aliases: None
+Possible values: Sparkline, Line, Area, Bar, HorizontalBar, Gauge, Circle, RadialBar, Bullet, Pie, Donut, ProgressBar, Pictorial
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Labels
+Optional labels used by point-based charts.
+
+```yaml
+Type: String[]
+Parameter Sets: Single, Multiple
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -LegendPosition
+Chart legend position.
+
+```yaml
+Type: BgInfoChartLegendPosition
+Parameter Sets: Single, Multiple
+Aliases: None
+Possible values: Bottom, Top, Left, Right
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -LineColor
+Line or bar color.
+
+```yaml
+Type: Object
+Parameter Sets: Single, Multiple
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Maximum
+Optional maximum scale value.
+
+```yaml
+Type: Double
+Parameter Sets: Single, Multiple
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -MaxPoints
+Maximum number of samples to keep in history.
+
+```yaml
+Type: Int32
+Parameter Sets: Single, Multiple
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Metric
+Built-in metric source used when no explicit values are provided.
+
+```yaml
+Type: BgInfoChartMetric
+Parameter Sets: Single, Multiple
+Aliases: None
+Possible values: None, CpuPercent, MemoryPercent, DiskFreePercent, DiskUsedPercent, DiskFreeGb, UptimeHours, UptimeDays
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -MetricArgument
+Optional metric argument (for example drive letter).
+
+```yaml
+Type: String
+Parameter Sets: Single, Multiple
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Minimum
+Optional minimum scale value.
+
+```yaml
+Type: Double
+Parameter Sets: Single, Multiple
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -NoCircleStatusLabel
+Hide circle status label.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: Single, Multiple
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -NoDonutCenterLabel
+Hide donut center label.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: Single, Multiple
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -NoHistory
+Disable history storage and render only provided values.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: Single, Multiple
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -NoProgressHandles
+Hide progress handles.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: Single, Multiple
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -NoProgressValues
+Hide progress values.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: Single, Multiple
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -NoRadialBarCenterLabel
+Hide radial-bar center label.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: Single, Multiple
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -OffsetX
+Horizontal offset from the anchor.
+
+```yaml
+Type: Int32
+Parameter Sets: Single, Multiple
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -OffsetY
+Vertical offset from the anchor.
+
+```yaml
+Type: Int32
+Parameter Sets: Single, Multiple
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Padding
+Padding inside the chart.
+
+```yaml
+Type: Int32
+Parameter Sets: Single, Multiple
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Palette
+Palette colors for point-based charts.
+
+```yaml
+Type: Object[]
+Parameter Sets: Single, Multiple
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -PictorialColumns
+Pictorial symbols per row.
+
+```yaml
+Type: Int32
+Parameter Sets: Single, Multiple
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -PictorialSymbol
+Pictorial chart symbol.
+
+```yaml
+Type: BgInfoChartPictorialSymbol
+Parameter Sets: Single, Multiple
+Aliases: None
+Possible values: Circle, Square, Diamond, Triangle, Star, Person
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -PositionX
+Absolute X position for placement.
+
+```yaml
+Type: Int32
+Parameter Sets: Single, Multiple
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -PositionY
+Absolute Y position for placement.
+
+```yaml
+Type: Int32
+Parameter Sets: Single, Multiple
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ProgressBarThicknessRatio
+Progress-bar thickness ratio.
+
+```yaml
+Type: Double
+Parameter Sets: Single, Multiple
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -RangeEnds
+Qualitative range ends used by bullet charts.
+
+```yaml
+Type: Double[]
+Parameter Sets: Single, Multiple
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ReplaceHistory
+Replace history instead of appending values.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: Single, Multiple
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ShowDataLabels
+Show supported data labels.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: Single, Multiple
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ShowGrid
+Show chart grid lines.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: Single, Multiple
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ShowLatestValue
+Show the latest value text.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: Single, Multiple
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ShowLegend
+Show the chart legend.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: Single, Multiple
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ShowPointLegend
+Show point-level legend entries.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: Single, Multiple
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Target
+Target value used by bullet charts.
+
+```yaml
+Type: Double
+Parameter Sets: Single, Multiple
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TextColor
+Text color for title/value.
+
+```yaml
+Type: Object
+Parameter Sets: Single, Multiple
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Title
+Chart title displayed above the plot.
+
+```yaml
+Type: String
+Parameter Sets: Single, Multiple
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TitleFontSize
+Title font size.
+
+```yaml
+Type: Single
+Parameter Sets: Single, Multiple
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Value
+Single value to append.
+
+```yaml
+Type: Double
+Parameter Sets: Single
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ValueFontSize
+Value font size.
+
+```yaml
+Type: Single
+Parameter Sets: Single, Multiple
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ValueFormat
+Format string for the latest value.
+
+```yaml
+Type: String
+Parameter Sets: Single, Multiple
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Values
+Multiple values to append or replace.
+
+```yaml
+Type: Double[]
+Parameter Sets: Multiple
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ValueSuffix
+Suffix appended to the latest value.
+
+```yaml
+Type: String
+Parameter Sets: Single, Multiple
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Width
+Chart width in pixels.
+
+```yaml
+Type: Int32
+Parameter Sets: Single, Multiple
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `None`
+
+## OUTPUTS
+
+- `PowerBGInfo.BgInfoChart`
+
+## RELATED LINKS
+
+- None

--- a/Docs/New-BGInfoConfiguration.md
+++ b/Docs/New-BGInfoConfiguration.md
@@ -4,24 +4,24 @@ Module Name: PowerBGInfo
 online version: https://github.com/EvotecIT/PowerBGInfo
 schema: 2.0.0
 ---
-# New-BGInfo
+# New-BGInfoConfiguration
 ## SYNOPSIS
-Creates a BGInfo overlay image and optionally applies it as wallpaper.
+Creates a BGInfo configuration object.
 
 ## SYNTAX
 ### __AllParameterSets
 ```powershell
-New-BGInfo [-BGInfoContent] <scriptblock> -ConfigurationDirectory <string> [-FilePath <string>] [-OutputFileName <string>] [-FontFamilyName <string>] [-Color <Object>] [-BackgroundColor <Object>] [-FontSize <int>] [-ValueColor <Object>] [-ValueFontSize <float>] [-ValueFontFamilyName <string>] [-ValueWrapWidth <int>] [-SpaceBetweenLines <int>] [-SpaceBetweenColumns <int>] [-PositionX <float>] [-PositionY <float>] [-MonitorIndex <int>] [-SpaceX <int>] [-SpaceY <int>] [-WallpaperFit <DesktopWallpaperPosition>] [-TextPosition <BgInfoTextPosition>] [-Target <BgInfoTarget>] [-ChartLayout <BgInfoChartLayoutMode>] [-ChartStackAnchor <BgInfoTextPosition>] [-ChartStackDirection <BgInfoChartStackDirection>] [-ChartStackSpacing <int>] [-ChartStackOffsetX <int>] [-ChartStackOffsetY <int>] [-ChartStackAlignToTextBlock] [-ChartStackOutsideTextBlock] [-AllUsers] [-ExcludeDefaultUserProfile] [-DisableWallpaperRefresh] [-DisableWallpaperSlideshow] [-UseScreenCoordinates] [-JsonPath <string>] [-ExportOnly] [-PassThru] [<CommonParameters>]
+New-BGInfoConfiguration [-FilePath <string>] [-OutputFileName <string>] [-ConfigurationDirectory <string>] [-FontFamilyName <string>] [-Color <Object>] [-BackgroundColor <Object>] [-FontSize <float>] [-ValueColor <Object>] [-ValueFontSize <float>] [-ValueFontFamilyName <string>] [-ValueWrapWidth <int>] [-SpaceBetweenLines <int>] [-SpaceBetweenColumns <int>] [-PositionX <float>] [-PositionY <float>] [-MonitorIndex <int>] [-SpaceX <int>] [-SpaceY <int>] [-WallpaperFit <DesktopWallpaperPosition>] [-TextPosition <BgInfoTextPosition>] [-Target <BgInfoTarget>] [-ChartLayout <BgInfoChartLayoutMode>] [-ChartStackAnchor <BgInfoTextPosition>] [-ChartStackDirection <BgInfoChartStackDirection>] [-ChartStackSpacing <int>] [-ChartStackOffsetX <int>] [-ChartStackOffsetY <int>] [-ChartStackAlignToTextBlock] [-ChartStackOutsideTextBlock] [-AllUsers] [-ExcludeDefaultUserProfile] [-DisableWallpaperRefresh] [-DisableWallpaperSlideshow] [-UseScreenCoordinates] [-Entries <BgInfoEntry[]>] [-Variables <BgInfoVariable[]>] [-Charts <BgInfoChart[]>] [-Topologies <BgInfoTopology[]>] [-Images <BgInfoImage[]>] [-VisualCanvases <BgInfoVisualCanvas[]>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-Use the script block to emit label/value entries.
+Use this to build reusable configurations that can be exported to JSON.
 
 ## EXAMPLES
 
 ### EXAMPLE 1
 ```powershell
-New-BGInfo -ConfigurationDirectory 'Value'
+New-BGInfoConfiguration -FilePath 'C:\Path'
 ```
 
 
@@ -59,22 +59,6 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -BGInfoContent
-Script block that outputs BGInfo entries.
-
-```yaml
-Type: ScriptBlock
-Parameter Sets: __AllParameterSets
-Aliases: None
-Possible values:
-
-Required: True
-Position: 0
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -ChartLayout
 Chart layout mode.
 
@@ -83,6 +67,22 @@ Type: BgInfoChartLayoutMode
 Parameter Sets: __AllParameterSets
 Aliases: None
 Possible values: Manual, Stack
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Charts
+Charts to include in the configuration.
+
+```yaml
+Type: BgInfoChart[]
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
 
 Required: False
 Position: named
@@ -172,7 +172,7 @@ Accept wildcard characters: False
 ```
 
 ### -ChartStackOutsideTextBlock
-Place stacked charts outside the text block.
+Place stacked charts outside of the text block.
 
 ```yaml
 Type: SwitchParameter
@@ -228,7 +228,7 @@ Parameter Sets: __AllParameterSets
 Aliases: None
 Possible values:
 
-Required: True
+Required: False
 Position: named
 Default value: None
 Accept pipeline input: False
@@ -236,7 +236,7 @@ Accept wildcard characters: False
 ```
 
 ### -DisableWallpaperRefresh
-Disable the forced wallpaper refresh after generation.
+Disable wallpaper refresh (keep old behavior).
 
 ```yaml
 Type: SwitchParameter
@@ -267,6 +267,22 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -Entries
+Entries to include in the configuration.
+
+```yaml
+Type: BgInfoEntry[]
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -ExcludeDefaultUserProfile
 Exclude the default user profile when applying to all users.
 
@@ -283,24 +299,8 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -ExportOnly
-Export JSON only and skip image generation/application. Requires JsonPath.
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: __AllParameterSets
-Aliases: None
-Possible values:
-
-Required: False
-Position: named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -FilePath
-Optional base wallpaper file path. When omitted, current wallpaper is used.
+Optional base wallpaper file path.
 
 ```yaml
 Type: String
@@ -335,7 +335,7 @@ Accept wildcard characters: False
 Default label font size.
 
 ```yaml
-Type: Int32
+Type: Single
 Parameter Sets: __AllParameterSets
 Aliases: None
 Possible values:
@@ -347,11 +347,11 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -JsonPath
-Optional path where the generated configuration JSON should be saved.
+### -Images
+Image overlays to include in the configuration.
 
 ```yaml
-Type: String
+Type: BgInfoImage[]
 Parameter Sets: __AllParameterSets
 Aliases: None
 Possible values:
@@ -395,24 +395,8 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -PassThru
-Return the generated configuration object instead of rendering the image.
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: __AllParameterSets
-Aliases: None
-Possible values:
-
-Required: False
-Position: named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -PositionX
-Legacy position X placeholder (reserved for future layout strategies).
+Legacy position X placeholder.
 
 ```yaml
 Type: Single
@@ -428,7 +412,7 @@ Accept wildcard characters: False
 ```
 
 ### -PositionY
-Legacy position Y placeholder (reserved for future layout strategies).
+Legacy position Y placeholder.
 
 ```yaml
 Type: Single
@@ -524,7 +508,7 @@ Accept wildcard characters: False
 ```
 
 ### -TextPosition
-Layout anchor position (for example TopLeft, TopCenter, BottomRight).
+Layout anchor position.
 
 ```yaml
 Type: BgInfoTextPosition
@@ -539,8 +523,24 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -Topologies
+Topology diagrams to include in the configuration.
+
+```yaml
+Type: BgInfoTopology[]
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -UseScreenCoordinates
-Use screen coordinates for placement calculations.
+Use screen coordinates for layout positioning.
 
 ```yaml
 Type: SwitchParameter
@@ -619,6 +619,38 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -Variables
+Variables to include in the configuration.
+
+```yaml
+Type: BgInfoVariable[]
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -VisualCanvases
+Visual canvas overlays to include in the configuration.
+
+```yaml
+Type: BgInfoVisualCanvas[]
+Parameter Sets: __AllParameterSets
+Aliases: VisualCanvas
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -WallpaperFit
 Wallpaper fit mode used after generation.
 
@@ -644,7 +676,6 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## OUTPUTS
 
-- `System.String`
 - `PowerBGInfo.BgInfoConfiguration`
 
 ## RELATED LINKS

--- a/Docs/New-BGInfoImage.md
+++ b/Docs/New-BGInfoImage.md
@@ -1,0 +1,203 @@
+---
+external help file: PowerBGInfo-help.xml
+Module Name: PowerBGInfo
+online version: https://github.com/EvotecIT/PowerBGInfo
+schema: 2.0.0
+---
+# New-BGInfoImage
+## SYNOPSIS
+Creates a BGInfo image overlay definition.
+
+## SYNTAX
+### __AllParameterSets
+```powershell
+New-BGInfoImage [-Path] <string> [-Width <int>] [-Height <int>] [-Anchor <BgInfoTextPosition>] [-OffsetX <int>] [-OffsetY <int>] [-PositionX <int>] [-PositionY <int>] [-Opacity <double>] [-Fit <BgInfoImageFit>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Creates a BGInfo image overlay definition.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+New-BGInfoImage -Path 'C:\Path'
+```
+
+
+## PARAMETERS
+
+### -Anchor
+Anchor position for placement.
+
+```yaml
+Type: BgInfoTextPosition
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values: TopLeft, TopCenter, TopRight, MiddleLeft, MiddleCenter, MiddleRight, BottomLeft, BottomCenter, BottomRight
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Fit
+How the image is fitted inside the destination rectangle.
+
+```yaml
+Type: BgInfoImageFit
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values: Stretch, Contain, Cover, Center, Tile
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Height
+Target image height in pixels. Omit with Width to preserve aspect ratio.
+
+```yaml
+Type: Int32
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -OffsetX
+Horizontal offset from the anchor.
+
+```yaml
+Type: Int32
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -OffsetY
+Vertical offset from the anchor.
+
+```yaml
+Type: Int32
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Opacity
+Image opacity from zero to one.
+
+```yaml
+Type: Double
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Path
+Path to the image file.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: FullName
+Possible values:
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -PositionX
+Absolute X position for placement.
+
+```yaml
+Type: Int32
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -PositionY
+Absolute Y position for placement.
+
+```yaml
+Type: Int32
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Width
+Target image width in pixels. Omit with Height to preserve aspect ratio.
+
+```yaml
+Type: Int32
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `None`
+
+## OUTPUTS
+
+- `PowerBGInfo.BgInfoImage`
+
+## RELATED LINKS
+
+- None

--- a/Docs/New-BGInfoTopology.md
+++ b/Docs/New-BGInfoTopology.md
@@ -1,0 +1,347 @@
+---
+external help file: PowerBGInfo-help.xml
+Module Name: PowerBGInfo
+online version: https://github.com/EvotecIT/PowerBGInfo
+schema: 2.0.0
+---
+# New-BGInfoTopology
+## SYNOPSIS
+Creates a BGInfo topology overlay definition.
+
+## SYNTAX
+### __AllParameterSets
+```powershell
+New-BGInfoTopology [-TopologyDefinition] <scriptblock> [-Title <string>] [-Subtitle <string>] [-Width <int>] [-Height <int>] [-Anchor <BgInfoTextPosition>] [-OffsetX <int>] [-OffsetY <int>] [-PositionX <int>] [-PositionY <int>] [-Layout <TopologyLayoutMode>] [-Direction <TopologyLayoutDirection>] [-NodeDisplayMode <TopologyNodeDisplayMode>] [-Theme <string>] [-Opaque] [-NoTitle] [-ShowLegend] [-NoGroups] [-NoEdgeLabels] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Creates a BGInfo topology overlay definition.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+New-BGInfoTopology -Anchor 'Value'
+```
+
+
+## PARAMETERS
+
+### -Anchor
+Anchor position for placement.
+
+```yaml
+Type: BgInfoTextPosition
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values: TopLeft, TopCenter, TopRight, MiddleLeft, MiddleCenter, MiddleRight, BottomLeft, BottomCenter, BottomRight
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Direction
+Topology layout direction.
+
+```yaml
+Type: TopologyLayoutDirection
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values: TopToBottom, LeftToRight, BottomToTop, RightToLeft
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Height
+Topology height in pixels.
+
+```yaml
+Type: Int32
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Layout
+Topology layout mode.
+
+```yaml
+Type: TopologyLayoutMode
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values: Manual, GroupGrid, HubAndSpoke, Layered, Matrix, DenseGrouped, Geographic, ForceDirected, RelationshipRadial, MindMap
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -NodeDisplayMode
+Node presentation mode.
+
+```yaml
+Type: TopologyNodeDisplayMode
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values: Card, CompactCard, Tile, Pill, Icon, Artwork, Dot, Hidden
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -NoEdgeLabels
+Hide edge labels.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -NoGroups
+Hide group containers.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -NoTitle
+Hide the topology title.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -OffsetX
+Horizontal offset from the anchor.
+
+```yaml
+Type: Int32
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -OffsetY
+Vertical offset from the anchor.
+
+```yaml
+Type: Int32
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Opaque
+Use an opaque topology canvas.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -PositionX
+Absolute X position.
+
+```yaml
+Type: Int32
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -PositionY
+Absolute Y position.
+
+```yaml
+Type: Int32
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ShowLegend
+Show the topology legend.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Subtitle
+Topology subtitle.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Theme
+Theme name.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values: Light, Dark
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Title
+Topology title.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TopologyDefinition
+Script block that emits topology groups, nodes, and edges.
+
+```yaml
+Type: ScriptBlock
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Width
+Topology width in pixels.
+
+```yaml
+Type: Int32
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `None`
+
+## OUTPUTS
+
+- `PowerBGInfo.BgInfoTopology`
+
+## RELATED LINKS
+
+- None

--- a/Docs/New-BGInfoTopologyEdge.md
+++ b/Docs/New-BGInfoTopologyEdge.md
@@ -1,0 +1,203 @@
+---
+external help file: PowerBGInfo-help.xml
+Module Name: PowerBGInfo
+online version: https://github.com/EvotecIT/PowerBGInfo
+schema: 2.0.0
+---
+# New-BGInfoTopologyEdge
+## SYNOPSIS
+Creates a BGInfo topology edge definition.
+
+## SYNTAX
+### __AllParameterSets
+```powershell
+New-BGInfoTopologyEdge [-SourceNodeId] <string> [-TargetNodeId] <string> [[-Label] <string>] [-Id <string>] [-Kind <TopologyEdgeKind>] [-Status <TopologyHealthStatus>] [-Direction <VisualLinkDirection>] [-Routing <TopologyEdgeRouting>] [-Color <string>] [-Muted] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Creates a BGInfo topology edge definition.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+New-BGInfoTopologyEdge -Color 'Value'
+```
+
+
+## PARAMETERS
+
+### -Color
+Optional edge color as CSS hex.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Direction
+Direction marker behavior.
+
+```yaml
+Type: VisualLinkDirection
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values: None, Forward, Backward, Bidirectional
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Id
+Stable edge identifier. When omitted, one is derived from source and target ids.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Kind
+Relationship kind.
+
+```yaml
+Type: TopologyEdgeKind
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values: Generic, Link, Replication, Connectivity, Dependency, Trust, Mapping, AuthenticationPath, CertificateChain, DataFlow, Ownership, Membership
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Label
+Primary edge label.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: 2
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Muted
+Render the edge as a quiet structural relationship.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Routing
+Edge routing mode.
+
+```yaml
+Type: TopologyEdgeRouting
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values: Straight, Curved, Orthogonal, ObstacleAvoidingOrthogonal
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SourceNodeId
+Source node identifier.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Status
+Relationship health or state.
+
+```yaml
+Type: TopologyHealthStatus
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values: Healthy, Warning, Critical, Unknown, Disabled
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TargetNodeId
+Target node identifier.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `None`
+
+## OUTPUTS
+
+- `ChartForgeX.Topology.TopologyEdge`
+
+## RELATED LINKS
+
+- None

--- a/Docs/New-BGInfoTopologyGroup.md
+++ b/Docs/New-BGInfoTopologyGroup.md
@@ -4,47 +4,31 @@ Module Name: PowerBGInfo
 online version: https://github.com/EvotecIT/PowerBGInfo
 schema: 2.0.0
 ---
-# New-BGInfoLabel
+# New-BGInfoTopologyGroup
 ## SYNOPSIS
-Creates a BGInfo label entry.
+Creates a BGInfo topology group definition.
 
 ## SYNTAX
 ### __AllParameterSets
 ```powershell
-New-BGInfoLabel -Name <string> [-ForEach <string>] [-Color <Object>] [-FontSize <float>] [-FontFamilyName <string>] [<CommonParameters>]
+New-BGInfoTopologyGroup [-Id] <string> [-Label] <string> [-Subtitle <string>] [-Status <TopologyHealthStatus>] [-Symbol <string>] [-Color <string>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-Creates a BGInfo label entry.
+Creates a BGInfo topology group definition.
 
 ## EXAMPLES
 
 ### EXAMPLE 1
 ```powershell
-New-BGInfoLabel -Name 'Name'
+New-BGInfoTopologyGroup -Color 'Value'
 ```
 
 
 ## PARAMETERS
 
 ### -Color
-Label color override.
-
-```yaml
-Type: Object
-Parameter Sets: __AllParameterSets
-Aliases: None
-Possible values:
-
-Required: False
-Position: named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -FontFamilyName
-Label font family override.
+Optional group accent color as CSS hex.
 
 ```yaml
 Type: String
@@ -59,40 +43,8 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -FontSize
-Label font size override.
-
-```yaml
-Type: Single
-Parameter Sets: __AllParameterSets
-Aliases: None
-Possible values:
-
-Required: False
-Position: named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -ForEach
-Variable name used to expand this label multiple times.
-
-```yaml
-Type: String
-Parameter Sets: __AllParameterSets
-Aliases: None
-Possible values:
-
-Required: False
-Position: named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -Name
-Label text to render.
+### -Id
+Stable group identifier.
 
 ```yaml
 Type: String
@@ -101,6 +53,70 @@ Aliases: None
 Possible values:
 
 Required: True
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Label
+Group label rendered in the topology.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Status
+Group health or state.
+
+```yaml
+Type: TopologyHealthStatus
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values: Healthy, Warning, Critical, Unknown, Disabled
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Subtitle
+Optional group subtitle.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Symbol
+Short symbol rendered near the group header.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
 Position: named
 Default value: None
 Accept pipeline input: False
@@ -116,7 +132,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## OUTPUTS
 
-- `PowerBGInfo.BgInfoEntry`
+- `ChartForgeX.Topology.TopologyGroup`
 
 ## RELATED LINKS
 

--- a/Docs/New-BGInfoTopologyNode.md
+++ b/Docs/New-BGInfoTopologyNode.md
@@ -1,0 +1,203 @@
+---
+external help file: PowerBGInfo-help.xml
+Module Name: PowerBGInfo
+online version: https://github.com/EvotecIT/PowerBGInfo
+schema: 2.0.0
+---
+# New-BGInfoTopologyNode
+## SYNOPSIS
+Creates a BGInfo topology node definition.
+
+## SYNTAX
+### __AllParameterSets
+```powershell
+New-BGInfoTopologyNode [-Id] <string> [-Label] <string> [-Subtitle <string>] [-Kind <TopologyNodeKind>] [-Status <TopologyHealthStatus>] [-GroupId <string>] [-Symbol <string>] [-Badge <string>] [-Color <string>] [-DisplayMode <TopologyNodeDisplayMode>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Creates a BGInfo topology node definition.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+New-BGInfoTopologyNode -Badge 'Value'
+```
+
+
+## PARAMETERS
+
+### -Badge
+Optional badge text.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Color
+Optional node accent color as CSS hex.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DisplayMode
+Optional node display mode override.
+
+```yaml
+Type: TopologyNodeDisplayMode
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values: Card, CompactCard, Tile, Pill, Icon, Artwork, Dot, Hidden
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -GroupId
+Optional parent group identifier.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Id
+Stable node identifier used by topology edges.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Kind
+Node kind used for icon and legend selection.
+
+```yaml
+Type: TopologyNodeKind
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values: Generic, Group, Location, Hub, Branch, Server, Service, Endpoint, Gateway, Cloud, Database, Storage, Network, NetworkSegment, Namespace, Application, Process, Queue, Person, Team, Certificate
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Label
+Node label rendered in the topology.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Status
+Node health or state.
+
+```yaml
+Type: TopologyHealthStatus
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values: Healthy, Warning, Critical, Unknown, Disabled
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Subtitle
+Optional node subtitle.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Symbol
+Short symbol rendered inside or near the node icon.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `None`
+
+## OUTPUTS
+
+- `ChartForgeX.Topology.TopologyNode`
+
+## RELATED LINKS
+
+- None

--- a/Docs/New-BGInfoValue.md
+++ b/Docs/New-BGInfoValue.md
@@ -1,232 +1,209 @@
 ---
 external help file: PowerBGInfo-help.xml
 Module Name: PowerBGInfo
-online version:
+online version: https://github.com/EvotecIT/PowerBGInfo
 schema: 2.0.0
 ---
-
 # New-BGInfoValue
-
 ## SYNOPSIS
-Special function that provides a way to create a value that will be displayed on the background image.
+Creates a BGInfo value entry.
 
 ## SYNTAX
-
 ### Values (Default)
-```
-New-BGInfoValue -Name <String> -Value <String> [-Color <Color>] [-FontSize <Single>] [-FontFamilyName <String>]
- [-ValueColor <Color>] [-ValueFontSize <Single>] [-ValueFontFamilyName <String>] [<CommonParameters>]
+```powershell
+New-BGInfoValue -Name <string> -Value <string> [-Color <Object>] [-FontSize <float>] [-FontFamilyName <string>] [-ValueColor <Object>] [-ValueFontSize <float>] [-ValueFontFamilyName <string>] [<CommonParameters>]
 ```
 
 ### Builtin
+```powershell
+New-BGInfoValue -BuiltinValue <string> [-Name <string>] [-Color <Object>] [-FontSize <float>] [-FontFamilyName <string>] [-ValueColor <Object>] [-ValueFontSize <float>] [-ValueFontFamilyName <string>] [<CommonParameters>]
 ```
-New-BGInfoValue [-Name <String>] -BuiltinValue <String> [-Color <Color>] [-FontSize <Single>]
- [-FontFamilyName <String>] [-ValueColor <Color>] [-ValueFontSize <Single>] [-ValueFontFamilyName <String>]
- [<CommonParameters>]
+
+### Template
+```powershell
+New-BGInfoValue -Name <string> -Value <string> -ForEach <string> [-Color <Object>] [-FontSize <float>] [-FontFamilyName <string>] [-ValueColor <Object>] [-ValueFontSize <float>] [-ValueFontFamilyName <string>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-Special function that provides a way to create a value that will be displayed on the background image.
-It allows using builtin values, or custom values depending on user needs.
+Creates a BGInfo value entry.
 
 ## EXAMPLES
 
 ### EXAMPLE 1
+```powershell
+New-BGInfoValue -Name 'Name' -Value 'Value'
 ```
-New-BGInfoValue -BuiltinValue HostName -Color Red -FontSize 20 -FontFamilyName 'Calibri'
 
-
-New-BGInfoValue -BuiltinValue FullUserName
-New-BGInfoValue -BuiltinValue CpuName
-```
 
 ### EXAMPLE 2
+```powershell
+New-BGInfoValue -BuiltinValue 'Value'
 ```
-# Lets get all drives and their labels
 
 
-foreach ($Disk in (Get-Disk)) {
-    $Volumes = $Disk | Get-Partition | Get-Volume
-    foreach ($V in $Volumes) {
-        New-BGInfoValue -Name "Drive $($V.DriveLetter)" -Value $V.SizeRemaining
-    }
-}
+### EXAMPLE 3
+```powershell
+New-BGInfoValue -Name 'Name' -Value 'Value' -ForEach 'Value'
 ```
+
 
 ## PARAMETERS
 
-### -Name
-Label that will be used on the left side of the value.
-
-```yaml
-Type: String
-Parameter Sets: Values
-Aliases:
-
-Required: True
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-```yaml
-Type: String
-Parameter Sets: Builtin
-Aliases:
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -Value
-Cystom Value that will be displayed on the right side of the label.
-
-```yaml
-Type: String
-Parameter Sets: Values
-Aliases:
-
-Required: True
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -BuiltinValue
-Builtin value that will be displayed on the right side of the label.
-It can be one of the following:
-- UserName - Current user name
-- HostName - Current host name
-- FullUserName - Current user name with domain
-- CpuName - CPU name
-- CpuMaxClockSpeed - CPU max clock speed
-- CpuCores - CPU cores
-- CpuLogicalCores - CPU logical cores
-- RAMSize - RAM size
-- RAMSpeed - RAM speed
-- RAMPartNumber - RAM part number
-- BiosVersion - BIOS version
-- BiosManufacturer - BIOS manufacturer
-- BiosReleaseDate - BIOS release date
-- OSName - OS name
-- OSVersion - OS version
-- OSArchitecture - OS architecture
-- OSBuild - OS build
-- OSInstallDate - OS install date
-- OSLastBootUpTime - OS last boot up time
-- UserDNSDomain - User DNS domain
-- FQDN - Fully qualified domain name
-- IPv4Address - IPv4 address
-- IPv6Address - IPv6 address
+Built-in token to resolve to a value.
 
 ```yaml
 Type: String
 Parameter Sets: Builtin
-Aliases:
+Aliases: None
+Possible values: UserName, HostName, FullUserName, CpuName, CpuMaxClockSpeed, CpuCores, CpuLogicalCores, RAMSize, RAMSpeed, RAMPartNumber, BiosVersion, BiosManufacturer, BiosReleaseDate, OSName, OSVersion, OSArchitecture, OSBuild, OSInstallDate, OSLastBootUpTime, UserDNSDomain, FQDN, IPv4Address, IPv6Address
 
 Required: True
-Position: Named
+Position: named
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -Color
-Color for the label.
-If not provided it will be taken from the parent New-BGInfo command.
+Label color override.
 
 ```yaml
-Type: Color
-Parameter Sets: (All)
-Aliases:
+Type: Object
+Parameter Sets: Values, Builtin, Template
+Aliases: None
+Possible values:
 
 Required: False
-Position: Named
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -FontFamilyName
+Label font family override.
+
+```yaml
+Type: String
+Parameter Sets: Values, Builtin, Template
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -FontSize
-Font size for the label.
-If not provided it will be taken from the parent New-BGInfo command.
+Label font size override.
 
 ```yaml
 Type: Single
-Parameter Sets: (All)
-Aliases:
+Parameter Sets: Values, Builtin, Template
+Aliases: None
+Possible values:
 
 Required: False
-Position: Named
-Default value: 0
+Position: named
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -FontFamilyName
-Font family name for the label.
-If not provided it will be taken from the parent New-BGInfo command.
+### -ForEach
+Variable name used to expand this entry multiple times.
 
 ```yaml
 Type: String
-Parameter Sets: (All)
-Aliases:
+Parameter Sets: Template
+Aliases: None
+Possible values:
 
-Required: False
-Position: Named
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Name
+Label text to render.
+
+```yaml
+Type: String
+Parameter Sets: Values, Builtin, Template
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Value
+Explicit value to render.
+
+```yaml
+Type: String
+Parameter Sets: Values, Template
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -ValueColor
-Color for the value.
-If not provided it will be taken first from Color of the label and if that is not provided from the parent New-BGInfo command.
+Value color override.
 
 ```yaml
-Type: Color
-Parameter Sets: (All)
-Aliases:
+Type: Object
+Parameter Sets: Values, Builtin, Template
+Aliases: None
+Possible values:
 
 Required: False
-Position: Named
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ValueFontFamilyName
+Value font family override.
+
+```yaml
+Type: String
+Parameter Sets: Values, Builtin, Template
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -ValueFontSize
-Font size for the value.
-If not provided it will be taken first from FontSize of the label and if that is not provided from the parent New-BGInfo command.
+Value font size override.
 
 ```yaml
 Type: Single
-Parameter Sets: (All)
-Aliases:
+Parameter Sets: Values, Builtin, Template
+Aliases: None
+Possible values:
 
 Required: False
-Position: Named
-Default value: 0
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -ValueFontFamilyName
-Font family name for the value.
-If not provided it will be taken first from FontFamilyName of the label and if that is not provided from the parent New-BGInfo command.
-
-```yaml
-Type: String
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
+Position: named
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -237,9 +214,12 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## INPUTS
 
+- `None`
+
 ## OUTPUTS
 
-## NOTES
-General notes
+- `PowerBGInfo.BgInfoEntry`
 
 ## RELATED LINKS
+
+- None

--- a/Docs/New-BGInfoVariable.md
+++ b/Docs/New-BGInfoVariable.md
@@ -4,79 +4,31 @@ Module Name: PowerBGInfo
 online version: https://github.com/EvotecIT/PowerBGInfo
 schema: 2.0.0
 ---
-# New-BGInfoLabel
+# New-BGInfoVariable
 ## SYNOPSIS
-Creates a BGInfo label entry.
+Creates a reusable BGInfo variable backed by a built-in provider.
 
 ## SYNTAX
 ### __AllParameterSets
 ```powershell
-New-BGInfoLabel -Name <string> [-ForEach <string>] [-Color <Object>] [-FontSize <float>] [-FontFamilyName <string>] [<CommonParameters>]
+New-BGInfoVariable -Name <string> -Provider <BgInfoVariableProvider> [-Argument <string>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-Creates a BGInfo label entry.
+Creates a reusable BGInfo variable backed by a built-in provider.
 
 ## EXAMPLES
 
 ### EXAMPLE 1
 ```powershell
-New-BGInfoLabel -Name 'Name'
+New-BGInfoVariable -Name 'Name' -Provider 'Value'
 ```
 
 
 ## PARAMETERS
 
-### -Color
-Label color override.
-
-```yaml
-Type: Object
-Parameter Sets: __AllParameterSets
-Aliases: None
-Possible values:
-
-Required: False
-Position: named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -FontFamilyName
-Label font family override.
-
-```yaml
-Type: String
-Parameter Sets: __AllParameterSets
-Aliases: None
-Possible values:
-
-Required: False
-Position: named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -FontSize
-Label font size override.
-
-```yaml
-Type: Single
-Parameter Sets: __AllParameterSets
-Aliases: None
-Possible values:
-
-Required: False
-Position: named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -ForEach
-Variable name used to expand this label multiple times.
+### -Argument
+Optional provider argument for filtering/customization.
 
 ```yaml
 Type: String
@@ -92,13 +44,29 @@ Accept wildcard characters: False
 ```
 
 ### -Name
-Label text to render.
+Name used by -ForEach references.
 
 ```yaml
 Type: String
 Parameter Sets: __AllParameterSets
 Aliases: None
 Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Provider
+Built-in provider used to populate the variable.
+
+```yaml
+Type: BgInfoVariableProvider
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values: Volumes
 
 Required: True
 Position: named
@@ -116,7 +84,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## OUTPUTS
 
-- `PowerBGInfo.BgInfoEntry`
+- `PowerBGInfo.BgInfoVariable`
 
 ## RELATED LINKS
 

--- a/Docs/New-BGInfoVisualCanvas.md
+++ b/Docs/New-BGInfoVisualCanvas.md
@@ -1,0 +1,904 @@
+---
+external help file: PowerBGInfo-help.xml
+Module Name: PowerBGInfo
+online version: https://github.com/EvotecIT/PowerBGInfo
+schema: 2.0.0
+---
+# New-BGInfoVisualCanvas
+## SYNOPSIS
+Creates a BGInfo visual canvas definition backed by ChartForgeX.
+
+## SYNTAX
+### __AllParameterSets
+```powershell
+New-BGInfoVisualCanvas [-Template <BgInfoVisualCanvasTemplate>] [-LayoutPreset <BgInfoVisualCanvasLayoutPreset>] [-Title <string>] [-Subtitle <string>] [-Width <int>] [-Height <int>] [-PositionX <int>] [-PositionY <int>] [-BackgroundTop <Object>] [-BackgroundBottom <Object>] [-Accent <Object>] [-SecondaryAccent <Object>] [-TitleColor <Object>] [-TitleAccentColor <Object>] [-SubtitleColor <Object>] [-TileGlassTop <Object>] [-TileGlassBottom <Object>] [-TileLabelColor <Object>] [-TileValueColor <Object>] [-TileDetailColor <Object>] [-TileProgressTrackColor <Object>] [-HeroBadgeTop <Object>] [-HeroBadgeBottom <Object>] [-HeroBadgeTextColor <Object>] [-NoHeroBadge] [-NoHeroContent] [-HeroBadgeText <string>] [-HeroBadgeImagePath <string>] [-HeroBadgeImageFit <BgInfoImageFit>] [-HeroBadgeImagePadding <int>] [-HeroBadgeImageOpacity <double>] [-FeatureAnchor <BgInfoTextPosition>] [-FeatureWidth <int>] [-FeatureHeight <int>] [-TileWidth <int>] [-TileHeight <int>] [-TileGap <int>] [-LeftTileWidth <int>] [-RightTileWidth <int>] [-CenterTileWidth <int>] [-LeftTileOffsetX <int>] [-LeftTileOffsetY <int>] [-RightTileOffsetX <int>] [-RightTileOffsetY <int>] [-CenterTileOffsetX <int>] [-CenterTileOffsetY <int>] [-TileTextFitPolicy <BgInfoVisualCanvasTileTextFitPolicy>] [-FeatureOffsetX <int>] [-FeatureOffsetY <int>] [-NoTechBackdrop] [-Opaque] [-Tile <BgInfoVisualCanvasTile[]>] [-Feature <BgInfoVisualCanvasFeature[]>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Visual canvases render a reusable HUD-style overlay with a central title, side information boxes, and an optional feature strip.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+$tiles = @(
+    New-BGInfoVisualCanvasTile -Side Left -IconKind Computer -SurfaceStyle Raised -Label HOSTNAME -Value '{{HostName}}'
+    New-BGInfoVisualCanvasTile -Side Right -IconKind Cpu -SurfaceStyle Raised -Label 'CPU LOAD' -Value '31% active' -MiniChartKind Area -MiniChartValues 22,28,25,36,31 -MiniChartMaximum 100
+)
+
+New-BGInfo -Target File {
+    New-BGInfoVisualCanvas -Title 'PowerBGInfo' -Subtitle 'High-contrast information boxes' -Tile $tiles -TileGlassTop '#FFF7EDD9' -TileGlassBottom '#DBEAFECC' -TileValueColor '#0F172AFF'
+} -FilePath .\Examples\Samples\TapC-Evotec-2560x1080.jpg -ConfigurationDirectory .\Examples\Output -OutputFileName 'PowerBGInfo.VisualCanvas.ContrastBox.jpg' -WallpaperFit Fill
+```
+
+
+### EXAMPLE 2
+```powershell
+New-BGInfoVisualCanvas -Title 'PowerBGInfo' -Feature $features -FeatureAnchor BottomRight -FeatureWidth 610 -FeatureOffsetX 165 -FeatureOffsetY 120
+```
+
+
+## PARAMETERS
+
+### -Accent
+Primary accent color.
+
+```yaml
+Type: Object
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -BackgroundBottom
+Bottom background color.
+
+```yaml
+Type: Object
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -BackgroundTop
+Top background color.
+
+```yaml
+Type: Object
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -CenterTileOffsetX
+Horizontal centered-lane offset in pixels. Positive values move the lane to the right.
+
+```yaml
+Type: Int32
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -CenterTileOffsetY
+Vertical centered-lane offset in pixels.
+
+```yaml
+Type: Int32
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -CenterTileWidth
+Default centered-lane tile width in pixels. Zero uses TileWidth or the template default.
+
+```yaml
+Type: Int32
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Feature
+Feature strip item definitions.
+
+```yaml
+Type: BgInfoVisualCanvasFeature[]
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -FeatureAnchor
+Optional feature-strip anchor. When omitted, the template keeps its default centered strip placement.
+
+```yaml
+Type: BgInfoTextPosition
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values: TopLeft, TopCenter, TopRight, MiddleLeft, MiddleCenter, MiddleRight, BottomLeft, BottomCenter, BottomRight
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -FeatureHeight
+Optional feature-strip height in pixels. Zero uses the template default height.
+
+```yaml
+Type: Int32
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -FeatureOffsetX
+Horizontal feature-strip offset. For right anchors, positive values inset from the right edge.
+
+```yaml
+Type: Int32
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -FeatureOffsetY
+Vertical feature-strip offset. For bottom anchors, positive values inset from the bottom edge.
+
+```yaml
+Type: Int32
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -FeatureWidth
+Optional feature-strip width in pixels. Zero uses the template default width.
+
+```yaml
+Type: Int32
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Height
+Canvas height in pixels. Zero uses the target wallpaper height.
+
+```yaml
+Type: Int32
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -HeroBadgeBottom
+Hero badge bottom fill color.
+
+```yaml
+Type: Object
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -HeroBadgeImageFit
+How the hero badge image is fitted inside the badge.
+
+```yaml
+Type: BgInfoImageFit
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values: Stretch, Contain, Cover, Center, Tile
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -HeroBadgeImageOpacity
+Hero badge image opacity from zero to one.
+
+```yaml
+Type: Double
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -HeroBadgeImagePadding
+Padding inside the hero badge image area.
+
+```yaml
+Type: Int32
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -HeroBadgeImagePath
+Optional image path rendered inside the central hero badge.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -HeroBadgeText
+Text rendered in the central hero badge when no image is configured.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: HeroBadgeSymbol
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -HeroBadgeTextColor
+Hero badge symbol color.
+
+```yaml
+Type: Object
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -HeroBadgeTop
+Hero badge top fill color.
+
+```yaml
+Type: Object
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -LayoutPreset
+Responsive side-rail sizing preset.
+
+```yaml
+Type: BgInfoVisualCanvasLayoutPreset
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values: Default, Compact, Comfortable, WideRails, Dense
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -LeftTileOffsetX
+Horizontal left side-rail offset in pixels.
+
+```yaml
+Type: Int32
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -LeftTileOffsetY
+Vertical left side-rail offset in pixels.
+
+```yaml
+Type: Int32
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -LeftTileWidth
+Default left side-rail tile width in pixels. Zero uses TileWidth or the template default.
+
+```yaml
+Type: Int32
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -NoHeroBadge
+Hide the central hero badge while keeping the title, subtitle, tiles, and feature strip.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -NoHeroContent
+Hide the central hero badge, title, and subtitle while keeping tiles and the feature strip.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -NoTechBackdrop
+Disable the built-in technology backdrop.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Opaque
+Render a full ChartForgeX background instead of floating over the wallpaper.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -PositionX
+Explicit X position on the generated wallpaper.
+
+```yaml
+Type: Int32
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -PositionY
+Explicit Y position on the generated wallpaper.
+
+```yaml
+Type: Int32
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -RightTileOffsetX
+Horizontal right side-rail inset in pixels.
+
+```yaml
+Type: Int32
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -RightTileOffsetY
+Vertical right side-rail offset in pixels.
+
+```yaml
+Type: Int32
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -RightTileWidth
+Default right side-rail tile width in pixels. Zero uses TileWidth or the template default.
+
+```yaml
+Type: Int32
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SecondaryAccent
+Secondary accent color for badge and backdrop highlights.
+
+```yaml
+Type: Object
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Subtitle
+Canvas subtitle text.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SubtitleColor
+Subtitle text color.
+
+```yaml
+Type: Object
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Template
+Visual canvas template.
+
+```yaml
+Type: BgInfoVisualCanvasTemplate
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values: PowerBgInfoHero
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Tile
+Tile lane definitions.
+
+```yaml
+Type: BgInfoVisualCanvasTile[]
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TileDetailColor
+Tile detail text color.
+
+```yaml
+Type: Object
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TileGap
+Default vertical gap between tiles in pixels. Zero uses the template default gap.
+
+```yaml
+Type: Int32
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TileGlassBottom
+Glass tile bottom color.
+
+```yaml
+Type: Object
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TileGlassTop
+Glass tile top color.
+
+```yaml
+Type: Object
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TileHeight
+Default tile height in pixels. Zero uses the template default height.
+
+```yaml
+Type: Int32
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TileLabelColor
+Tile label text color.
+
+```yaml
+Type: Object
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TileProgressTrackColor
+Tile progress track color.
+
+```yaml
+Type: Object
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TileTextFitPolicy
+Default tile text fitting policy.
+
+```yaml
+Type: BgInfoVisualCanvasTileTextFitPolicy
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values: Auto, SingleLineEllipsis, Wrap, ShrinkToFit, WrapThenShrink
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TileValueColor
+Tile value text color.
+
+```yaml
+Type: Object
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TileWidth
+Default tile width in pixels. Zero uses the template default width.
+
+```yaml
+Type: Int32
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Title
+Canvas title or brand text.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TitleAccentColor
+Accent hero title color.
+
+```yaml
+Type: Object
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TitleColor
+Primary hero title color.
+
+```yaml
+Type: Object
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Width
+Canvas width in pixels. Zero uses the target wallpaper width.
+
+```yaml
+Type: Int32
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `None`
+
+## OUTPUTS
+
+- `PowerBGInfo.BgInfoVisualCanvas`
+
+## RELATED LINKS
+
+- None

--- a/Docs/New-BGInfoVisualCanvasFeature.md
+++ b/Docs/New-BGInfoVisualCanvasFeature.md
@@ -1,0 +1,78 @@
+---
+external help file: PowerBGInfo-help.xml
+Module Name: PowerBGInfo
+online version: https://github.com/EvotecIT/PowerBGInfo
+schema: 2.0.0
+---
+# New-BGInfoVisualCanvasFeature
+## SYNOPSIS
+Creates a BGInfo visual canvas feature-strip item.
+
+## SYNTAX
+### __AllParameterSets
+```powershell
+New-BGInfoVisualCanvasFeature -Label <string> [-Icon <string>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Feature-strip items are compact labels shown in the optional visual canvas footer strip.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+$features = @(
+    New-BGInfoVisualCanvasFeature -Icon 'A+' -Label 'light contrast boxes'
+    New-BGInfoVisualCanvasFeature -Icon 'JSON' -Label 'portable config'
+)
+```
+
+
+## PARAMETERS
+
+### -Icon
+Compact item icon or symbol.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Label
+Feature label.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `None`
+
+## OUTPUTS
+
+- `PowerBGInfo.BgInfoVisualCanvasFeature`
+
+## RELATED LINKS
+
+- None

--- a/Docs/New-BGInfoVisualCanvasTile.md
+++ b/Docs/New-BGInfoVisualCanvasTile.md
@@ -11,7 +11,7 @@ Creates a BGInfo visual canvas tile definition.
 ## SYNTAX
 ### __AllParameterSets
 ```powershell
-New-BGInfoVisualCanvasTile -Label <string> -Value <string> [-Side <BgInfoVisualCanvasSide>] [-Icon <string>] [-Detail <string>] [-Width <int>] [-Height <int>] [-Accent <Object>] [-Progress <double>] [-SurfaceStyle <BgInfoVisualCanvasTileSurfaceStyle>] [-IconKind <BgInfoVisualCanvasTileIconKind>] [-MiniChartKind <BgInfoVisualCanvasTileMiniChartKind>] [-TextFitPolicy <BgInfoVisualCanvasTileTextFitPolicy>] [-MiniChartValues <double[]>] [-MiniChartMaximum <double>] [<CommonParameters>]
+New-BGInfoVisualCanvasTile -Label <string> -Value <string> [-Side <BgInfoVisualCanvasSide>] [-Icon <string>] [-Detail <string>] [-Width <int>] [-Height <int>] [-Accent <Object>] [-Progress <Double>] [-SurfaceStyle <BgInfoVisualCanvasTileSurfaceStyle>] [-IconKind <BgInfoVisualCanvasTileIconKind>] [-MiniChartKind <BgInfoVisualCanvasTileMiniChartKind>] [-TextFitPolicy <BgInfoVisualCanvasTileTextFitPolicy>] [-MiniChartValues <double[]>] [-MiniChartMaximum <Double>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -149,7 +149,7 @@ Accept wildcard characters: False
 Optional compact chart maximum.
 
 ```yaml
-Type: Nullable`1
+Type: Double
 Parameter Sets: __AllParameterSets
 Aliases: None
 Possible values:
@@ -181,7 +181,7 @@ Accept wildcard characters: False
 Optional progress value from zero to one.
 
 ```yaml
-Type: Nullable`1
+Type: Double
 Parameter Sets: __AllParameterSets
 Aliases: None
 Possible values:

--- a/Docs/New-BGInfoVisualCanvasTile.md
+++ b/Docs/New-BGInfoVisualCanvasTile.md
@@ -1,0 +1,289 @@
+---
+external help file: PowerBGInfo-help.xml
+Module Name: PowerBGInfo
+online version: https://github.com/EvotecIT/PowerBGInfo
+schema: 2.0.0
+---
+# New-BGInfoVisualCanvasTile
+## SYNOPSIS
+Creates a BGInfo visual canvas tile definition.
+
+## SYNTAX
+### __AllParameterSets
+```powershell
+New-BGInfoVisualCanvasTile -Label <string> -Value <string> [-Side <BgInfoVisualCanvasSide>] [-Icon <string>] [-Detail <string>] [-Width <int>] [-Height <int>] [-Accent <Object>] [-Progress <double>] [-SurfaceStyle <BgInfoVisualCanvasTileSurfaceStyle>] [-IconKind <BgInfoVisualCanvasTileIconKind>] [-MiniChartKind <BgInfoVisualCanvasTileMiniChartKind>] [-TextFitPolicy <BgInfoVisualCanvasTileTextFitPolicy>] [-MiniChartValues <double[]>] [-MiniChartMaximum <double>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Tiles are the readable lane-based information boxes used by New-BGInfoVisualCanvas.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+New-BGInfoVisualCanvasTile -Side Left -IconKind Computer -SurfaceStyle Raised -Label HOSTNAME -Value '{{HostName}}' -Detail 'production desktop' -Accent '#0F766EFF'
+```
+
+
+### EXAMPLE 2
+```powershell
+New-BGInfoVisualCanvasTile -Side Right -IconKind Cpu -SurfaceStyle Raised -Label 'CPU LOAD' -Value '31% active' -MiniChartKind Area -MiniChartValues 22,28,25,36,31 -MiniChartMaximum 100
+```
+
+
+## PARAMETERS
+
+### -Accent
+Optional accent color.
+
+```yaml
+Type: Object
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Detail
+Optional detail text. Templates are resolved at render time.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Height
+Optional tile height in pixels. Zero uses the visual canvas default or template default.
+
+```yaml
+Type: Int32
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Icon
+Compact tile icon or symbol.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -IconKind
+Built-in icon to render instead of the Icon text.
+
+```yaml
+Type: BgInfoVisualCanvasTileIconKind
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values: Text, Computer, Network, OperatingSystem, Cpu, Memory, User, Domain, Terminal, Storage, Shield
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Label
+Tile label. Templates such as {{HostName}} are resolved at render time.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -MiniChartKind
+Compact chart kind rendered inside the tile.
+
+```yaml
+Type: BgInfoVisualCanvasTileMiniChartKind
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values: None, Sparkline, Area, Bars
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -MiniChartMaximum
+Optional compact chart maximum.
+
+```yaml
+Type: Nullable`1
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -MiniChartValues
+Compact chart values rendered inside the tile.
+
+```yaml
+Type: Double[]
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Progress
+Optional progress value from zero to one.
+
+```yaml
+Type: Nullable`1
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Side
+Tile lane placement.
+
+```yaml
+Type: BgInfoVisualCanvasSide
+Parameter Sets: __AllParameterSets
+Aliases: Lane
+Possible values: Left, Right, Center
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SurfaceStyle
+Tile surface style.
+
+```yaml
+Type: BgInfoVisualCanvasTileSurfaceStyle
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values: Glass, Outline, Raised
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TextFitPolicy
+Tile-specific text fitting policy. Auto inherits the visual canvas setting.
+
+```yaml
+Type: BgInfoVisualCanvasTileTextFitPolicy
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values: Auto, SingleLineEllipsis, Wrap, ShrinkToFit, WrapThenShrink
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Value
+Primary tile value. Templates such as {{HostName}} are resolved at render time.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Width
+Optional tile width in pixels. Zero uses the visual canvas default or template default.
+
+```yaml
+Type: Int32
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `None`
+
+## OUTPUTS
+
+- `PowerBGInfo.BgInfoVisualCanvasTile`
+
+## RELATED LINKS
+
+- None

--- a/Docs/Readme.md
+++ b/Docs/Readme.md
@@ -1,23 +1,59 @@
 ---
 Module Name: PowerBGInfo
 Module Guid: 91b9c52d-6a39-4a65-a276-409b9390ee04
-Download Help Link: {{ Update Download Link }}
-Help Version: {{ Please enter version of help manually (X.X.X.X) format }}
+Download Help Link: https://github.com/EvotecIT/PowerBGInfo
+Help Version: 2.0.2
 Locale: en-US
 ---
-
 # PowerBGInfo Module
 ## Description
-{{ Fill in the Description }}
+PowerBGInfo is a module that allows you to create background images with information about your environment.
 
 ## PowerBGInfo Cmdlets
+### [Export-BGInfoConfiguration](Export-BGInfoConfiguration.md)
+Exports a BGInfo configuration to JSON.
+
+### [Invoke-BGInfo](Invoke-BGInfo.md)
+Runs BGInfo from a JSON configuration file.
+
 ### [New-BGInfo](New-BGInfo.md)
-Provides a simple way to create PowerBGInfo configuration.
+Creates a BGInfo overlay image and optionally applies it as wallpaper.
+
+### [New-BGInfoChart](New-BGInfoChart.md)
+Creates a BGInfo chart definition.
+
+### [New-BGInfoConfiguration](New-BGInfoConfiguration.md)
+Creates a BGInfo configuration object.
+
+### [New-BGInfoImage](New-BGInfoImage.md)
+Creates a BGInfo image overlay definition.
 
 ### [New-BGInfoLabel](New-BGInfoLabel.md)
-Provides ability to set label without value.
-It can be used to separate different sections of information.
+Creates a BGInfo label entry.
+
+### [New-BGInfoTopology](New-BGInfoTopology.md)
+Creates a BGInfo topology overlay definition.
+
+### [New-BGInfoTopologyEdge](New-BGInfoTopologyEdge.md)
+Creates a BGInfo topology edge definition.
+
+### [New-BGInfoTopologyGroup](New-BGInfoTopologyGroup.md)
+Creates a BGInfo topology group definition.
+
+### [New-BGInfoTopologyNode](New-BGInfoTopologyNode.md)
+Creates a BGInfo topology node definition.
 
 ### [New-BGInfoValue](New-BGInfoValue.md)
-Special function that provides a way to create a value that will be displayed on the background image.
+Creates a BGInfo value entry.
 
+### [New-BGInfoVariable](New-BGInfoVariable.md)
+Creates a reusable BGInfo variable backed by a built-in provider.
+
+### [New-BGInfoVisualCanvas](New-BGInfoVisualCanvas.md)
+Creates a BGInfo visual canvas definition backed by ChartForgeX.
+
+### [New-BGInfoVisualCanvasFeature](New-BGInfoVisualCanvasFeature.md)
+Creates a BGInfo visual canvas feature-strip item.
+
+### [New-BGInfoVisualCanvasTile](New-BGInfoVisualCanvasTile.md)
+Creates a BGInfo visual canvas tile definition.

--- a/PowerBGInfo.psd1
+++ b/PowerBGInfo.psd1
@@ -9,7 +9,7 @@
     DotNetFrameworkVersion = '4.7.2'
     FunctionsToExport      = @()
     GUID                   = '91b9c52d-6a39-4a65-a276-409b9390ee04'
-    ModuleVersion          = '2.0.1'
+    ModuleVersion          = '2.0.2'
     PowerShellVersion      = '5.1'
     PrivateData            = @{
         PSData = @{

--- a/Sources/PowerBGInfo.PowerShell/PowerBGInfo.PowerShell.csproj
+++ b/Sources/PowerBGInfo.PowerShell/PowerBGInfo.PowerShell.csproj
@@ -47,7 +47,7 @@
     </ItemGroup>
 
     <PropertyGroup>
-        <!-- This is needed for XmlDoc2CmdletDoc to generate a PowerShell documentation file. -->
+        <!-- PowerForge enriches module help from the compiler XML documentation file. -->
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
     </PropertyGroup>
 
@@ -61,17 +61,4 @@
         <Delete Files="$(OutDir)System.Management.dll" Condition="'$(TargetFramework)' == 'net472'" />
     </Target>
 
-    <ItemGroup>
-        <PackageReference Include="MatejKafka.XmlDoc2CmdletDoc" Version="0.8.0">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-    </ItemGroup>
-
-    <!-- Copy help documentation to publish output after publish -->
-    <Target Name="CopyHelpDocumentationToPublishOutput" AfterTargets="Publish">
-        <Copy SourceFiles="$(OutputPath)$(AssemblyName).dll-Help.xml"
-            DestinationFiles="$(PublishDir)$(AssemblyName).dll-Help.xml"
-            Condition="Exists('$(OutputPath)$(AssemblyName).dll-Help.xml')" />
-    </Target>
 </Project>

--- a/en-US/PowerBGInfo-help.xml
+++ b/en-US/PowerBGInfo-help.xml
@@ -8897,9 +8897,9 @@ New-BGInfo -Target File {&#xD;
           <maml:description>
             <maml:para>Optional compact chart maximum.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Double</command:parameterValue>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>Double</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -8921,9 +8921,9 @@ New-BGInfo -Target File {&#xD;
           <maml:description>
             <maml:para>Optional progress value from zero to one.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Double</command:parameterValue>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>Double</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -9116,9 +9116,9 @@ New-BGInfo -Target File {&#xD;
         <maml:description>
           <maml:para>Optional compact chart maximum.</maml:para>
         </maml:description>
-        <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+        <command:parameterValue required="false" variableLength="false">Double</command:parameterValue>
         <dev:type>
-          <maml:name>Nullable`1</maml:name>
+          <maml:name>Double</maml:name>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
@@ -9140,9 +9140,9 @@ New-BGInfo -Target File {&#xD;
         <maml:description>
           <maml:para>Optional progress value from zero to one.</maml:para>
         </maml:description>
-        <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+        <command:parameterValue required="false" variableLength="false">Double</command:parameterValue>
         <dev:type>
-          <maml:name>Nullable`1</maml:name>
+          <maml:name>Double</maml:name>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>

--- a/en-US/PowerBGInfo-help.xml
+++ b/en-US/PowerBGInfo-help.xml
@@ -1,0 +1,9265 @@
+<?xml version="1.0" encoding="utf-8"?>
+<helpItems schema="maml" xmlns="http://msh">
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>Export-BGInfoConfiguration</command:name>
+      <command:verb>Export</command:verb>
+      <command:noun>BGInfoConfiguration</command:noun>
+      <maml:description>
+        <maml:para>Exports a BGInfo configuration to JSON.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Writes a JSON file compatible with Invoke-BGInfo and the CLI.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="__AllParameterSets">
+        <maml:name>Export-BGInfoConfiguration</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Force</maml:name>
+          <maml:description>
+            <maml:para>Overwrite the output file if it exists.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="None">
+          <maml:name>InputObject</maml:name>
+          <maml:description>
+            <maml:para>Configuration object to export.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">BgInfoConfiguration</command:parameterValue>
+          <dev:type>
+            <maml:name>BgInfoConfiguration</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>PassThru</maml:name>
+          <maml:description>
+            <maml:para>Return the output path.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="0" aliases="None">
+          <maml:name>Path</maml:name>
+          <maml:description>
+            <maml:para>Output path for the JSON configuration file.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Force</maml:name>
+        <maml:description>
+          <maml:para>Overwrite the output file if it exists.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="None">
+        <maml:name>InputObject</maml:name>
+        <maml:description>
+          <maml:para>Configuration object to export.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">BgInfoConfiguration</command:parameterValue>
+        <dev:type>
+          <maml:name>BgInfoConfiguration</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>PassThru</maml:name>
+        <maml:description>
+          <maml:para>Return the output path.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="0" aliases="None">
+        <maml:name>Path</maml:name>
+        <maml:description>
+          <maml:para>Output path for the JSON configuration file.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>PowerBGInfo.BgInfoConfiguration</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>System.String</maml:name>
+        </dev:type>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>EXAMPLE 1</maml:title>
+        <dev:code>Export-BGInfoConfiguration -InputObject 'Value'</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>Invoke-BGInfo</command:name>
+      <command:verb>Invoke</command:verb>
+      <command:noun>BGInfo</command:noun>
+      <maml:description>
+        <maml:para>Runs BGInfo from a JSON configuration file.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Runs BGInfo from a JSON configuration file.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="__AllParameterSets">
+        <maml:name>Invoke-BGInfo</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ConfigurationDirectory</maml:name>
+          <maml:description>
+            <maml:para>Override configuration output directory.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>MonitorIndex</maml:name>
+          <maml:description>
+            <maml:para>Override monitor index.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>NoApply</maml:name>
+          <maml:description>
+            <maml:para>Generate the image without applying it to the wallpaper.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>OutputFileName</maml:name>
+          <maml:description>
+            <maml:para>Override output file name.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="0" aliases="None">
+          <maml:name>Path</maml:name>
+          <maml:description>
+            <maml:para>Path to the JSON configuration file.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Target</maml:name>
+          <maml:description>
+            <maml:para>Override output target.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">BgInfoTarget</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Wallpaper</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">LogonScreen</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Both</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">File</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>BgInfoTarget</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ConfigurationDirectory</maml:name>
+        <maml:description>
+          <maml:para>Override configuration output directory.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>MonitorIndex</maml:name>
+        <maml:description>
+          <maml:para>Override monitor index.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>NoApply</maml:name>
+        <maml:description>
+          <maml:para>Generate the image without applying it to the wallpaper.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>OutputFileName</maml:name>
+        <maml:description>
+          <maml:para>Override output file name.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="0" aliases="None">
+        <maml:name>Path</maml:name>
+        <maml:description>
+          <maml:para>Path to the JSON configuration file.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Target</maml:name>
+        <maml:description>
+          <maml:para>Override output target.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">BgInfoTarget</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">Wallpaper</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">LogonScreen</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Both</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">File</command:parameterValue>
+        </command:parameterValueGroup>
+        <dev:type>
+          <maml:name>BgInfoTarget</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>None</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>System.String</maml:name>
+        </dev:type>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>EXAMPLE 1</maml:title>
+        <dev:code>Invoke-BGInfo -Path 'C:\Path'</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>New-BGInfo</command:name>
+      <command:verb>New</command:verb>
+      <command:noun>BGInfo</command:noun>
+      <maml:description>
+        <maml:para>Creates a BGInfo overlay image and optionally applies it as wallpaper.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Use the script block to emit label/value entries.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="__AllParameterSets">
+        <maml:name>New-BGInfo</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>AllUsers</maml:name>
+          <maml:description>
+            <maml:para>Apply wallpaper for all user profiles.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>BackgroundColor</maml:name>
+          <maml:description>
+            <maml:para>Background color to use when no wallpaper image is available.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Object</command:parameterValue>
+          <dev:type>
+            <maml:name>Object</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="0" aliases="None">
+          <maml:name>BGInfoContent</maml:name>
+          <maml:description>
+            <maml:para>Script block that outputs BGInfo entries.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">ScriptBlock</command:parameterValue>
+          <dev:type>
+            <maml:name>ScriptBlock</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ChartLayout</maml:name>
+          <maml:description>
+            <maml:para>Chart layout mode.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">BgInfoChartLayoutMode</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Manual</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Stack</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>BgInfoChartLayoutMode</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ChartStackAlignToTextBlock</maml:name>
+          <maml:description>
+            <maml:para>Align stacked charts to the text block.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ChartStackAnchor</maml:name>
+          <maml:description>
+            <maml:para>Anchor used when stacking charts.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">BgInfoTextPosition</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">TopLeft</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TopCenter</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TopRight</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MiddleLeft</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MiddleCenter</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MiddleRight</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">BottomLeft</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">BottomCenter</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">BottomRight</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>BgInfoTextPosition</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ChartStackDirection</maml:name>
+          <maml:description>
+            <maml:para>Direction used when stacking charts.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">BgInfoChartStackDirection</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Vertical</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Horizontal</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>BgInfoChartStackDirection</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ChartStackOffsetX</maml:name>
+          <maml:description>
+            <maml:para>Horizontal offset for stacked charts.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ChartStackOffsetY</maml:name>
+          <maml:description>
+            <maml:para>Vertical offset for stacked charts.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ChartStackOutsideTextBlock</maml:name>
+          <maml:description>
+            <maml:para>Place stacked charts outside the text block.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ChartStackSpacing</maml:name>
+          <maml:description>
+            <maml:para>Spacing between stacked charts.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Color</maml:name>
+          <maml:description>
+            <maml:para>Default label color.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Object</command:parameterValue>
+          <dev:type>
+            <maml:name>Object</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ConfigurationDirectory</maml:name>
+          <maml:description>
+            <maml:para>Output directory for generated BGInfo images.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>DisableWallpaperRefresh</maml:name>
+          <maml:description>
+            <maml:para>Disable the forced wallpaper refresh after generation.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>DisableWallpaperSlideshow</maml:name>
+          <maml:description>
+            <maml:para>Disable automatic preservation of the current Windows wallpaper slideshow.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ExcludeDefaultUserProfile</maml:name>
+          <maml:description>
+            <maml:para>Exclude the default user profile when applying to all users.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ExportOnly</maml:name>
+          <maml:description>
+            <maml:para>Export JSON only and skip image generation/application. Requires JsonPath.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>FilePath</maml:name>
+          <maml:description>
+            <maml:para>Optional base wallpaper file path. When omitted, current wallpaper is used.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>FontFamilyName</maml:name>
+          <maml:description>
+            <maml:para>Default label font family.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>FontSize</maml:name>
+          <maml:description>
+            <maml:para>Default label font size.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>JsonPath</maml:name>
+          <maml:description>
+            <maml:para>Optional path where the generated configuration JSON should be saved.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>MonitorIndex</maml:name>
+          <maml:description>
+            <maml:para>Monitor index to target for wallpaper operations.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>OutputFileName</maml:name>
+          <maml:description>
+            <maml:para>Optional output file name for the generated image.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>PassThru</maml:name>
+          <maml:description>
+            <maml:para>Return the generated configuration object instead of rendering the image.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>PositionX</maml:name>
+          <maml:description>
+            <maml:para>Legacy position X placeholder (reserved for future layout strategies).</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Single</command:parameterValue>
+          <dev:type>
+            <maml:name>Single</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>PositionY</maml:name>
+          <maml:description>
+            <maml:para>Legacy position Y placeholder (reserved for future layout strategies).</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Single</command:parameterValue>
+          <dev:type>
+            <maml:name>Single</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>SpaceBetweenColumns</maml:name>
+          <maml:description>
+            <maml:para>Spacing between label and value columns.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>SpaceBetweenLines</maml:name>
+          <maml:description>
+            <maml:para>Vertical spacing between rows.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>SpaceX</maml:name>
+          <maml:description>
+            <maml:para>X padding used for layout positioning.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>SpaceY</maml:name>
+          <maml:description>
+            <maml:para>Y padding used for layout positioning.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Target</maml:name>
+          <maml:description>
+            <maml:para>Output target (Wallpaper, File, LogonScreen, or Both).</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">BgInfoTarget</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Wallpaper</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">LogonScreen</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Both</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">File</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>BgInfoTarget</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>TextPosition</maml:name>
+          <maml:description>
+            <maml:para>Layout anchor position (for example TopLeft, TopCenter, BottomRight).</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">BgInfoTextPosition</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">TopLeft</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TopCenter</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TopRight</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MiddleLeft</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MiddleCenter</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MiddleRight</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">BottomLeft</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">BottomCenter</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">BottomRight</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>BgInfoTextPosition</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>UseScreenCoordinates</maml:name>
+          <maml:description>
+            <maml:para>Use screen coordinates for placement calculations.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ValueColor</maml:name>
+          <maml:description>
+            <maml:para>Default value color.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Object</command:parameterValue>
+          <dev:type>
+            <maml:name>Object</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ValueFontFamilyName</maml:name>
+          <maml:description>
+            <maml:para>Default value font family.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ValueFontSize</maml:name>
+          <maml:description>
+            <maml:para>Default value font size.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Single</command:parameterValue>
+          <dev:type>
+            <maml:name>Single</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ValueWrapWidth</maml:name>
+          <maml:description>
+            <maml:para>Maximum width used when wrapping value text. Set to 0 to disable wrapping.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>WallpaperFit</maml:name>
+          <maml:description>
+            <maml:para>Wallpaper fit mode used after generation.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">DesktopWallpaperPosition</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Center</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Tile</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Stretch</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Fit</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Fill</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Span</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>DesktopWallpaperPosition</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>AllUsers</maml:name>
+        <maml:description>
+          <maml:para>Apply wallpaper for all user profiles.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>BackgroundColor</maml:name>
+        <maml:description>
+          <maml:para>Background color to use when no wallpaper image is available.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Object</command:parameterValue>
+        <dev:type>
+          <maml:name>Object</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="0" aliases="None">
+        <maml:name>BGInfoContent</maml:name>
+        <maml:description>
+          <maml:para>Script block that outputs BGInfo entries.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">ScriptBlock</command:parameterValue>
+        <dev:type>
+          <maml:name>ScriptBlock</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ChartLayout</maml:name>
+        <maml:description>
+          <maml:para>Chart layout mode.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">BgInfoChartLayoutMode</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">Manual</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Stack</command:parameterValue>
+        </command:parameterValueGroup>
+        <dev:type>
+          <maml:name>BgInfoChartLayoutMode</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ChartStackAlignToTextBlock</maml:name>
+        <maml:description>
+          <maml:para>Align stacked charts to the text block.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ChartStackAnchor</maml:name>
+        <maml:description>
+          <maml:para>Anchor used when stacking charts.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">BgInfoTextPosition</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">TopLeft</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">TopCenter</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">TopRight</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">MiddleLeft</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">MiddleCenter</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">MiddleRight</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">BottomLeft</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">BottomCenter</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">BottomRight</command:parameterValue>
+        </command:parameterValueGroup>
+        <dev:type>
+          <maml:name>BgInfoTextPosition</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ChartStackDirection</maml:name>
+        <maml:description>
+          <maml:para>Direction used when stacking charts.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">BgInfoChartStackDirection</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">Vertical</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Horizontal</command:parameterValue>
+        </command:parameterValueGroup>
+        <dev:type>
+          <maml:name>BgInfoChartStackDirection</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ChartStackOffsetX</maml:name>
+        <maml:description>
+          <maml:para>Horizontal offset for stacked charts.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ChartStackOffsetY</maml:name>
+        <maml:description>
+          <maml:para>Vertical offset for stacked charts.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ChartStackOutsideTextBlock</maml:name>
+        <maml:description>
+          <maml:para>Place stacked charts outside the text block.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ChartStackSpacing</maml:name>
+        <maml:description>
+          <maml:para>Spacing between stacked charts.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Color</maml:name>
+        <maml:description>
+          <maml:para>Default label color.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Object</command:parameterValue>
+        <dev:type>
+          <maml:name>Object</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ConfigurationDirectory</maml:name>
+        <maml:description>
+          <maml:para>Output directory for generated BGInfo images.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>DisableWallpaperRefresh</maml:name>
+        <maml:description>
+          <maml:para>Disable the forced wallpaper refresh after generation.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>DisableWallpaperSlideshow</maml:name>
+        <maml:description>
+          <maml:para>Disable automatic preservation of the current Windows wallpaper slideshow.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ExcludeDefaultUserProfile</maml:name>
+        <maml:description>
+          <maml:para>Exclude the default user profile when applying to all users.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ExportOnly</maml:name>
+        <maml:description>
+          <maml:para>Export JSON only and skip image generation/application. Requires JsonPath.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>FilePath</maml:name>
+        <maml:description>
+          <maml:para>Optional base wallpaper file path. When omitted, current wallpaper is used.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>FontFamilyName</maml:name>
+        <maml:description>
+          <maml:para>Default label font family.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>FontSize</maml:name>
+        <maml:description>
+          <maml:para>Default label font size.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>JsonPath</maml:name>
+        <maml:description>
+          <maml:para>Optional path where the generated configuration JSON should be saved.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>MonitorIndex</maml:name>
+        <maml:description>
+          <maml:para>Monitor index to target for wallpaper operations.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>OutputFileName</maml:name>
+        <maml:description>
+          <maml:para>Optional output file name for the generated image.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>PassThru</maml:name>
+        <maml:description>
+          <maml:para>Return the generated configuration object instead of rendering the image.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>PositionX</maml:name>
+        <maml:description>
+          <maml:para>Legacy position X placeholder (reserved for future layout strategies).</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Single</command:parameterValue>
+        <dev:type>
+          <maml:name>Single</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>PositionY</maml:name>
+        <maml:description>
+          <maml:para>Legacy position Y placeholder (reserved for future layout strategies).</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Single</command:parameterValue>
+        <dev:type>
+          <maml:name>Single</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>SpaceBetweenColumns</maml:name>
+        <maml:description>
+          <maml:para>Spacing between label and value columns.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>SpaceBetweenLines</maml:name>
+        <maml:description>
+          <maml:para>Vertical spacing between rows.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>SpaceX</maml:name>
+        <maml:description>
+          <maml:para>X padding used for layout positioning.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>SpaceY</maml:name>
+        <maml:description>
+          <maml:para>Y padding used for layout positioning.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Target</maml:name>
+        <maml:description>
+          <maml:para>Output target (Wallpaper, File, LogonScreen, or Both).</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">BgInfoTarget</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">Wallpaper</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">LogonScreen</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Both</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">File</command:parameterValue>
+        </command:parameterValueGroup>
+        <dev:type>
+          <maml:name>BgInfoTarget</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>TextPosition</maml:name>
+        <maml:description>
+          <maml:para>Layout anchor position (for example TopLeft, TopCenter, BottomRight).</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">BgInfoTextPosition</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">TopLeft</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">TopCenter</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">TopRight</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">MiddleLeft</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">MiddleCenter</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">MiddleRight</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">BottomLeft</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">BottomCenter</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">BottomRight</command:parameterValue>
+        </command:parameterValueGroup>
+        <dev:type>
+          <maml:name>BgInfoTextPosition</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>UseScreenCoordinates</maml:name>
+        <maml:description>
+          <maml:para>Use screen coordinates for placement calculations.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ValueColor</maml:name>
+        <maml:description>
+          <maml:para>Default value color.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Object</command:parameterValue>
+        <dev:type>
+          <maml:name>Object</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ValueFontFamilyName</maml:name>
+        <maml:description>
+          <maml:para>Default value font family.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ValueFontSize</maml:name>
+        <maml:description>
+          <maml:para>Default value font size.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Single</command:parameterValue>
+        <dev:type>
+          <maml:name>Single</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ValueWrapWidth</maml:name>
+        <maml:description>
+          <maml:para>Maximum width used when wrapping value text. Set to 0 to disable wrapping.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>WallpaperFit</maml:name>
+        <maml:description>
+          <maml:para>Wallpaper fit mode used after generation.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">DesktopWallpaperPosition</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">Center</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Tile</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Stretch</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Fit</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Fill</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Span</command:parameterValue>
+        </command:parameterValueGroup>
+        <dev:type>
+          <maml:name>DesktopWallpaperPosition</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>None</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>System.String</maml:name>
+        </dev:type>
+      </command:returnValue>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>PowerBGInfo.BgInfoConfiguration</maml:name>
+        </dev:type>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>EXAMPLE 1</maml:title>
+        <dev:code>New-BGInfo -ConfigurationDirectory 'Value'</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>New-BGInfoChart</command:name>
+      <command:verb>New</command:verb>
+      <command:noun>BGInfoChart</command:noun>
+      <maml:description>
+        <maml:para>Creates a BGInfo chart definition.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Creates a BGInfo chart definition.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="Single">
+        <maml:name>New-BGInfoChart</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Anchor</maml:name>
+          <maml:description>
+            <maml:para>Anchor position for placement.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">BgInfoTextPosition</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">TopLeft</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TopCenter</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TopRight</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MiddleLeft</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MiddleCenter</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MiddleRight</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">BottomLeft</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">BottomCenter</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">BottomRight</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>BgInfoTextPosition</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>BackgroundColor</maml:name>
+          <maml:description>
+            <maml:para>Background color for the chart block.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Object</command:parameterValue>
+          <dev:type>
+            <maml:name>Object</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>BarGap</maml:name>
+          <maml:description>
+            <maml:para>Gap between bars (0-1).</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Single</command:parameterValue>
+          <dev:type>
+            <maml:name>Single</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>DonutCenterLabel</maml:name>
+          <maml:description>
+            <maml:para>Donut center label text.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>DonutCenterValue</maml:name>
+          <maml:description>
+            <maml:para>Donut center value text.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>DonutInnerRadiusRatio</maml:name>
+          <maml:description>
+            <maml:para>Donut inner radius ratio.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Double</command:parameterValue>
+          <dev:type>
+            <maml:name>Double</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>FillColor</maml:name>
+          <maml:description>
+            <maml:para>Fill color for sparklines.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Object</command:parameterValue>
+          <dev:type>
+            <maml:name>Object</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>FontFamilyName</maml:name>
+          <maml:description>
+            <maml:para>Font family for title and value.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>GridColor</maml:name>
+          <maml:description>
+            <maml:para>Grid line color.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Object</command:parameterValue>
+          <dev:type>
+            <maml:name>Object</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>GridLineCount</maml:name>
+          <maml:description>
+            <maml:para>Number of horizontal grid lines.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Height</maml:name>
+          <maml:description>
+            <maml:para>Chart height in pixels.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Id</maml:name>
+          <maml:description>
+            <maml:para>Chart identifier used for history storage.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Kind</maml:name>
+          <maml:description>
+            <maml:para>Chart kind to render, such as Sparkline, Line, Area, Bar, HorizontalBar, Gauge, Circle, RadialBar, Bullet, Pie, Donut, ProgressBar, or Pictorial.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">BgInfoChartKind</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Sparkline</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Line</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Area</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Bar</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">HorizontalBar</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Gauge</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Circle</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RadialBar</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Bullet</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Pie</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Donut</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ProgressBar</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Pictorial</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>BgInfoChartKind</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Labels</maml:name>
+          <maml:description>
+            <maml:para>Optional labels used by point-based charts.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>LegendPosition</maml:name>
+          <maml:description>
+            <maml:para>Chart legend position.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">BgInfoChartLegendPosition</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Bottom</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Top</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Left</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Right</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>BgInfoChartLegendPosition</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>LineColor</maml:name>
+          <maml:description>
+            <maml:para>Line or bar color.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Object</command:parameterValue>
+          <dev:type>
+            <maml:name>Object</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Maximum</maml:name>
+          <maml:description>
+            <maml:para>Optional maximum scale value.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Double</command:parameterValue>
+          <dev:type>
+            <maml:name>Double</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>MaxPoints</maml:name>
+          <maml:description>
+            <maml:para>Maximum number of samples to keep in history.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Metric</maml:name>
+          <maml:description>
+            <maml:para>Built-in metric source used when no explicit values are provided.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">BgInfoChartMetric</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">None</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CpuPercent</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MemoryPercent</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DiskFreePercent</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DiskUsedPercent</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DiskFreeGb</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">UptimeHours</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">UptimeDays</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>BgInfoChartMetric</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>MetricArgument</maml:name>
+          <maml:description>
+            <maml:para>Optional metric argument (for example drive letter).</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Minimum</maml:name>
+          <maml:description>
+            <maml:para>Optional minimum scale value.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Double</command:parameterValue>
+          <dev:type>
+            <maml:name>Double</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>NoCircleStatusLabel</maml:name>
+          <maml:description>
+            <maml:para>Hide circle status label.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>NoDonutCenterLabel</maml:name>
+          <maml:description>
+            <maml:para>Hide donut center label.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>NoHistory</maml:name>
+          <maml:description>
+            <maml:para>Disable history storage and render only provided values.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>NoProgressHandles</maml:name>
+          <maml:description>
+            <maml:para>Hide progress handles.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>NoProgressValues</maml:name>
+          <maml:description>
+            <maml:para>Hide progress values.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>NoRadialBarCenterLabel</maml:name>
+          <maml:description>
+            <maml:para>Hide radial-bar center label.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>OffsetX</maml:name>
+          <maml:description>
+            <maml:para>Horizontal offset from the anchor.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>OffsetY</maml:name>
+          <maml:description>
+            <maml:para>Vertical offset from the anchor.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Padding</maml:name>
+          <maml:description>
+            <maml:para>Padding inside the chart.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Palette</maml:name>
+          <maml:description>
+            <maml:para>Palette colors for point-based charts.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Object[]</command:parameterValue>
+          <dev:type>
+            <maml:name>Object[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>PictorialColumns</maml:name>
+          <maml:description>
+            <maml:para>Pictorial symbols per row.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>PictorialSymbol</maml:name>
+          <maml:description>
+            <maml:para>Pictorial chart symbol.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">BgInfoChartPictorialSymbol</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Circle</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Square</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Diamond</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Triangle</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Star</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Person</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>BgInfoChartPictorialSymbol</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>PositionX</maml:name>
+          <maml:description>
+            <maml:para>Absolute X position for placement.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>PositionY</maml:name>
+          <maml:description>
+            <maml:para>Absolute Y position for placement.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ProgressBarThicknessRatio</maml:name>
+          <maml:description>
+            <maml:para>Progress-bar thickness ratio.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Double</command:parameterValue>
+          <dev:type>
+            <maml:name>Double</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>RangeEnds</maml:name>
+          <maml:description>
+            <maml:para>Qualitative range ends used by bullet charts.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Double[]</command:parameterValue>
+          <dev:type>
+            <maml:name>Double[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ReplaceHistory</maml:name>
+          <maml:description>
+            <maml:para>Replace history instead of appending values.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ShowDataLabels</maml:name>
+          <maml:description>
+            <maml:para>Show supported data labels.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ShowGrid</maml:name>
+          <maml:description>
+            <maml:para>Show chart grid lines.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ShowLatestValue</maml:name>
+          <maml:description>
+            <maml:para>Show the latest value text.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ShowLegend</maml:name>
+          <maml:description>
+            <maml:para>Show the chart legend.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ShowPointLegend</maml:name>
+          <maml:description>
+            <maml:para>Show point-level legend entries.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Target</maml:name>
+          <maml:description>
+            <maml:para>Target value used by bullet charts.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Double</command:parameterValue>
+          <dev:type>
+            <maml:name>Double</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>TextColor</maml:name>
+          <maml:description>
+            <maml:para>Text color for title/value.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Object</command:parameterValue>
+          <dev:type>
+            <maml:name>Object</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Title</maml:name>
+          <maml:description>
+            <maml:para>Chart title displayed above the plot.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>TitleFontSize</maml:name>
+          <maml:description>
+            <maml:para>Title font size.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Single</command:parameterValue>
+          <dev:type>
+            <maml:name>Single</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Value</maml:name>
+          <maml:description>
+            <maml:para>Single value to append.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Double</command:parameterValue>
+          <dev:type>
+            <maml:name>Double</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ValueFontSize</maml:name>
+          <maml:description>
+            <maml:para>Value font size.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Single</command:parameterValue>
+          <dev:type>
+            <maml:name>Single</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ValueFormat</maml:name>
+          <maml:description>
+            <maml:para>Format string for the latest value.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ValueSuffix</maml:name>
+          <maml:description>
+            <maml:para>Suffix appended to the latest value.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Width</maml:name>
+          <maml:description>
+            <maml:para>Chart width in pixels.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem parameterSetName="Multiple">
+        <maml:name>New-BGInfoChart</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Anchor</maml:name>
+          <maml:description>
+            <maml:para>Anchor position for placement.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">BgInfoTextPosition</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">TopLeft</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TopCenter</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TopRight</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MiddleLeft</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MiddleCenter</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MiddleRight</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">BottomLeft</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">BottomCenter</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">BottomRight</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>BgInfoTextPosition</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>BackgroundColor</maml:name>
+          <maml:description>
+            <maml:para>Background color for the chart block.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Object</command:parameterValue>
+          <dev:type>
+            <maml:name>Object</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>BarGap</maml:name>
+          <maml:description>
+            <maml:para>Gap between bars (0-1).</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Single</command:parameterValue>
+          <dev:type>
+            <maml:name>Single</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>DonutCenterLabel</maml:name>
+          <maml:description>
+            <maml:para>Donut center label text.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>DonutCenterValue</maml:name>
+          <maml:description>
+            <maml:para>Donut center value text.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>DonutInnerRadiusRatio</maml:name>
+          <maml:description>
+            <maml:para>Donut inner radius ratio.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Double</command:parameterValue>
+          <dev:type>
+            <maml:name>Double</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>FillColor</maml:name>
+          <maml:description>
+            <maml:para>Fill color for sparklines.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Object</command:parameterValue>
+          <dev:type>
+            <maml:name>Object</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>FontFamilyName</maml:name>
+          <maml:description>
+            <maml:para>Font family for title and value.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>GridColor</maml:name>
+          <maml:description>
+            <maml:para>Grid line color.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Object</command:parameterValue>
+          <dev:type>
+            <maml:name>Object</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>GridLineCount</maml:name>
+          <maml:description>
+            <maml:para>Number of horizontal grid lines.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Height</maml:name>
+          <maml:description>
+            <maml:para>Chart height in pixels.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Id</maml:name>
+          <maml:description>
+            <maml:para>Chart identifier used for history storage.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Kind</maml:name>
+          <maml:description>
+            <maml:para>Chart kind to render, such as Sparkline, Line, Area, Bar, HorizontalBar, Gauge, Circle, RadialBar, Bullet, Pie, Donut, ProgressBar, or Pictorial.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">BgInfoChartKind</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Sparkline</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Line</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Area</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Bar</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">HorizontalBar</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Gauge</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Circle</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RadialBar</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Bullet</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Pie</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Donut</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ProgressBar</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Pictorial</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>BgInfoChartKind</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Labels</maml:name>
+          <maml:description>
+            <maml:para>Optional labels used by point-based charts.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>LegendPosition</maml:name>
+          <maml:description>
+            <maml:para>Chart legend position.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">BgInfoChartLegendPosition</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Bottom</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Top</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Left</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Right</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>BgInfoChartLegendPosition</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>LineColor</maml:name>
+          <maml:description>
+            <maml:para>Line or bar color.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Object</command:parameterValue>
+          <dev:type>
+            <maml:name>Object</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Maximum</maml:name>
+          <maml:description>
+            <maml:para>Optional maximum scale value.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Double</command:parameterValue>
+          <dev:type>
+            <maml:name>Double</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>MaxPoints</maml:name>
+          <maml:description>
+            <maml:para>Maximum number of samples to keep in history.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Metric</maml:name>
+          <maml:description>
+            <maml:para>Built-in metric source used when no explicit values are provided.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">BgInfoChartMetric</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">None</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CpuPercent</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MemoryPercent</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DiskFreePercent</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DiskUsedPercent</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DiskFreeGb</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">UptimeHours</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">UptimeDays</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>BgInfoChartMetric</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>MetricArgument</maml:name>
+          <maml:description>
+            <maml:para>Optional metric argument (for example drive letter).</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Minimum</maml:name>
+          <maml:description>
+            <maml:para>Optional minimum scale value.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Double</command:parameterValue>
+          <dev:type>
+            <maml:name>Double</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>NoCircleStatusLabel</maml:name>
+          <maml:description>
+            <maml:para>Hide circle status label.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>NoDonutCenterLabel</maml:name>
+          <maml:description>
+            <maml:para>Hide donut center label.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>NoHistory</maml:name>
+          <maml:description>
+            <maml:para>Disable history storage and render only provided values.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>NoProgressHandles</maml:name>
+          <maml:description>
+            <maml:para>Hide progress handles.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>NoProgressValues</maml:name>
+          <maml:description>
+            <maml:para>Hide progress values.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>NoRadialBarCenterLabel</maml:name>
+          <maml:description>
+            <maml:para>Hide radial-bar center label.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>OffsetX</maml:name>
+          <maml:description>
+            <maml:para>Horizontal offset from the anchor.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>OffsetY</maml:name>
+          <maml:description>
+            <maml:para>Vertical offset from the anchor.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Padding</maml:name>
+          <maml:description>
+            <maml:para>Padding inside the chart.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Palette</maml:name>
+          <maml:description>
+            <maml:para>Palette colors for point-based charts.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Object[]</command:parameterValue>
+          <dev:type>
+            <maml:name>Object[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>PictorialColumns</maml:name>
+          <maml:description>
+            <maml:para>Pictorial symbols per row.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>PictorialSymbol</maml:name>
+          <maml:description>
+            <maml:para>Pictorial chart symbol.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">BgInfoChartPictorialSymbol</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Circle</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Square</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Diamond</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Triangle</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Star</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Person</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>BgInfoChartPictorialSymbol</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>PositionX</maml:name>
+          <maml:description>
+            <maml:para>Absolute X position for placement.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>PositionY</maml:name>
+          <maml:description>
+            <maml:para>Absolute Y position for placement.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ProgressBarThicknessRatio</maml:name>
+          <maml:description>
+            <maml:para>Progress-bar thickness ratio.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Double</command:parameterValue>
+          <dev:type>
+            <maml:name>Double</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>RangeEnds</maml:name>
+          <maml:description>
+            <maml:para>Qualitative range ends used by bullet charts.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Double[]</command:parameterValue>
+          <dev:type>
+            <maml:name>Double[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ReplaceHistory</maml:name>
+          <maml:description>
+            <maml:para>Replace history instead of appending values.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ShowDataLabels</maml:name>
+          <maml:description>
+            <maml:para>Show supported data labels.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ShowGrid</maml:name>
+          <maml:description>
+            <maml:para>Show chart grid lines.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ShowLatestValue</maml:name>
+          <maml:description>
+            <maml:para>Show the latest value text.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ShowLegend</maml:name>
+          <maml:description>
+            <maml:para>Show the chart legend.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ShowPointLegend</maml:name>
+          <maml:description>
+            <maml:para>Show point-level legend entries.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Target</maml:name>
+          <maml:description>
+            <maml:para>Target value used by bullet charts.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Double</command:parameterValue>
+          <dev:type>
+            <maml:name>Double</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>TextColor</maml:name>
+          <maml:description>
+            <maml:para>Text color for title/value.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Object</command:parameterValue>
+          <dev:type>
+            <maml:name>Object</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Title</maml:name>
+          <maml:description>
+            <maml:para>Chart title displayed above the plot.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>TitleFontSize</maml:name>
+          <maml:description>
+            <maml:para>Title font size.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Single</command:parameterValue>
+          <dev:type>
+            <maml:name>Single</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ValueFontSize</maml:name>
+          <maml:description>
+            <maml:para>Value font size.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Single</command:parameterValue>
+          <dev:type>
+            <maml:name>Single</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ValueFormat</maml:name>
+          <maml:description>
+            <maml:para>Format string for the latest value.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Values</maml:name>
+          <maml:description>
+            <maml:para>Multiple values to append or replace.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Double[]</command:parameterValue>
+          <dev:type>
+            <maml:name>Double[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ValueSuffix</maml:name>
+          <maml:description>
+            <maml:para>Suffix appended to the latest value.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Width</maml:name>
+          <maml:description>
+            <maml:para>Chart width in pixels.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Anchor</maml:name>
+        <maml:description>
+          <maml:para>Anchor position for placement.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">BgInfoTextPosition</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">TopLeft</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">TopCenter</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">TopRight</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">MiddleLeft</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">MiddleCenter</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">MiddleRight</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">BottomLeft</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">BottomCenter</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">BottomRight</command:parameterValue>
+        </command:parameterValueGroup>
+        <dev:type>
+          <maml:name>BgInfoTextPosition</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>BackgroundColor</maml:name>
+        <maml:description>
+          <maml:para>Background color for the chart block.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Object</command:parameterValue>
+        <dev:type>
+          <maml:name>Object</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>BarGap</maml:name>
+        <maml:description>
+          <maml:para>Gap between bars (0-1).</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Single</command:parameterValue>
+        <dev:type>
+          <maml:name>Single</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>DonutCenterLabel</maml:name>
+        <maml:description>
+          <maml:para>Donut center label text.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>DonutCenterValue</maml:name>
+        <maml:description>
+          <maml:para>Donut center value text.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>DonutInnerRadiusRatio</maml:name>
+        <maml:description>
+          <maml:para>Donut inner radius ratio.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Double</command:parameterValue>
+        <dev:type>
+          <maml:name>Double</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>FillColor</maml:name>
+        <maml:description>
+          <maml:para>Fill color for sparklines.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Object</command:parameterValue>
+        <dev:type>
+          <maml:name>Object</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>FontFamilyName</maml:name>
+        <maml:description>
+          <maml:para>Font family for title and value.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>GridColor</maml:name>
+        <maml:description>
+          <maml:para>Grid line color.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Object</command:parameterValue>
+        <dev:type>
+          <maml:name>Object</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>GridLineCount</maml:name>
+        <maml:description>
+          <maml:para>Number of horizontal grid lines.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Height</maml:name>
+        <maml:description>
+          <maml:para>Chart height in pixels.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Id</maml:name>
+        <maml:description>
+          <maml:para>Chart identifier used for history storage.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Kind</maml:name>
+        <maml:description>
+          <maml:para>Chart kind to render, such as Sparkline, Line, Area, Bar, HorizontalBar, Gauge, Circle, RadialBar, Bullet, Pie, Donut, ProgressBar, or Pictorial.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">BgInfoChartKind</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">Sparkline</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Line</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Area</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Bar</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">HorizontalBar</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Gauge</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Circle</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">RadialBar</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Bullet</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Pie</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Donut</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">ProgressBar</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Pictorial</command:parameterValue>
+        </command:parameterValueGroup>
+        <dev:type>
+          <maml:name>BgInfoChartKind</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Labels</maml:name>
+        <maml:description>
+          <maml:para>Optional labels used by point-based charts.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+        <dev:type>
+          <maml:name>String[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>LegendPosition</maml:name>
+        <maml:description>
+          <maml:para>Chart legend position.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">BgInfoChartLegendPosition</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">Bottom</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Top</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Left</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Right</command:parameterValue>
+        </command:parameterValueGroup>
+        <dev:type>
+          <maml:name>BgInfoChartLegendPosition</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>LineColor</maml:name>
+        <maml:description>
+          <maml:para>Line or bar color.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Object</command:parameterValue>
+        <dev:type>
+          <maml:name>Object</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Maximum</maml:name>
+        <maml:description>
+          <maml:para>Optional maximum scale value.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Double</command:parameterValue>
+        <dev:type>
+          <maml:name>Double</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>MaxPoints</maml:name>
+        <maml:description>
+          <maml:para>Maximum number of samples to keep in history.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Metric</maml:name>
+        <maml:description>
+          <maml:para>Built-in metric source used when no explicit values are provided.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">BgInfoChartMetric</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">None</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">CpuPercent</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">MemoryPercent</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">DiskFreePercent</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">DiskUsedPercent</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">DiskFreeGb</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">UptimeHours</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">UptimeDays</command:parameterValue>
+        </command:parameterValueGroup>
+        <dev:type>
+          <maml:name>BgInfoChartMetric</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>MetricArgument</maml:name>
+        <maml:description>
+          <maml:para>Optional metric argument (for example drive letter).</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Minimum</maml:name>
+        <maml:description>
+          <maml:para>Optional minimum scale value.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Double</command:parameterValue>
+        <dev:type>
+          <maml:name>Double</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>NoCircleStatusLabel</maml:name>
+        <maml:description>
+          <maml:para>Hide circle status label.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>NoDonutCenterLabel</maml:name>
+        <maml:description>
+          <maml:para>Hide donut center label.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>NoHistory</maml:name>
+        <maml:description>
+          <maml:para>Disable history storage and render only provided values.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>NoProgressHandles</maml:name>
+        <maml:description>
+          <maml:para>Hide progress handles.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>NoProgressValues</maml:name>
+        <maml:description>
+          <maml:para>Hide progress values.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>NoRadialBarCenterLabel</maml:name>
+        <maml:description>
+          <maml:para>Hide radial-bar center label.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>OffsetX</maml:name>
+        <maml:description>
+          <maml:para>Horizontal offset from the anchor.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>OffsetY</maml:name>
+        <maml:description>
+          <maml:para>Vertical offset from the anchor.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Padding</maml:name>
+        <maml:description>
+          <maml:para>Padding inside the chart.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Palette</maml:name>
+        <maml:description>
+          <maml:para>Palette colors for point-based charts.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Object[]</command:parameterValue>
+        <dev:type>
+          <maml:name>Object[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>PictorialColumns</maml:name>
+        <maml:description>
+          <maml:para>Pictorial symbols per row.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>PictorialSymbol</maml:name>
+        <maml:description>
+          <maml:para>Pictorial chart symbol.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">BgInfoChartPictorialSymbol</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">Circle</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Square</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Diamond</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Triangle</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Star</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Person</command:parameterValue>
+        </command:parameterValueGroup>
+        <dev:type>
+          <maml:name>BgInfoChartPictorialSymbol</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>PositionX</maml:name>
+        <maml:description>
+          <maml:para>Absolute X position for placement.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>PositionY</maml:name>
+        <maml:description>
+          <maml:para>Absolute Y position for placement.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ProgressBarThicknessRatio</maml:name>
+        <maml:description>
+          <maml:para>Progress-bar thickness ratio.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Double</command:parameterValue>
+        <dev:type>
+          <maml:name>Double</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>RangeEnds</maml:name>
+        <maml:description>
+          <maml:para>Qualitative range ends used by bullet charts.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Double[]</command:parameterValue>
+        <dev:type>
+          <maml:name>Double[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ReplaceHistory</maml:name>
+        <maml:description>
+          <maml:para>Replace history instead of appending values.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ShowDataLabels</maml:name>
+        <maml:description>
+          <maml:para>Show supported data labels.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ShowGrid</maml:name>
+        <maml:description>
+          <maml:para>Show chart grid lines.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ShowLatestValue</maml:name>
+        <maml:description>
+          <maml:para>Show the latest value text.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ShowLegend</maml:name>
+        <maml:description>
+          <maml:para>Show the chart legend.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ShowPointLegend</maml:name>
+        <maml:description>
+          <maml:para>Show point-level legend entries.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Target</maml:name>
+        <maml:description>
+          <maml:para>Target value used by bullet charts.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Double</command:parameterValue>
+        <dev:type>
+          <maml:name>Double</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>TextColor</maml:name>
+        <maml:description>
+          <maml:para>Text color for title/value.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Object</command:parameterValue>
+        <dev:type>
+          <maml:name>Object</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Title</maml:name>
+        <maml:description>
+          <maml:para>Chart title displayed above the plot.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>TitleFontSize</maml:name>
+        <maml:description>
+          <maml:para>Title font size.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Single</command:parameterValue>
+        <dev:type>
+          <maml:name>Single</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Value</maml:name>
+        <maml:description>
+          <maml:para>Single value to append.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Double</command:parameterValue>
+        <dev:type>
+          <maml:name>Double</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ValueFontSize</maml:name>
+        <maml:description>
+          <maml:para>Value font size.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Single</command:parameterValue>
+        <dev:type>
+          <maml:name>Single</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ValueFormat</maml:name>
+        <maml:description>
+          <maml:para>Format string for the latest value.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Values</maml:name>
+        <maml:description>
+          <maml:para>Multiple values to append or replace.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Double[]</command:parameterValue>
+        <dev:type>
+          <maml:name>Double[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ValueSuffix</maml:name>
+        <maml:description>
+          <maml:para>Suffix appended to the latest value.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Width</maml:name>
+        <maml:description>
+          <maml:para>Chart width in pixels.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>None</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>PowerBGInfo.BgInfoChart</maml:name>
+        </dev:type>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>EXAMPLE 1</maml:title>
+        <dev:code>New-BGInfoChart -Anchor 'Value'</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>New-BGInfoConfiguration</command:name>
+      <command:verb>New</command:verb>
+      <command:noun>BGInfoConfiguration</command:noun>
+      <maml:description>
+        <maml:para>Creates a BGInfo configuration object.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Use this to build reusable configurations that can be exported to JSON.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="__AllParameterSets">
+        <maml:name>New-BGInfoConfiguration</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>AllUsers</maml:name>
+          <maml:description>
+            <maml:para>Apply wallpaper for all user profiles.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>BackgroundColor</maml:name>
+          <maml:description>
+            <maml:para>Background color to use when no wallpaper image is available.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Object</command:parameterValue>
+          <dev:type>
+            <maml:name>Object</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ChartLayout</maml:name>
+          <maml:description>
+            <maml:para>Chart layout mode.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">BgInfoChartLayoutMode</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Manual</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Stack</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>BgInfoChartLayoutMode</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Charts</maml:name>
+          <maml:description>
+            <maml:para>Charts to include in the configuration.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">BgInfoChart[]</command:parameterValue>
+          <dev:type>
+            <maml:name>BgInfoChart[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ChartStackAlignToTextBlock</maml:name>
+          <maml:description>
+            <maml:para>Align stacked charts to the text block.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ChartStackAnchor</maml:name>
+          <maml:description>
+            <maml:para>Anchor used when stacking charts.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">BgInfoTextPosition</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">TopLeft</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TopCenter</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TopRight</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MiddleLeft</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MiddleCenter</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MiddleRight</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">BottomLeft</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">BottomCenter</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">BottomRight</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>BgInfoTextPosition</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ChartStackDirection</maml:name>
+          <maml:description>
+            <maml:para>Direction used when stacking charts.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">BgInfoChartStackDirection</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Vertical</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Horizontal</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>BgInfoChartStackDirection</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ChartStackOffsetX</maml:name>
+          <maml:description>
+            <maml:para>Horizontal offset for stacked charts.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ChartStackOffsetY</maml:name>
+          <maml:description>
+            <maml:para>Vertical offset for stacked charts.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ChartStackOutsideTextBlock</maml:name>
+          <maml:description>
+            <maml:para>Place stacked charts outside of the text block.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ChartStackSpacing</maml:name>
+          <maml:description>
+            <maml:para>Spacing between stacked charts.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Color</maml:name>
+          <maml:description>
+            <maml:para>Default label color.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Object</command:parameterValue>
+          <dev:type>
+            <maml:name>Object</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ConfigurationDirectory</maml:name>
+          <maml:description>
+            <maml:para>Output directory for generated BGInfo images.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>DisableWallpaperRefresh</maml:name>
+          <maml:description>
+            <maml:para>Disable wallpaper refresh (keep old behavior).</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>DisableWallpaperSlideshow</maml:name>
+          <maml:description>
+            <maml:para>Disable automatic preservation of the current Windows wallpaper slideshow.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Entries</maml:name>
+          <maml:description>
+            <maml:para>Entries to include in the configuration.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">BgInfoEntry[]</command:parameterValue>
+          <dev:type>
+            <maml:name>BgInfoEntry[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ExcludeDefaultUserProfile</maml:name>
+          <maml:description>
+            <maml:para>Exclude the default user profile when applying to all users.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>FilePath</maml:name>
+          <maml:description>
+            <maml:para>Optional base wallpaper file path.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>FontFamilyName</maml:name>
+          <maml:description>
+            <maml:para>Default label font family.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>FontSize</maml:name>
+          <maml:description>
+            <maml:para>Default label font size.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Single</command:parameterValue>
+          <dev:type>
+            <maml:name>Single</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Images</maml:name>
+          <maml:description>
+            <maml:para>Image overlays to include in the configuration.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">BgInfoImage[]</command:parameterValue>
+          <dev:type>
+            <maml:name>BgInfoImage[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>MonitorIndex</maml:name>
+          <maml:description>
+            <maml:para>Monitor index to target for wallpaper operations.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>OutputFileName</maml:name>
+          <maml:description>
+            <maml:para>Optional output file name for the generated image.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>PositionX</maml:name>
+          <maml:description>
+            <maml:para>Legacy position X placeholder.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Single</command:parameterValue>
+          <dev:type>
+            <maml:name>Single</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>PositionY</maml:name>
+          <maml:description>
+            <maml:para>Legacy position Y placeholder.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Single</command:parameterValue>
+          <dev:type>
+            <maml:name>Single</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>SpaceBetweenColumns</maml:name>
+          <maml:description>
+            <maml:para>Spacing between label and value columns.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>SpaceBetweenLines</maml:name>
+          <maml:description>
+            <maml:para>Vertical spacing between rows.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>SpaceX</maml:name>
+          <maml:description>
+            <maml:para>X padding used for layout positioning.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>SpaceY</maml:name>
+          <maml:description>
+            <maml:para>Y padding used for layout positioning.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Target</maml:name>
+          <maml:description>
+            <maml:para>Output target (Wallpaper, File, LogonScreen, or Both).</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">BgInfoTarget</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Wallpaper</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">LogonScreen</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Both</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">File</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>BgInfoTarget</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>TextPosition</maml:name>
+          <maml:description>
+            <maml:para>Layout anchor position.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">BgInfoTextPosition</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">TopLeft</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TopCenter</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TopRight</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MiddleLeft</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MiddleCenter</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MiddleRight</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">BottomLeft</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">BottomCenter</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">BottomRight</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>BgInfoTextPosition</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Topologies</maml:name>
+          <maml:description>
+            <maml:para>Topology diagrams to include in the configuration.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">BgInfoTopology[]</command:parameterValue>
+          <dev:type>
+            <maml:name>BgInfoTopology[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>UseScreenCoordinates</maml:name>
+          <maml:description>
+            <maml:para>Use screen coordinates for layout positioning.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ValueColor</maml:name>
+          <maml:description>
+            <maml:para>Default value color.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Object</command:parameterValue>
+          <dev:type>
+            <maml:name>Object</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ValueFontFamilyName</maml:name>
+          <maml:description>
+            <maml:para>Default value font family.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ValueFontSize</maml:name>
+          <maml:description>
+            <maml:para>Default value font size.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Single</command:parameterValue>
+          <dev:type>
+            <maml:name>Single</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ValueWrapWidth</maml:name>
+          <maml:description>
+            <maml:para>Maximum width used when wrapping value text. Set to 0 to disable wrapping.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Variables</maml:name>
+          <maml:description>
+            <maml:para>Variables to include in the configuration.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">BgInfoVariable[]</command:parameterValue>
+          <dev:type>
+            <maml:name>BgInfoVariable[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="VisualCanvas">
+          <maml:name>VisualCanvases</maml:name>
+          <maml:description>
+            <maml:para>Visual canvas overlays to include in the configuration.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">BgInfoVisualCanvas[]</command:parameterValue>
+          <dev:type>
+            <maml:name>BgInfoVisualCanvas[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>WallpaperFit</maml:name>
+          <maml:description>
+            <maml:para>Wallpaper fit mode used after generation.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">DesktopWallpaperPosition</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Center</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Tile</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Stretch</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Fit</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Fill</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Span</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>DesktopWallpaperPosition</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>AllUsers</maml:name>
+        <maml:description>
+          <maml:para>Apply wallpaper for all user profiles.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>BackgroundColor</maml:name>
+        <maml:description>
+          <maml:para>Background color to use when no wallpaper image is available.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Object</command:parameterValue>
+        <dev:type>
+          <maml:name>Object</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ChartLayout</maml:name>
+        <maml:description>
+          <maml:para>Chart layout mode.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">BgInfoChartLayoutMode</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">Manual</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Stack</command:parameterValue>
+        </command:parameterValueGroup>
+        <dev:type>
+          <maml:name>BgInfoChartLayoutMode</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Charts</maml:name>
+        <maml:description>
+          <maml:para>Charts to include in the configuration.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">BgInfoChart[]</command:parameterValue>
+        <dev:type>
+          <maml:name>BgInfoChart[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ChartStackAlignToTextBlock</maml:name>
+        <maml:description>
+          <maml:para>Align stacked charts to the text block.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ChartStackAnchor</maml:name>
+        <maml:description>
+          <maml:para>Anchor used when stacking charts.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">BgInfoTextPosition</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">TopLeft</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">TopCenter</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">TopRight</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">MiddleLeft</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">MiddleCenter</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">MiddleRight</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">BottomLeft</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">BottomCenter</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">BottomRight</command:parameterValue>
+        </command:parameterValueGroup>
+        <dev:type>
+          <maml:name>BgInfoTextPosition</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ChartStackDirection</maml:name>
+        <maml:description>
+          <maml:para>Direction used when stacking charts.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">BgInfoChartStackDirection</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">Vertical</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Horizontal</command:parameterValue>
+        </command:parameterValueGroup>
+        <dev:type>
+          <maml:name>BgInfoChartStackDirection</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ChartStackOffsetX</maml:name>
+        <maml:description>
+          <maml:para>Horizontal offset for stacked charts.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ChartStackOffsetY</maml:name>
+        <maml:description>
+          <maml:para>Vertical offset for stacked charts.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ChartStackOutsideTextBlock</maml:name>
+        <maml:description>
+          <maml:para>Place stacked charts outside of the text block.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ChartStackSpacing</maml:name>
+        <maml:description>
+          <maml:para>Spacing between stacked charts.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Color</maml:name>
+        <maml:description>
+          <maml:para>Default label color.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Object</command:parameterValue>
+        <dev:type>
+          <maml:name>Object</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ConfigurationDirectory</maml:name>
+        <maml:description>
+          <maml:para>Output directory for generated BGInfo images.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>DisableWallpaperRefresh</maml:name>
+        <maml:description>
+          <maml:para>Disable wallpaper refresh (keep old behavior).</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>DisableWallpaperSlideshow</maml:name>
+        <maml:description>
+          <maml:para>Disable automatic preservation of the current Windows wallpaper slideshow.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Entries</maml:name>
+        <maml:description>
+          <maml:para>Entries to include in the configuration.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">BgInfoEntry[]</command:parameterValue>
+        <dev:type>
+          <maml:name>BgInfoEntry[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ExcludeDefaultUserProfile</maml:name>
+        <maml:description>
+          <maml:para>Exclude the default user profile when applying to all users.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>FilePath</maml:name>
+        <maml:description>
+          <maml:para>Optional base wallpaper file path.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>FontFamilyName</maml:name>
+        <maml:description>
+          <maml:para>Default label font family.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>FontSize</maml:name>
+        <maml:description>
+          <maml:para>Default label font size.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Single</command:parameterValue>
+        <dev:type>
+          <maml:name>Single</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Images</maml:name>
+        <maml:description>
+          <maml:para>Image overlays to include in the configuration.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">BgInfoImage[]</command:parameterValue>
+        <dev:type>
+          <maml:name>BgInfoImage[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>MonitorIndex</maml:name>
+        <maml:description>
+          <maml:para>Monitor index to target for wallpaper operations.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>OutputFileName</maml:name>
+        <maml:description>
+          <maml:para>Optional output file name for the generated image.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>PositionX</maml:name>
+        <maml:description>
+          <maml:para>Legacy position X placeholder.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Single</command:parameterValue>
+        <dev:type>
+          <maml:name>Single</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>PositionY</maml:name>
+        <maml:description>
+          <maml:para>Legacy position Y placeholder.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Single</command:parameterValue>
+        <dev:type>
+          <maml:name>Single</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>SpaceBetweenColumns</maml:name>
+        <maml:description>
+          <maml:para>Spacing between label and value columns.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>SpaceBetweenLines</maml:name>
+        <maml:description>
+          <maml:para>Vertical spacing between rows.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>SpaceX</maml:name>
+        <maml:description>
+          <maml:para>X padding used for layout positioning.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>SpaceY</maml:name>
+        <maml:description>
+          <maml:para>Y padding used for layout positioning.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Target</maml:name>
+        <maml:description>
+          <maml:para>Output target (Wallpaper, File, LogonScreen, or Both).</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">BgInfoTarget</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">Wallpaper</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">LogonScreen</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Both</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">File</command:parameterValue>
+        </command:parameterValueGroup>
+        <dev:type>
+          <maml:name>BgInfoTarget</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>TextPosition</maml:name>
+        <maml:description>
+          <maml:para>Layout anchor position.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">BgInfoTextPosition</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">TopLeft</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">TopCenter</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">TopRight</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">MiddleLeft</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">MiddleCenter</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">MiddleRight</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">BottomLeft</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">BottomCenter</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">BottomRight</command:parameterValue>
+        </command:parameterValueGroup>
+        <dev:type>
+          <maml:name>BgInfoTextPosition</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Topologies</maml:name>
+        <maml:description>
+          <maml:para>Topology diagrams to include in the configuration.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">BgInfoTopology[]</command:parameterValue>
+        <dev:type>
+          <maml:name>BgInfoTopology[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>UseScreenCoordinates</maml:name>
+        <maml:description>
+          <maml:para>Use screen coordinates for layout positioning.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ValueColor</maml:name>
+        <maml:description>
+          <maml:para>Default value color.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Object</command:parameterValue>
+        <dev:type>
+          <maml:name>Object</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ValueFontFamilyName</maml:name>
+        <maml:description>
+          <maml:para>Default value font family.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ValueFontSize</maml:name>
+        <maml:description>
+          <maml:para>Default value font size.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Single</command:parameterValue>
+        <dev:type>
+          <maml:name>Single</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ValueWrapWidth</maml:name>
+        <maml:description>
+          <maml:para>Maximum width used when wrapping value text. Set to 0 to disable wrapping.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Variables</maml:name>
+        <maml:description>
+          <maml:para>Variables to include in the configuration.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">BgInfoVariable[]</command:parameterValue>
+        <dev:type>
+          <maml:name>BgInfoVariable[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="VisualCanvas">
+        <maml:name>VisualCanvases</maml:name>
+        <maml:description>
+          <maml:para>Visual canvas overlays to include in the configuration.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">BgInfoVisualCanvas[]</command:parameterValue>
+        <dev:type>
+          <maml:name>BgInfoVisualCanvas[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>WallpaperFit</maml:name>
+        <maml:description>
+          <maml:para>Wallpaper fit mode used after generation.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">DesktopWallpaperPosition</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">Center</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Tile</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Stretch</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Fit</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Fill</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Span</command:parameterValue>
+        </command:parameterValueGroup>
+        <dev:type>
+          <maml:name>DesktopWallpaperPosition</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>None</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>PowerBGInfo.BgInfoConfiguration</maml:name>
+        </dev:type>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>EXAMPLE 1</maml:title>
+        <dev:code>New-BGInfoConfiguration -FilePath 'C:\Path'</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>New-BGInfoImage</command:name>
+      <command:verb>New</command:verb>
+      <command:noun>BGInfoImage</command:noun>
+      <maml:description>
+        <maml:para>Creates a BGInfo image overlay definition.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Creates a BGInfo image overlay definition.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="__AllParameterSets">
+        <maml:name>New-BGInfoImage</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Anchor</maml:name>
+          <maml:description>
+            <maml:para>Anchor position for placement.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">BgInfoTextPosition</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">TopLeft</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TopCenter</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TopRight</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MiddleLeft</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MiddleCenter</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MiddleRight</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">BottomLeft</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">BottomCenter</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">BottomRight</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>BgInfoTextPosition</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Fit</maml:name>
+          <maml:description>
+            <maml:para>How the image is fitted inside the destination rectangle.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">BgInfoImageFit</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Stretch</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Contain</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Cover</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Center</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Tile</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>BgInfoImageFit</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Height</maml:name>
+          <maml:description>
+            <maml:para>Target image height in pixels. Omit with Width to preserve aspect ratio.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>OffsetX</maml:name>
+          <maml:description>
+            <maml:para>Horizontal offset from the anchor.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>OffsetY</maml:name>
+          <maml:description>
+            <maml:para>Vertical offset from the anchor.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Opacity</maml:name>
+          <maml:description>
+            <maml:para>Image opacity from zero to one.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Double</command:parameterValue>
+          <dev:type>
+            <maml:name>Double</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="0" aliases="FullName">
+          <maml:name>Path</maml:name>
+          <maml:description>
+            <maml:para>Path to the image file.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>PositionX</maml:name>
+          <maml:description>
+            <maml:para>Absolute X position for placement.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>PositionY</maml:name>
+          <maml:description>
+            <maml:para>Absolute Y position for placement.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Width</maml:name>
+          <maml:description>
+            <maml:para>Target image width in pixels. Omit with Height to preserve aspect ratio.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Anchor</maml:name>
+        <maml:description>
+          <maml:para>Anchor position for placement.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">BgInfoTextPosition</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">TopLeft</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">TopCenter</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">TopRight</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">MiddleLeft</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">MiddleCenter</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">MiddleRight</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">BottomLeft</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">BottomCenter</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">BottomRight</command:parameterValue>
+        </command:parameterValueGroup>
+        <dev:type>
+          <maml:name>BgInfoTextPosition</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Fit</maml:name>
+        <maml:description>
+          <maml:para>How the image is fitted inside the destination rectangle.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">BgInfoImageFit</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">Stretch</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Contain</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Cover</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Center</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Tile</command:parameterValue>
+        </command:parameterValueGroup>
+        <dev:type>
+          <maml:name>BgInfoImageFit</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Height</maml:name>
+        <maml:description>
+          <maml:para>Target image height in pixels. Omit with Width to preserve aspect ratio.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>OffsetX</maml:name>
+        <maml:description>
+          <maml:para>Horizontal offset from the anchor.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>OffsetY</maml:name>
+        <maml:description>
+          <maml:para>Vertical offset from the anchor.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Opacity</maml:name>
+        <maml:description>
+          <maml:para>Image opacity from zero to one.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Double</command:parameterValue>
+        <dev:type>
+          <maml:name>Double</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="0" aliases="FullName">
+        <maml:name>Path</maml:name>
+        <maml:description>
+          <maml:para>Path to the image file.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>PositionX</maml:name>
+        <maml:description>
+          <maml:para>Absolute X position for placement.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>PositionY</maml:name>
+        <maml:description>
+          <maml:para>Absolute Y position for placement.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Width</maml:name>
+        <maml:description>
+          <maml:para>Target image width in pixels. Omit with Height to preserve aspect ratio.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>None</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>PowerBGInfo.BgInfoImage</maml:name>
+        </dev:type>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>EXAMPLE 1</maml:title>
+        <dev:code>New-BGInfoImage -Path 'C:\Path'</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>New-BGInfoLabel</command:name>
+      <command:verb>New</command:verb>
+      <command:noun>BGInfoLabel</command:noun>
+      <maml:description>
+        <maml:para>Creates a BGInfo label entry.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Creates a BGInfo label entry.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="__AllParameterSets">
+        <maml:name>New-BGInfoLabel</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Color</maml:name>
+          <maml:description>
+            <maml:para>Label color override.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Object</command:parameterValue>
+          <dev:type>
+            <maml:name>Object</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>FontFamilyName</maml:name>
+          <maml:description>
+            <maml:para>Label font family override.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>FontSize</maml:name>
+          <maml:description>
+            <maml:para>Label font size override.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Single</command:parameterValue>
+          <dev:type>
+            <maml:name>Single</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ForEach</maml:name>
+          <maml:description>
+            <maml:para>Variable name used to expand this label multiple times.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Name</maml:name>
+          <maml:description>
+            <maml:para>Label text to render.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Color</maml:name>
+        <maml:description>
+          <maml:para>Label color override.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Object</command:parameterValue>
+        <dev:type>
+          <maml:name>Object</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>FontFamilyName</maml:name>
+        <maml:description>
+          <maml:para>Label font family override.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>FontSize</maml:name>
+        <maml:description>
+          <maml:para>Label font size override.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Single</command:parameterValue>
+        <dev:type>
+          <maml:name>Single</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ForEach</maml:name>
+        <maml:description>
+          <maml:para>Variable name used to expand this label multiple times.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Name</maml:name>
+        <maml:description>
+          <maml:para>Label text to render.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>None</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>PowerBGInfo.BgInfoEntry</maml:name>
+        </dev:type>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>EXAMPLE 1</maml:title>
+        <dev:code>New-BGInfoLabel -Name 'Name'</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>New-BGInfoTopology</command:name>
+      <command:verb>New</command:verb>
+      <command:noun>BGInfoTopology</command:noun>
+      <maml:description>
+        <maml:para>Creates a BGInfo topology overlay definition.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Creates a BGInfo topology overlay definition.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="__AllParameterSets">
+        <maml:name>New-BGInfoTopology</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Anchor</maml:name>
+          <maml:description>
+            <maml:para>Anchor position for placement.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">BgInfoTextPosition</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">TopLeft</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TopCenter</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TopRight</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MiddleLeft</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MiddleCenter</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MiddleRight</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">BottomLeft</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">BottomCenter</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">BottomRight</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>BgInfoTextPosition</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Direction</maml:name>
+          <maml:description>
+            <maml:para>Topology layout direction.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">TopologyLayoutDirection</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">TopToBottom</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">LeftToRight</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">BottomToTop</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RightToLeft</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>TopologyLayoutDirection</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Height</maml:name>
+          <maml:description>
+            <maml:para>Topology height in pixels.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Layout</maml:name>
+          <maml:description>
+            <maml:para>Topology layout mode.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">TopologyLayoutMode</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Manual</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">GroupGrid</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">HubAndSpoke</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Layered</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Matrix</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DenseGrouped</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Geographic</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ForceDirected</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RelationshipRadial</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MindMap</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>TopologyLayoutMode</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>NodeDisplayMode</maml:name>
+          <maml:description>
+            <maml:para>Node presentation mode.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">TopologyNodeDisplayMode</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Card</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CompactCard</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Tile</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Pill</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Icon</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Artwork</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Dot</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Hidden</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>TopologyNodeDisplayMode</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>NoEdgeLabels</maml:name>
+          <maml:description>
+            <maml:para>Hide edge labels.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>NoGroups</maml:name>
+          <maml:description>
+            <maml:para>Hide group containers.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>NoTitle</maml:name>
+          <maml:description>
+            <maml:para>Hide the topology title.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>OffsetX</maml:name>
+          <maml:description>
+            <maml:para>Horizontal offset from the anchor.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>OffsetY</maml:name>
+          <maml:description>
+            <maml:para>Vertical offset from the anchor.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Opaque</maml:name>
+          <maml:description>
+            <maml:para>Use an opaque topology canvas.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>PositionX</maml:name>
+          <maml:description>
+            <maml:para>Absolute X position.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>PositionY</maml:name>
+          <maml:description>
+            <maml:para>Absolute Y position.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ShowLegend</maml:name>
+          <maml:description>
+            <maml:para>Show the topology legend.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Subtitle</maml:name>
+          <maml:description>
+            <maml:para>Topology subtitle.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Theme</maml:name>
+          <maml:description>
+            <maml:para>Theme name.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Light</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Dark</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Title</maml:name>
+          <maml:description>
+            <maml:para>Topology title.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="0" aliases="None">
+          <maml:name>TopologyDefinition</maml:name>
+          <maml:description>
+            <maml:para>Script block that emits topology groups, nodes, and edges.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">ScriptBlock</command:parameterValue>
+          <dev:type>
+            <maml:name>ScriptBlock</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Width</maml:name>
+          <maml:description>
+            <maml:para>Topology width in pixels.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Anchor</maml:name>
+        <maml:description>
+          <maml:para>Anchor position for placement.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">BgInfoTextPosition</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">TopLeft</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">TopCenter</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">TopRight</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">MiddleLeft</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">MiddleCenter</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">MiddleRight</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">BottomLeft</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">BottomCenter</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">BottomRight</command:parameterValue>
+        </command:parameterValueGroup>
+        <dev:type>
+          <maml:name>BgInfoTextPosition</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Direction</maml:name>
+        <maml:description>
+          <maml:para>Topology layout direction.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">TopologyLayoutDirection</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">TopToBottom</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">LeftToRight</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">BottomToTop</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">RightToLeft</command:parameterValue>
+        </command:parameterValueGroup>
+        <dev:type>
+          <maml:name>TopologyLayoutDirection</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Height</maml:name>
+        <maml:description>
+          <maml:para>Topology height in pixels.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Layout</maml:name>
+        <maml:description>
+          <maml:para>Topology layout mode.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">TopologyLayoutMode</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">Manual</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">GroupGrid</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">HubAndSpoke</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Layered</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Matrix</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">DenseGrouped</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Geographic</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">ForceDirected</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">RelationshipRadial</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">MindMap</command:parameterValue>
+        </command:parameterValueGroup>
+        <dev:type>
+          <maml:name>TopologyLayoutMode</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>NodeDisplayMode</maml:name>
+        <maml:description>
+          <maml:para>Node presentation mode.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">TopologyNodeDisplayMode</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">Card</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">CompactCard</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Tile</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Pill</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Icon</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Artwork</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Dot</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Hidden</command:parameterValue>
+        </command:parameterValueGroup>
+        <dev:type>
+          <maml:name>TopologyNodeDisplayMode</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>NoEdgeLabels</maml:name>
+        <maml:description>
+          <maml:para>Hide edge labels.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>NoGroups</maml:name>
+        <maml:description>
+          <maml:para>Hide group containers.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>NoTitle</maml:name>
+        <maml:description>
+          <maml:para>Hide the topology title.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>OffsetX</maml:name>
+        <maml:description>
+          <maml:para>Horizontal offset from the anchor.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>OffsetY</maml:name>
+        <maml:description>
+          <maml:para>Vertical offset from the anchor.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Opaque</maml:name>
+        <maml:description>
+          <maml:para>Use an opaque topology canvas.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>PositionX</maml:name>
+        <maml:description>
+          <maml:para>Absolute X position.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>PositionY</maml:name>
+        <maml:description>
+          <maml:para>Absolute Y position.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ShowLegend</maml:name>
+        <maml:description>
+          <maml:para>Show the topology legend.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Subtitle</maml:name>
+        <maml:description>
+          <maml:para>Topology subtitle.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Theme</maml:name>
+        <maml:description>
+          <maml:para>Theme name.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">Light</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Dark</command:parameterValue>
+        </command:parameterValueGroup>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Title</maml:name>
+        <maml:description>
+          <maml:para>Topology title.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="0" aliases="None">
+        <maml:name>TopologyDefinition</maml:name>
+        <maml:description>
+          <maml:para>Script block that emits topology groups, nodes, and edges.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">ScriptBlock</command:parameterValue>
+        <dev:type>
+          <maml:name>ScriptBlock</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Width</maml:name>
+        <maml:description>
+          <maml:para>Topology width in pixels.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>None</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>PowerBGInfo.BgInfoTopology</maml:name>
+        </dev:type>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>EXAMPLE 1</maml:title>
+        <dev:code>New-BGInfoTopology -Anchor 'Value'</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>New-BGInfoTopologyEdge</command:name>
+      <command:verb>New</command:verb>
+      <command:noun>BGInfoTopologyEdge</command:noun>
+      <maml:description>
+        <maml:para>Creates a BGInfo topology edge definition.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Creates a BGInfo topology edge definition.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="__AllParameterSets">
+        <maml:name>New-BGInfoTopologyEdge</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Color</maml:name>
+          <maml:description>
+            <maml:para>Optional edge color as CSS hex.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Direction</maml:name>
+          <maml:description>
+            <maml:para>Direction marker behavior.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">VisualLinkDirection</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">None</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Forward</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Backward</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Bidirectional</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>VisualLinkDirection</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Id</maml:name>
+          <maml:description>
+            <maml:para>Stable edge identifier. When omitted, one is derived from source and target ids.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Kind</maml:name>
+          <maml:description>
+            <maml:para>Relationship kind.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">TopologyEdgeKind</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Generic</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Link</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Replication</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Connectivity</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Dependency</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Trust</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Mapping</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AuthenticationPath</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CertificateChain</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DataFlow</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Ownership</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Membership</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>TopologyEdgeKind</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="2" aliases="None">
+          <maml:name>Label</maml:name>
+          <maml:description>
+            <maml:para>Primary edge label.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Muted</maml:name>
+          <maml:description>
+            <maml:para>Render the edge as a quiet structural relationship.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Routing</maml:name>
+          <maml:description>
+            <maml:para>Edge routing mode.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">TopologyEdgeRouting</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Straight</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Curved</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Orthogonal</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ObstacleAvoidingOrthogonal</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>TopologyEdgeRouting</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="0" aliases="None">
+          <maml:name>SourceNodeId</maml:name>
+          <maml:description>
+            <maml:para>Source node identifier.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Status</maml:name>
+          <maml:description>
+            <maml:para>Relationship health or state.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">TopologyHealthStatus</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Healthy</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Warning</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Critical</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Unknown</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Disabled</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>TopologyHealthStatus</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="1" aliases="None">
+          <maml:name>TargetNodeId</maml:name>
+          <maml:description>
+            <maml:para>Target node identifier.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Color</maml:name>
+        <maml:description>
+          <maml:para>Optional edge color as CSS hex.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Direction</maml:name>
+        <maml:description>
+          <maml:para>Direction marker behavior.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">VisualLinkDirection</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">None</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Forward</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Backward</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Bidirectional</command:parameterValue>
+        </command:parameterValueGroup>
+        <dev:type>
+          <maml:name>VisualLinkDirection</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Id</maml:name>
+        <maml:description>
+          <maml:para>Stable edge identifier. When omitted, one is derived from source and target ids.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Kind</maml:name>
+        <maml:description>
+          <maml:para>Relationship kind.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">TopologyEdgeKind</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">Generic</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Link</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Replication</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Connectivity</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Dependency</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Trust</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Mapping</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">AuthenticationPath</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">CertificateChain</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">DataFlow</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Ownership</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Membership</command:parameterValue>
+        </command:parameterValueGroup>
+        <dev:type>
+          <maml:name>TopologyEdgeKind</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="2" aliases="None">
+        <maml:name>Label</maml:name>
+        <maml:description>
+          <maml:para>Primary edge label.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Muted</maml:name>
+        <maml:description>
+          <maml:para>Render the edge as a quiet structural relationship.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Routing</maml:name>
+        <maml:description>
+          <maml:para>Edge routing mode.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">TopologyEdgeRouting</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">Straight</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Curved</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Orthogonal</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">ObstacleAvoidingOrthogonal</command:parameterValue>
+        </command:parameterValueGroup>
+        <dev:type>
+          <maml:name>TopologyEdgeRouting</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="0" aliases="None">
+        <maml:name>SourceNodeId</maml:name>
+        <maml:description>
+          <maml:para>Source node identifier.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Status</maml:name>
+        <maml:description>
+          <maml:para>Relationship health or state.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">TopologyHealthStatus</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">Healthy</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Warning</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Critical</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Unknown</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Disabled</command:parameterValue>
+        </command:parameterValueGroup>
+        <dev:type>
+          <maml:name>TopologyHealthStatus</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="1" aliases="None">
+        <maml:name>TargetNodeId</maml:name>
+        <maml:description>
+          <maml:para>Target node identifier.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>None</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>ChartForgeX.Topology.TopologyEdge</maml:name>
+        </dev:type>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>EXAMPLE 1</maml:title>
+        <dev:code>New-BGInfoTopologyEdge -Color 'Value'</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>New-BGInfoTopologyGroup</command:name>
+      <command:verb>New</command:verb>
+      <command:noun>BGInfoTopologyGroup</command:noun>
+      <maml:description>
+        <maml:para>Creates a BGInfo topology group definition.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Creates a BGInfo topology group definition.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="__AllParameterSets">
+        <maml:name>New-BGInfoTopologyGroup</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Color</maml:name>
+          <maml:description>
+            <maml:para>Optional group accent color as CSS hex.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="0" aliases="None">
+          <maml:name>Id</maml:name>
+          <maml:description>
+            <maml:para>Stable group identifier.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="1" aliases="None">
+          <maml:name>Label</maml:name>
+          <maml:description>
+            <maml:para>Group label rendered in the topology.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Status</maml:name>
+          <maml:description>
+            <maml:para>Group health or state.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">TopologyHealthStatus</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Healthy</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Warning</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Critical</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Unknown</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Disabled</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>TopologyHealthStatus</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Subtitle</maml:name>
+          <maml:description>
+            <maml:para>Optional group subtitle.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Symbol</maml:name>
+          <maml:description>
+            <maml:para>Short symbol rendered near the group header.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Color</maml:name>
+        <maml:description>
+          <maml:para>Optional group accent color as CSS hex.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="0" aliases="None">
+        <maml:name>Id</maml:name>
+        <maml:description>
+          <maml:para>Stable group identifier.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="1" aliases="None">
+        <maml:name>Label</maml:name>
+        <maml:description>
+          <maml:para>Group label rendered in the topology.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Status</maml:name>
+        <maml:description>
+          <maml:para>Group health or state.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">TopologyHealthStatus</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">Healthy</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Warning</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Critical</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Unknown</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Disabled</command:parameterValue>
+        </command:parameterValueGroup>
+        <dev:type>
+          <maml:name>TopologyHealthStatus</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Subtitle</maml:name>
+        <maml:description>
+          <maml:para>Optional group subtitle.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Symbol</maml:name>
+        <maml:description>
+          <maml:para>Short symbol rendered near the group header.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>None</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>ChartForgeX.Topology.TopologyGroup</maml:name>
+        </dev:type>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>EXAMPLE 1</maml:title>
+        <dev:code>New-BGInfoTopologyGroup -Color 'Value'</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>New-BGInfoTopologyNode</command:name>
+      <command:verb>New</command:verb>
+      <command:noun>BGInfoTopologyNode</command:noun>
+      <maml:description>
+        <maml:para>Creates a BGInfo topology node definition.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Creates a BGInfo topology node definition.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="__AllParameterSets">
+        <maml:name>New-BGInfoTopologyNode</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Badge</maml:name>
+          <maml:description>
+            <maml:para>Optional badge text.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Color</maml:name>
+          <maml:description>
+            <maml:para>Optional node accent color as CSS hex.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>DisplayMode</maml:name>
+          <maml:description>
+            <maml:para>Optional node display mode override.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">TopologyNodeDisplayMode</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Card</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CompactCard</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Tile</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Pill</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Icon</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Artwork</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Dot</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Hidden</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>TopologyNodeDisplayMode</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>GroupId</maml:name>
+          <maml:description>
+            <maml:para>Optional parent group identifier.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="0" aliases="None">
+          <maml:name>Id</maml:name>
+          <maml:description>
+            <maml:para>Stable node identifier used by topology edges.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Kind</maml:name>
+          <maml:description>
+            <maml:para>Node kind used for icon and legend selection.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">TopologyNodeKind</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Generic</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Group</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Location</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Hub</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Branch</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Server</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Service</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Endpoint</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Gateway</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Cloud</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Database</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Storage</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Network</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NetworkSegment</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Namespace</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Application</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Process</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Queue</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Person</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Team</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Certificate</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>TopologyNodeKind</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="1" aliases="None">
+          <maml:name>Label</maml:name>
+          <maml:description>
+            <maml:para>Node label rendered in the topology.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Status</maml:name>
+          <maml:description>
+            <maml:para>Node health or state.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">TopologyHealthStatus</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Healthy</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Warning</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Critical</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Unknown</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Disabled</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>TopologyHealthStatus</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Subtitle</maml:name>
+          <maml:description>
+            <maml:para>Optional node subtitle.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Symbol</maml:name>
+          <maml:description>
+            <maml:para>Short symbol rendered inside or near the node icon.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Badge</maml:name>
+        <maml:description>
+          <maml:para>Optional badge text.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Color</maml:name>
+        <maml:description>
+          <maml:para>Optional node accent color as CSS hex.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>DisplayMode</maml:name>
+        <maml:description>
+          <maml:para>Optional node display mode override.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">TopologyNodeDisplayMode</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">Card</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">CompactCard</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Tile</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Pill</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Icon</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Artwork</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Dot</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Hidden</command:parameterValue>
+        </command:parameterValueGroup>
+        <dev:type>
+          <maml:name>TopologyNodeDisplayMode</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>GroupId</maml:name>
+        <maml:description>
+          <maml:para>Optional parent group identifier.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="0" aliases="None">
+        <maml:name>Id</maml:name>
+        <maml:description>
+          <maml:para>Stable node identifier used by topology edges.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Kind</maml:name>
+        <maml:description>
+          <maml:para>Node kind used for icon and legend selection.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">TopologyNodeKind</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">Generic</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Group</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Location</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Hub</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Branch</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Server</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Service</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Endpoint</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Gateway</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Cloud</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Database</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Storage</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Network</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">NetworkSegment</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Namespace</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Application</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Process</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Queue</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Person</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Team</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Certificate</command:parameterValue>
+        </command:parameterValueGroup>
+        <dev:type>
+          <maml:name>TopologyNodeKind</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="1" aliases="None">
+        <maml:name>Label</maml:name>
+        <maml:description>
+          <maml:para>Node label rendered in the topology.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Status</maml:name>
+        <maml:description>
+          <maml:para>Node health or state.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">TopologyHealthStatus</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">Healthy</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Warning</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Critical</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Unknown</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Disabled</command:parameterValue>
+        </command:parameterValueGroup>
+        <dev:type>
+          <maml:name>TopologyHealthStatus</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Subtitle</maml:name>
+        <maml:description>
+          <maml:para>Optional node subtitle.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Symbol</maml:name>
+        <maml:description>
+          <maml:para>Short symbol rendered inside or near the node icon.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>None</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>ChartForgeX.Topology.TopologyNode</maml:name>
+        </dev:type>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>EXAMPLE 1</maml:title>
+        <dev:code>New-BGInfoTopologyNode -Badge 'Value'</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>New-BGInfoValue</command:name>
+      <command:verb>New</command:verb>
+      <command:noun>BGInfoValue</command:noun>
+      <maml:description>
+        <maml:para>Creates a BGInfo value entry.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Creates a BGInfo value entry.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="Values">
+        <maml:name>New-BGInfoValue</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Color</maml:name>
+          <maml:description>
+            <maml:para>Label color override.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Object</command:parameterValue>
+          <dev:type>
+            <maml:name>Object</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>FontFamilyName</maml:name>
+          <maml:description>
+            <maml:para>Label font family override.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>FontSize</maml:name>
+          <maml:description>
+            <maml:para>Label font size override.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Single</command:parameterValue>
+          <dev:type>
+            <maml:name>Single</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Name</maml:name>
+          <maml:description>
+            <maml:para>Label text to render.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Value</maml:name>
+          <maml:description>
+            <maml:para>Explicit value to render.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ValueColor</maml:name>
+          <maml:description>
+            <maml:para>Value color override.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Object</command:parameterValue>
+          <dev:type>
+            <maml:name>Object</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ValueFontFamilyName</maml:name>
+          <maml:description>
+            <maml:para>Value font family override.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ValueFontSize</maml:name>
+          <maml:description>
+            <maml:para>Value font size override.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Single</command:parameterValue>
+          <dev:type>
+            <maml:name>Single</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem parameterSetName="Builtin">
+        <maml:name>New-BGInfoValue</maml:name>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>BuiltinValue</maml:name>
+          <maml:description>
+            <maml:para>Built-in token to resolve to a value.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">UserName</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">HostName</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">FullUserName</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CpuName</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CpuMaxClockSpeed</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CpuCores</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CpuLogicalCores</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RAMSize</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RAMSpeed</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RAMPartNumber</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">BiosVersion</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">BiosManufacturer</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">BiosReleaseDate</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">OSName</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">OSVersion</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">OSArchitecture</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">OSBuild</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">OSInstallDate</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">OSLastBootUpTime</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">UserDNSDomain</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">FQDN</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">IPv4Address</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">IPv6Address</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Color</maml:name>
+          <maml:description>
+            <maml:para>Label color override.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Object</command:parameterValue>
+          <dev:type>
+            <maml:name>Object</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>FontFamilyName</maml:name>
+          <maml:description>
+            <maml:para>Label font family override.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>FontSize</maml:name>
+          <maml:description>
+            <maml:para>Label font size override.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Single</command:parameterValue>
+          <dev:type>
+            <maml:name>Single</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Name</maml:name>
+          <maml:description>
+            <maml:para>Label text to render.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ValueColor</maml:name>
+          <maml:description>
+            <maml:para>Value color override.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Object</command:parameterValue>
+          <dev:type>
+            <maml:name>Object</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ValueFontFamilyName</maml:name>
+          <maml:description>
+            <maml:para>Value font family override.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ValueFontSize</maml:name>
+          <maml:description>
+            <maml:para>Value font size override.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Single</command:parameterValue>
+          <dev:type>
+            <maml:name>Single</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem parameterSetName="Template">
+        <maml:name>New-BGInfoValue</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Color</maml:name>
+          <maml:description>
+            <maml:para>Label color override.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Object</command:parameterValue>
+          <dev:type>
+            <maml:name>Object</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>FontFamilyName</maml:name>
+          <maml:description>
+            <maml:para>Label font family override.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>FontSize</maml:name>
+          <maml:description>
+            <maml:para>Label font size override.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Single</command:parameterValue>
+          <dev:type>
+            <maml:name>Single</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ForEach</maml:name>
+          <maml:description>
+            <maml:para>Variable name used to expand this entry multiple times.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Name</maml:name>
+          <maml:description>
+            <maml:para>Label text to render.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Value</maml:name>
+          <maml:description>
+            <maml:para>Explicit value to render.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ValueColor</maml:name>
+          <maml:description>
+            <maml:para>Value color override.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Object</command:parameterValue>
+          <dev:type>
+            <maml:name>Object</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ValueFontFamilyName</maml:name>
+          <maml:description>
+            <maml:para>Value font family override.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ValueFontSize</maml:name>
+          <maml:description>
+            <maml:para>Value font size override.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Single</command:parameterValue>
+          <dev:type>
+            <maml:name>Single</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>BuiltinValue</maml:name>
+        <maml:description>
+          <maml:para>Built-in token to resolve to a value.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">UserName</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">HostName</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">FullUserName</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">CpuName</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">CpuMaxClockSpeed</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">CpuCores</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">CpuLogicalCores</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">RAMSize</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">RAMSpeed</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">RAMPartNumber</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">BiosVersion</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">BiosManufacturer</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">BiosReleaseDate</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">OSName</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">OSVersion</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">OSArchitecture</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">OSBuild</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">OSInstallDate</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">OSLastBootUpTime</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">UserDNSDomain</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">FQDN</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">IPv4Address</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">IPv6Address</command:parameterValue>
+        </command:parameterValueGroup>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Color</maml:name>
+        <maml:description>
+          <maml:para>Label color override.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Object</command:parameterValue>
+        <dev:type>
+          <maml:name>Object</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>FontFamilyName</maml:name>
+        <maml:description>
+          <maml:para>Label font family override.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>FontSize</maml:name>
+        <maml:description>
+          <maml:para>Label font size override.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Single</command:parameterValue>
+        <dev:type>
+          <maml:name>Single</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ForEach</maml:name>
+        <maml:description>
+          <maml:para>Variable name used to expand this entry multiple times.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Name</maml:name>
+        <maml:description>
+          <maml:para>Label text to render.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Value</maml:name>
+        <maml:description>
+          <maml:para>Explicit value to render.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ValueColor</maml:name>
+        <maml:description>
+          <maml:para>Value color override.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Object</command:parameterValue>
+        <dev:type>
+          <maml:name>Object</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ValueFontFamilyName</maml:name>
+        <maml:description>
+          <maml:para>Value font family override.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ValueFontSize</maml:name>
+        <maml:description>
+          <maml:para>Value font size override.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Single</command:parameterValue>
+        <dev:type>
+          <maml:name>Single</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>None</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>PowerBGInfo.BgInfoEntry</maml:name>
+        </dev:type>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>EXAMPLE 1</maml:title>
+        <dev:code>New-BGInfoValue -Name 'Name' -Value 'Value'</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>EXAMPLE 2</maml:title>
+        <dev:code>New-BGInfoValue -BuiltinValue 'Value'</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>EXAMPLE 3</maml:title>
+        <dev:code>New-BGInfoValue -Name 'Name' -Value 'Value' -ForEach 'Value'</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>New-BGInfoVariable</command:name>
+      <command:verb>New</command:verb>
+      <command:noun>BGInfoVariable</command:noun>
+      <maml:description>
+        <maml:para>Creates a reusable BGInfo variable backed by a built-in provider.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Creates a reusable BGInfo variable backed by a built-in provider.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="__AllParameterSets">
+        <maml:name>New-BGInfoVariable</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Argument</maml:name>
+          <maml:description>
+            <maml:para>Optional provider argument for filtering/customization.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Name</maml:name>
+          <maml:description>
+            <maml:para>Name used by -ForEach references.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Provider</maml:name>
+          <maml:description>
+            <maml:para>Built-in provider used to populate the variable.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">BgInfoVariableProvider</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Volumes</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>BgInfoVariableProvider</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Argument</maml:name>
+        <maml:description>
+          <maml:para>Optional provider argument for filtering/customization.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Name</maml:name>
+        <maml:description>
+          <maml:para>Name used by -ForEach references.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Provider</maml:name>
+        <maml:description>
+          <maml:para>Built-in provider used to populate the variable.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">BgInfoVariableProvider</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">Volumes</command:parameterValue>
+        </command:parameterValueGroup>
+        <dev:type>
+          <maml:name>BgInfoVariableProvider</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>None</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>PowerBGInfo.BgInfoVariable</maml:name>
+        </dev:type>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>EXAMPLE 1</maml:title>
+        <dev:code>New-BGInfoVariable -Name 'Name' -Provider 'Value'</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>New-BGInfoVisualCanvas</command:name>
+      <command:verb>New</command:verb>
+      <command:noun>BGInfoVisualCanvas</command:noun>
+      <maml:description>
+        <maml:para>Creates a BGInfo visual canvas definition backed by ChartForgeX.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Visual canvases render a reusable HUD-style overlay with a central title, side information boxes, and an optional feature strip.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="__AllParameterSets">
+        <maml:name>New-BGInfoVisualCanvas</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Accent</maml:name>
+          <maml:description>
+            <maml:para>Primary accent color.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Object</command:parameterValue>
+          <dev:type>
+            <maml:name>Object</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>BackgroundBottom</maml:name>
+          <maml:description>
+            <maml:para>Bottom background color.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Object</command:parameterValue>
+          <dev:type>
+            <maml:name>Object</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>BackgroundTop</maml:name>
+          <maml:description>
+            <maml:para>Top background color.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Object</command:parameterValue>
+          <dev:type>
+            <maml:name>Object</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>CenterTileOffsetX</maml:name>
+          <maml:description>
+            <maml:para>Horizontal centered-lane offset in pixels. Positive values move the lane to the right.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>CenterTileOffsetY</maml:name>
+          <maml:description>
+            <maml:para>Vertical centered-lane offset in pixels.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>CenterTileWidth</maml:name>
+          <maml:description>
+            <maml:para>Default centered-lane tile width in pixels. Zero uses TileWidth or the template default.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Feature</maml:name>
+          <maml:description>
+            <maml:para>Feature strip item definitions.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">BgInfoVisualCanvasFeature[]</command:parameterValue>
+          <dev:type>
+            <maml:name>BgInfoVisualCanvasFeature[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>FeatureAnchor</maml:name>
+          <maml:description>
+            <maml:para>Optional feature-strip anchor. When omitted, the template keeps its default centered strip placement.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">BgInfoTextPosition</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">TopLeft</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TopCenter</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TopRight</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MiddleLeft</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MiddleCenter</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MiddleRight</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">BottomLeft</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">BottomCenter</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">BottomRight</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>BgInfoTextPosition</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>FeatureHeight</maml:name>
+          <maml:description>
+            <maml:para>Optional feature-strip height in pixels. Zero uses the template default height.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>FeatureOffsetX</maml:name>
+          <maml:description>
+            <maml:para>Horizontal feature-strip offset. For right anchors, positive values inset from the right edge.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>FeatureOffsetY</maml:name>
+          <maml:description>
+            <maml:para>Vertical feature-strip offset. For bottom anchors, positive values inset from the bottom edge.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>FeatureWidth</maml:name>
+          <maml:description>
+            <maml:para>Optional feature-strip width in pixels. Zero uses the template default width.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Height</maml:name>
+          <maml:description>
+            <maml:para>Canvas height in pixels. Zero uses the target wallpaper height.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>HeroBadgeBottom</maml:name>
+          <maml:description>
+            <maml:para>Hero badge bottom fill color.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Object</command:parameterValue>
+          <dev:type>
+            <maml:name>Object</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>HeroBadgeImageFit</maml:name>
+          <maml:description>
+            <maml:para>How the hero badge image is fitted inside the badge.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">BgInfoImageFit</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Stretch</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Contain</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Cover</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Center</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Tile</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>BgInfoImageFit</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>HeroBadgeImageOpacity</maml:name>
+          <maml:description>
+            <maml:para>Hero badge image opacity from zero to one.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Double</command:parameterValue>
+          <dev:type>
+            <maml:name>Double</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>HeroBadgeImagePadding</maml:name>
+          <maml:description>
+            <maml:para>Padding inside the hero badge image area.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>HeroBadgeImagePath</maml:name>
+          <maml:description>
+            <maml:para>Optional image path rendered inside the central hero badge.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="HeroBadgeSymbol">
+          <maml:name>HeroBadgeText</maml:name>
+          <maml:description>
+            <maml:para>Text rendered in the central hero badge when no image is configured.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>HeroBadgeTextColor</maml:name>
+          <maml:description>
+            <maml:para>Hero badge symbol color.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Object</command:parameterValue>
+          <dev:type>
+            <maml:name>Object</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>HeroBadgeTop</maml:name>
+          <maml:description>
+            <maml:para>Hero badge top fill color.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Object</command:parameterValue>
+          <dev:type>
+            <maml:name>Object</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>LayoutPreset</maml:name>
+          <maml:description>
+            <maml:para>Responsive side-rail sizing preset.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">BgInfoVisualCanvasLayoutPreset</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Default</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Compact</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Comfortable</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">WideRails</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Dense</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>BgInfoVisualCanvasLayoutPreset</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>LeftTileOffsetX</maml:name>
+          <maml:description>
+            <maml:para>Horizontal left side-rail offset in pixels.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>LeftTileOffsetY</maml:name>
+          <maml:description>
+            <maml:para>Vertical left side-rail offset in pixels.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>LeftTileWidth</maml:name>
+          <maml:description>
+            <maml:para>Default left side-rail tile width in pixels. Zero uses TileWidth or the template default.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>NoHeroBadge</maml:name>
+          <maml:description>
+            <maml:para>Hide the central hero badge while keeping the title, subtitle, tiles, and feature strip.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>NoHeroContent</maml:name>
+          <maml:description>
+            <maml:para>Hide the central hero badge, title, and subtitle while keeping tiles and the feature strip.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>NoTechBackdrop</maml:name>
+          <maml:description>
+            <maml:para>Disable the built-in technology backdrop.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Opaque</maml:name>
+          <maml:description>
+            <maml:para>Render a full ChartForgeX background instead of floating over the wallpaper.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>PositionX</maml:name>
+          <maml:description>
+            <maml:para>Explicit X position on the generated wallpaper.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>PositionY</maml:name>
+          <maml:description>
+            <maml:para>Explicit Y position on the generated wallpaper.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>RightTileOffsetX</maml:name>
+          <maml:description>
+            <maml:para>Horizontal right side-rail inset in pixels.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>RightTileOffsetY</maml:name>
+          <maml:description>
+            <maml:para>Vertical right side-rail offset in pixels.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>RightTileWidth</maml:name>
+          <maml:description>
+            <maml:para>Default right side-rail tile width in pixels. Zero uses TileWidth or the template default.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>SecondaryAccent</maml:name>
+          <maml:description>
+            <maml:para>Secondary accent color for badge and backdrop highlights.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Object</command:parameterValue>
+          <dev:type>
+            <maml:name>Object</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Subtitle</maml:name>
+          <maml:description>
+            <maml:para>Canvas subtitle text.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>SubtitleColor</maml:name>
+          <maml:description>
+            <maml:para>Subtitle text color.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Object</command:parameterValue>
+          <dev:type>
+            <maml:name>Object</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Template</maml:name>
+          <maml:description>
+            <maml:para>Visual canvas template.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">BgInfoVisualCanvasTemplate</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">PowerBgInfoHero</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>BgInfoVisualCanvasTemplate</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Tile</maml:name>
+          <maml:description>
+            <maml:para>Tile lane definitions.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">BgInfoVisualCanvasTile[]</command:parameterValue>
+          <dev:type>
+            <maml:name>BgInfoVisualCanvasTile[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>TileDetailColor</maml:name>
+          <maml:description>
+            <maml:para>Tile detail text color.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Object</command:parameterValue>
+          <dev:type>
+            <maml:name>Object</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>TileGap</maml:name>
+          <maml:description>
+            <maml:para>Default vertical gap between tiles in pixels. Zero uses the template default gap.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>TileGlassBottom</maml:name>
+          <maml:description>
+            <maml:para>Glass tile bottom color.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Object</command:parameterValue>
+          <dev:type>
+            <maml:name>Object</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>TileGlassTop</maml:name>
+          <maml:description>
+            <maml:para>Glass tile top color.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Object</command:parameterValue>
+          <dev:type>
+            <maml:name>Object</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>TileHeight</maml:name>
+          <maml:description>
+            <maml:para>Default tile height in pixels. Zero uses the template default height.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>TileLabelColor</maml:name>
+          <maml:description>
+            <maml:para>Tile label text color.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Object</command:parameterValue>
+          <dev:type>
+            <maml:name>Object</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>TileProgressTrackColor</maml:name>
+          <maml:description>
+            <maml:para>Tile progress track color.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Object</command:parameterValue>
+          <dev:type>
+            <maml:name>Object</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>TileTextFitPolicy</maml:name>
+          <maml:description>
+            <maml:para>Default tile text fitting policy.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">BgInfoVisualCanvasTileTextFitPolicy</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Auto</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SingleLineEllipsis</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Wrap</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ShrinkToFit</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">WrapThenShrink</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>BgInfoVisualCanvasTileTextFitPolicy</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>TileValueColor</maml:name>
+          <maml:description>
+            <maml:para>Tile value text color.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Object</command:parameterValue>
+          <dev:type>
+            <maml:name>Object</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>TileWidth</maml:name>
+          <maml:description>
+            <maml:para>Default tile width in pixels. Zero uses the template default width.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Title</maml:name>
+          <maml:description>
+            <maml:para>Canvas title or brand text.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>TitleAccentColor</maml:name>
+          <maml:description>
+            <maml:para>Accent hero title color.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Object</command:parameterValue>
+          <dev:type>
+            <maml:name>Object</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>TitleColor</maml:name>
+          <maml:description>
+            <maml:para>Primary hero title color.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Object</command:parameterValue>
+          <dev:type>
+            <maml:name>Object</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Width</maml:name>
+          <maml:description>
+            <maml:para>Canvas width in pixels. Zero uses the target wallpaper width.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Accent</maml:name>
+        <maml:description>
+          <maml:para>Primary accent color.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Object</command:parameterValue>
+        <dev:type>
+          <maml:name>Object</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>BackgroundBottom</maml:name>
+        <maml:description>
+          <maml:para>Bottom background color.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Object</command:parameterValue>
+        <dev:type>
+          <maml:name>Object</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>BackgroundTop</maml:name>
+        <maml:description>
+          <maml:para>Top background color.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Object</command:parameterValue>
+        <dev:type>
+          <maml:name>Object</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>CenterTileOffsetX</maml:name>
+        <maml:description>
+          <maml:para>Horizontal centered-lane offset in pixels. Positive values move the lane to the right.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>CenterTileOffsetY</maml:name>
+        <maml:description>
+          <maml:para>Vertical centered-lane offset in pixels.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>CenterTileWidth</maml:name>
+        <maml:description>
+          <maml:para>Default centered-lane tile width in pixels. Zero uses TileWidth or the template default.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Feature</maml:name>
+        <maml:description>
+          <maml:para>Feature strip item definitions.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">BgInfoVisualCanvasFeature[]</command:parameterValue>
+        <dev:type>
+          <maml:name>BgInfoVisualCanvasFeature[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>FeatureAnchor</maml:name>
+        <maml:description>
+          <maml:para>Optional feature-strip anchor. When omitted, the template keeps its default centered strip placement.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">BgInfoTextPosition</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">TopLeft</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">TopCenter</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">TopRight</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">MiddleLeft</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">MiddleCenter</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">MiddleRight</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">BottomLeft</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">BottomCenter</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">BottomRight</command:parameterValue>
+        </command:parameterValueGroup>
+        <dev:type>
+          <maml:name>BgInfoTextPosition</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>FeatureHeight</maml:name>
+        <maml:description>
+          <maml:para>Optional feature-strip height in pixels. Zero uses the template default height.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>FeatureOffsetX</maml:name>
+        <maml:description>
+          <maml:para>Horizontal feature-strip offset. For right anchors, positive values inset from the right edge.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>FeatureOffsetY</maml:name>
+        <maml:description>
+          <maml:para>Vertical feature-strip offset. For bottom anchors, positive values inset from the bottom edge.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>FeatureWidth</maml:name>
+        <maml:description>
+          <maml:para>Optional feature-strip width in pixels. Zero uses the template default width.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Height</maml:name>
+        <maml:description>
+          <maml:para>Canvas height in pixels. Zero uses the target wallpaper height.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>HeroBadgeBottom</maml:name>
+        <maml:description>
+          <maml:para>Hero badge bottom fill color.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Object</command:parameterValue>
+        <dev:type>
+          <maml:name>Object</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>HeroBadgeImageFit</maml:name>
+        <maml:description>
+          <maml:para>How the hero badge image is fitted inside the badge.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">BgInfoImageFit</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">Stretch</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Contain</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Cover</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Center</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Tile</command:parameterValue>
+        </command:parameterValueGroup>
+        <dev:type>
+          <maml:name>BgInfoImageFit</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>HeroBadgeImageOpacity</maml:name>
+        <maml:description>
+          <maml:para>Hero badge image opacity from zero to one.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Double</command:parameterValue>
+        <dev:type>
+          <maml:name>Double</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>HeroBadgeImagePadding</maml:name>
+        <maml:description>
+          <maml:para>Padding inside the hero badge image area.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>HeroBadgeImagePath</maml:name>
+        <maml:description>
+          <maml:para>Optional image path rendered inside the central hero badge.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="HeroBadgeSymbol">
+        <maml:name>HeroBadgeText</maml:name>
+        <maml:description>
+          <maml:para>Text rendered in the central hero badge when no image is configured.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>HeroBadgeTextColor</maml:name>
+        <maml:description>
+          <maml:para>Hero badge symbol color.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Object</command:parameterValue>
+        <dev:type>
+          <maml:name>Object</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>HeroBadgeTop</maml:name>
+        <maml:description>
+          <maml:para>Hero badge top fill color.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Object</command:parameterValue>
+        <dev:type>
+          <maml:name>Object</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>LayoutPreset</maml:name>
+        <maml:description>
+          <maml:para>Responsive side-rail sizing preset.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">BgInfoVisualCanvasLayoutPreset</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">Default</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Compact</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Comfortable</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">WideRails</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Dense</command:parameterValue>
+        </command:parameterValueGroup>
+        <dev:type>
+          <maml:name>BgInfoVisualCanvasLayoutPreset</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>LeftTileOffsetX</maml:name>
+        <maml:description>
+          <maml:para>Horizontal left side-rail offset in pixels.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>LeftTileOffsetY</maml:name>
+        <maml:description>
+          <maml:para>Vertical left side-rail offset in pixels.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>LeftTileWidth</maml:name>
+        <maml:description>
+          <maml:para>Default left side-rail tile width in pixels. Zero uses TileWidth or the template default.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>NoHeroBadge</maml:name>
+        <maml:description>
+          <maml:para>Hide the central hero badge while keeping the title, subtitle, tiles, and feature strip.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>NoHeroContent</maml:name>
+        <maml:description>
+          <maml:para>Hide the central hero badge, title, and subtitle while keeping tiles and the feature strip.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>NoTechBackdrop</maml:name>
+        <maml:description>
+          <maml:para>Disable the built-in technology backdrop.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Opaque</maml:name>
+        <maml:description>
+          <maml:para>Render a full ChartForgeX background instead of floating over the wallpaper.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>PositionX</maml:name>
+        <maml:description>
+          <maml:para>Explicit X position on the generated wallpaper.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>PositionY</maml:name>
+        <maml:description>
+          <maml:para>Explicit Y position on the generated wallpaper.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>RightTileOffsetX</maml:name>
+        <maml:description>
+          <maml:para>Horizontal right side-rail inset in pixels.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>RightTileOffsetY</maml:name>
+        <maml:description>
+          <maml:para>Vertical right side-rail offset in pixels.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>RightTileWidth</maml:name>
+        <maml:description>
+          <maml:para>Default right side-rail tile width in pixels. Zero uses TileWidth or the template default.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>SecondaryAccent</maml:name>
+        <maml:description>
+          <maml:para>Secondary accent color for badge and backdrop highlights.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Object</command:parameterValue>
+        <dev:type>
+          <maml:name>Object</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Subtitle</maml:name>
+        <maml:description>
+          <maml:para>Canvas subtitle text.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>SubtitleColor</maml:name>
+        <maml:description>
+          <maml:para>Subtitle text color.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Object</command:parameterValue>
+        <dev:type>
+          <maml:name>Object</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Template</maml:name>
+        <maml:description>
+          <maml:para>Visual canvas template.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">BgInfoVisualCanvasTemplate</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">PowerBgInfoHero</command:parameterValue>
+        </command:parameterValueGroup>
+        <dev:type>
+          <maml:name>BgInfoVisualCanvasTemplate</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Tile</maml:name>
+        <maml:description>
+          <maml:para>Tile lane definitions.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">BgInfoVisualCanvasTile[]</command:parameterValue>
+        <dev:type>
+          <maml:name>BgInfoVisualCanvasTile[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>TileDetailColor</maml:name>
+        <maml:description>
+          <maml:para>Tile detail text color.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Object</command:parameterValue>
+        <dev:type>
+          <maml:name>Object</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>TileGap</maml:name>
+        <maml:description>
+          <maml:para>Default vertical gap between tiles in pixels. Zero uses the template default gap.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>TileGlassBottom</maml:name>
+        <maml:description>
+          <maml:para>Glass tile bottom color.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Object</command:parameterValue>
+        <dev:type>
+          <maml:name>Object</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>TileGlassTop</maml:name>
+        <maml:description>
+          <maml:para>Glass tile top color.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Object</command:parameterValue>
+        <dev:type>
+          <maml:name>Object</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>TileHeight</maml:name>
+        <maml:description>
+          <maml:para>Default tile height in pixels. Zero uses the template default height.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>TileLabelColor</maml:name>
+        <maml:description>
+          <maml:para>Tile label text color.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Object</command:parameterValue>
+        <dev:type>
+          <maml:name>Object</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>TileProgressTrackColor</maml:name>
+        <maml:description>
+          <maml:para>Tile progress track color.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Object</command:parameterValue>
+        <dev:type>
+          <maml:name>Object</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>TileTextFitPolicy</maml:name>
+        <maml:description>
+          <maml:para>Default tile text fitting policy.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">BgInfoVisualCanvasTileTextFitPolicy</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">Auto</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">SingleLineEllipsis</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Wrap</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">ShrinkToFit</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">WrapThenShrink</command:parameterValue>
+        </command:parameterValueGroup>
+        <dev:type>
+          <maml:name>BgInfoVisualCanvasTileTextFitPolicy</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>TileValueColor</maml:name>
+        <maml:description>
+          <maml:para>Tile value text color.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Object</command:parameterValue>
+        <dev:type>
+          <maml:name>Object</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>TileWidth</maml:name>
+        <maml:description>
+          <maml:para>Default tile width in pixels. Zero uses the template default width.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Title</maml:name>
+        <maml:description>
+          <maml:para>Canvas title or brand text.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>TitleAccentColor</maml:name>
+        <maml:description>
+          <maml:para>Accent hero title color.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Object</command:parameterValue>
+        <dev:type>
+          <maml:name>Object</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>TitleColor</maml:name>
+        <maml:description>
+          <maml:para>Primary hero title color.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Object</command:parameterValue>
+        <dev:type>
+          <maml:name>Object</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Width</maml:name>
+        <maml:description>
+          <maml:para>Canvas width in pixels. Zero uses the target wallpaper width.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>None</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>PowerBGInfo.BgInfoVisualCanvas</maml:name>
+        </dev:type>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>EXAMPLE 1</maml:title>
+        <dev:code>$tiles = @(&#xD;
+    New-BGInfoVisualCanvasTile -Side Left -IconKind Computer -SurfaceStyle Raised -Label HOSTNAME -Value '{{HostName}}'&#xD;
+    New-BGInfoVisualCanvasTile -Side Right -IconKind Cpu -SurfaceStyle Raised -Label 'CPU LOAD' -Value '31% active' -MiniChartKind Area -MiniChartValues 22,28,25,36,31 -MiniChartMaximum 100&#xD;
+)&#xD;
+&#xD;
+New-BGInfo -Target File {&#xD;
+    New-BGInfoVisualCanvas -Title 'PowerBGInfo' -Subtitle 'High-contrast information boxes' -Tile $tiles -TileGlassTop '#FFF7EDD9' -TileGlassBottom '#DBEAFECC' -TileValueColor '#0F172AFF'&#xD;
+} -FilePath .\Examples\Samples\TapC-Evotec-2560x1080.jpg -ConfigurationDirectory .\Examples\Output -OutputFileName 'PowerBGInfo.VisualCanvas.ContrastBox.jpg' -WallpaperFit Fill</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>EXAMPLE 2</maml:title>
+        <dev:code>New-BGInfoVisualCanvas -Title 'PowerBGInfo' -Feature $features -FeatureAnchor BottomRight -FeatureWidth 610 -FeatureOffsetX 165 -FeatureOffsetY 120</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>New-BGInfoVisualCanvasFeature</command:name>
+      <command:verb>New</command:verb>
+      <command:noun>BGInfoVisualCanvasFeature</command:noun>
+      <maml:description>
+        <maml:para>Creates a BGInfo visual canvas feature-strip item.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Feature-strip items are compact labels shown in the optional visual canvas footer strip.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="__AllParameterSets">
+        <maml:name>New-BGInfoVisualCanvasFeature</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Icon</maml:name>
+          <maml:description>
+            <maml:para>Compact item icon or symbol.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Label</maml:name>
+          <maml:description>
+            <maml:para>Feature label.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Icon</maml:name>
+        <maml:description>
+          <maml:para>Compact item icon or symbol.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Label</maml:name>
+        <maml:description>
+          <maml:para>Feature label.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>None</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>PowerBGInfo.BgInfoVisualCanvasFeature</maml:name>
+        </dev:type>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>EXAMPLE 1</maml:title>
+        <dev:code>$features = @(&#xD;
+    New-BGInfoVisualCanvasFeature -Icon 'A+' -Label 'light contrast boxes'&#xD;
+    New-BGInfoVisualCanvasFeature -Icon 'JSON' -Label 'portable config'&#xD;
+)</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>New-BGInfoVisualCanvasTile</command:name>
+      <command:verb>New</command:verb>
+      <command:noun>BGInfoVisualCanvasTile</command:noun>
+      <maml:description>
+        <maml:para>Creates a BGInfo visual canvas tile definition.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Tiles are the readable lane-based information boxes used by New-BGInfoVisualCanvas.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="__AllParameterSets">
+        <maml:name>New-BGInfoVisualCanvasTile</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Accent</maml:name>
+          <maml:description>
+            <maml:para>Optional accent color.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Object</command:parameterValue>
+          <dev:type>
+            <maml:name>Object</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Detail</maml:name>
+          <maml:description>
+            <maml:para>Optional detail text. Templates are resolved at render time.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Height</maml:name>
+          <maml:description>
+            <maml:para>Optional tile height in pixels. Zero uses the visual canvas default or template default.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Icon</maml:name>
+          <maml:description>
+            <maml:para>Compact tile icon or symbol.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>IconKind</maml:name>
+          <maml:description>
+            <maml:para>Built-in icon to render instead of the Icon text.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">BgInfoVisualCanvasTileIconKind</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Text</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Computer</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Network</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">OperatingSystem</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Cpu</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Memory</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">User</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Domain</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Terminal</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Storage</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Shield</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>BgInfoVisualCanvasTileIconKind</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Label</maml:name>
+          <maml:description>
+            <maml:para>Tile label. Templates such as {{HostName}} are resolved at render time.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>MiniChartKind</maml:name>
+          <maml:description>
+            <maml:para>Compact chart kind rendered inside the tile.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">BgInfoVisualCanvasTileMiniChartKind</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">None</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sparkline</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Area</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Bars</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>BgInfoVisualCanvasTileMiniChartKind</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>MiniChartMaximum</maml:name>
+          <maml:description>
+            <maml:para>Optional compact chart maximum.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>MiniChartValues</maml:name>
+          <maml:description>
+            <maml:para>Compact chart values rendered inside the tile.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Double[]</command:parameterValue>
+          <dev:type>
+            <maml:name>Double[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Progress</maml:name>
+          <maml:description>
+            <maml:para>Optional progress value from zero to one.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="Lane">
+          <maml:name>Side</maml:name>
+          <maml:description>
+            <maml:para>Tile lane placement.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">BgInfoVisualCanvasSide</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Left</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Right</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Center</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>BgInfoVisualCanvasSide</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>SurfaceStyle</maml:name>
+          <maml:description>
+            <maml:para>Tile surface style.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">BgInfoVisualCanvasTileSurfaceStyle</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Glass</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Outline</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Raised</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>BgInfoVisualCanvasTileSurfaceStyle</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>TextFitPolicy</maml:name>
+          <maml:description>
+            <maml:para>Tile-specific text fitting policy. Auto inherits the visual canvas setting.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">BgInfoVisualCanvasTileTextFitPolicy</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Auto</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SingleLineEllipsis</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Wrap</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ShrinkToFit</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">WrapThenShrink</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>BgInfoVisualCanvasTileTextFitPolicy</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Value</maml:name>
+          <maml:description>
+            <maml:para>Primary tile value. Templates such as {{HostName}} are resolved at render time.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Width</maml:name>
+          <maml:description>
+            <maml:para>Optional tile width in pixels. Zero uses the visual canvas default or template default.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Accent</maml:name>
+        <maml:description>
+          <maml:para>Optional accent color.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Object</command:parameterValue>
+        <dev:type>
+          <maml:name>Object</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Detail</maml:name>
+        <maml:description>
+          <maml:para>Optional detail text. Templates are resolved at render time.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Height</maml:name>
+        <maml:description>
+          <maml:para>Optional tile height in pixels. Zero uses the visual canvas default or template default.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Icon</maml:name>
+        <maml:description>
+          <maml:para>Compact tile icon or symbol.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>IconKind</maml:name>
+        <maml:description>
+          <maml:para>Built-in icon to render instead of the Icon text.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">BgInfoVisualCanvasTileIconKind</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">Text</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Computer</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Network</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">OperatingSystem</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Cpu</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Memory</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">User</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Domain</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Terminal</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Storage</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Shield</command:parameterValue>
+        </command:parameterValueGroup>
+        <dev:type>
+          <maml:name>BgInfoVisualCanvasTileIconKind</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Label</maml:name>
+        <maml:description>
+          <maml:para>Tile label. Templates such as {{HostName}} are resolved at render time.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>MiniChartKind</maml:name>
+        <maml:description>
+          <maml:para>Compact chart kind rendered inside the tile.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">BgInfoVisualCanvasTileMiniChartKind</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">None</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Sparkline</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Area</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Bars</command:parameterValue>
+        </command:parameterValueGroup>
+        <dev:type>
+          <maml:name>BgInfoVisualCanvasTileMiniChartKind</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>MiniChartMaximum</maml:name>
+        <maml:description>
+          <maml:para>Optional compact chart maximum.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+        <dev:type>
+          <maml:name>Nullable`1</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>MiniChartValues</maml:name>
+        <maml:description>
+          <maml:para>Compact chart values rendered inside the tile.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Double[]</command:parameterValue>
+        <dev:type>
+          <maml:name>Double[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Progress</maml:name>
+        <maml:description>
+          <maml:para>Optional progress value from zero to one.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+        <dev:type>
+          <maml:name>Nullable`1</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="Lane">
+        <maml:name>Side</maml:name>
+        <maml:description>
+          <maml:para>Tile lane placement.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">BgInfoVisualCanvasSide</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">Left</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Right</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Center</command:parameterValue>
+        </command:parameterValueGroup>
+        <dev:type>
+          <maml:name>BgInfoVisualCanvasSide</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>SurfaceStyle</maml:name>
+        <maml:description>
+          <maml:para>Tile surface style.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">BgInfoVisualCanvasTileSurfaceStyle</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">Glass</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Outline</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Raised</command:parameterValue>
+        </command:parameterValueGroup>
+        <dev:type>
+          <maml:name>BgInfoVisualCanvasTileSurfaceStyle</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>TextFitPolicy</maml:name>
+        <maml:description>
+          <maml:para>Tile-specific text fitting policy. Auto inherits the visual canvas setting.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">BgInfoVisualCanvasTileTextFitPolicy</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">Auto</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">SingleLineEllipsis</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Wrap</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">ShrinkToFit</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">WrapThenShrink</command:parameterValue>
+        </command:parameterValueGroup>
+        <dev:type>
+          <maml:name>BgInfoVisualCanvasTileTextFitPolicy</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Value</maml:name>
+        <maml:description>
+          <maml:para>Primary tile value. Templates such as {{HostName}} are resolved at render time.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Width</maml:name>
+        <maml:description>
+          <maml:para>Optional tile width in pixels. Zero uses the visual canvas default or template default.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>None</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>PowerBGInfo.BgInfoVisualCanvasTile</maml:name>
+        </dev:type>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>EXAMPLE 1</maml:title>
+        <dev:code>New-BGInfoVisualCanvasTile -Side Left -IconKind Computer -SurfaceStyle Raised -Label HOSTNAME -Value '{{HostName}}' -Detail 'production desktop' -Accent '#0F766EFF'</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>EXAMPLE 2</maml:title>
+        <dev:code>New-BGInfoVisualCanvasTile -Side Right -IconKind Cpu -SurfaceStyle Raised -Label 'CPU LOAD' -Value '31% active' -MiniChartKind Area -MiniChartValues 22,28,25,36,31 -MiniChartMaximum 100</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+</helpItems>


### PR DESCRIPTION
## Summary

- Removes the MatejKafka.XmlDoc2CmdletDoc dependency and its build targets.
- Uses the public PSPublishModule 3.0.88 / PowerForge documentation owner.
- Regenerates Markdown and MAML and keeps binary external help discoverable with the assembly-named alias.

## Validation

- Full public-package module build completed.
- Markdown and MAML command identities match; MAML parses as XML.
- Regeneration is idempotent.
- Generated help was exercised through PowerShell 7 and Windows PowerShell 5.1.
- Repository-native .NET builds pass for the supported target frameworks.

## Scope

This PR is intentionally limited to dependency removal and functional build/package/import/Get-Help preservation. Documentation-content debt such as prose, examples, defaults, output annotations, and display enrichment is recorded separately and is not hand-edited in generated artifacts here.