### PR TITLE
Publish complete PowerBGInfo website documentation

### DIFF
--- a/Website/content/examples/_index.md
+++ b/Website/content/examples/_index.md
@@ -19,4 +19,14 @@ These PowerBGInfo examples focus on repeatable desktop background layouts rather
     <h3>Position background information</h3>
     <p>Place inventory text at a predictable coordinate on the wallpaper.</p>
   </a>
+  <a class="ev-example-card" href="./configuration-and-deployment/">
+    <span class="ev-example-card__eyebrow">Deployment</span>
+    <h3>Export and deploy a configuration</h3>
+    <p>Separate reviewed JSON layout from scheduled or RMM execution.</p>
+  </a>
+  <a class="ev-example-card" href="./charts-and-topology/">
+    <span class="ev-example-card__eyebrow">Visuals</span>
+    <h3>Add charts and topology</h3>
+    <p>Composite compact operational ChartForgeX visuals into the wallpaper.</p>
+  </a>
 </div>

--- a/Website/content/examples/charts-and-topology.md
+++ b/Website/content/examples/charts-and-topology.md
@@ -1,0 +1,15 @@
+---
+title: "Add operational charts and topology"
+description: "Add compact ChartForgeX visuals to a PowerBGInfo wallpaper."
+layout: docs
+---
+
+PowerBGInfo 2.x can composite ChartForgeX-backed charts and topology into the generated wallpaper. This works well for a small CPU or capacity trend, service ownership, a lab route, or a build target.
+
+Start from the maintained repository examples:
+
+- [`PowerBGInfo.OperationalCharts.ps1`](https://github.com/EvotecIT/PowerBGInfo/blob/v2-speedygonzales/Examples/Scripts/PowerBGInfo.OperationalCharts.ps1) for rolling system charts
+- [`PowerBGInfo.TopologyOverlay.ps1`](https://github.com/EvotecIT/PowerBGInfo/blob/v2-speedygonzales/Examples/Scripts/PowerBGInfo.TopologyOverlay.ps1) for a service topology overlay
+- [`PowerBGInfo.VisualCanvas.ps1`](https://github.com/EvotecIT/PowerBGInfo/blob/v2-speedygonzales/Examples/Scripts/PowerBGInfo.VisualCanvas.ps1) for structured tiles and panels
+
+Render to a file first, inspect it at the target monitor resolution, and only then switch to the current-user, all-users, or logon-screen target.

--- a/Website/content/examples/configuration-and-deployment.md
+++ b/Website/content/examples/configuration-and-deployment.md
@@ -1,0 +1,26 @@
+---
+title: "Export and deploy a PowerBGInfo configuration"
+description: "Separate PowerBGInfo layout authoring from scheduled or RMM execution."
+layout: docs
+---
+
+Export a reviewed layout to JSON when deployment should not carry a long inline script.
+
+```powershell
+$configPath = 'C:\ProgramData\PowerBGInfo\workstation.json'
+
+New-BGInfo {
+    New-BGInfoValue -BuiltinValue HostName -Name 'Machine'
+    New-BGInfoValue -BuiltinValue FullUserName -Name 'User'
+    New-BGInfoValue -BuiltinValue OSName -Name 'Operating system'
+    New-BGInfoValue -Name 'Support' -Value 'helpdesk@contoso.com'
+} -MonitorIndex 0 `
+    -Target File `
+    -ConfigurationDirectory 'C:\ProgramData\PowerBGInfo' `
+    -JsonPath $configPath `
+    -ExportOnly
+
+Invoke-BGInfo -Path $configPath
+```
+
+Keep the JSON beside the deployment policy, test with file output first, and run the final user or system target from the appropriate security context.

--- a/Website/content/project-docs/docs/_index.md
+++ b/Website/content/project-docs/docs/_index.md
@@ -10,4 +10,8 @@ PowerBGInfo generates desktop background information from PowerShell-authored co
 
 - [Installation](./install/)
 - [Project overview](./overview/)
+- [Deployment](./deployment/)
+- [Layouts and visual overlays](./layouts-and-overlays/)
+- [Troubleshooting](./troubleshooting/)
+- [Curated examples](/projects/powerbginfo/examples/)
 - [Back to project overview](/projects/powerbginfo/)

--- a/Website/content/project-docs/docs/deployment.md
+++ b/Website/content/project-docs/docs/deployment.md
@@ -1,0 +1,29 @@
+---
+title: "Deploy and refresh PowerBGInfo"
+description: "Choose the PowerBGInfo target and refresh model for user, fleet, and logon backgrounds."
+layout: docs
+---
+
+PowerBGInfo can render a file, change the current desktop, stage a background for multiple profiles, or update the Windows logon screen. Choose the narrowest target that matches the job.
+
+## Preview before applying
+
+Use `-Target File` and `-OutputFileName` while authoring a layout. This creates an inspectable image without changing the current user environment.
+
+## Current user
+
+The default workflow renders for the selected monitor and applies the output to the current user. Run it at sign-in or from a scheduled task when values need periodic refresh.
+
+## Existing and future users
+
+Use `-AllUsers` from an elevated process to stage the same generated background for existing profiles and the default profile. Add `-ExcludeDefaultUserProfile` when new profiles should retain their own default.
+
+## Logon and lock screen
+
+`-Target LogonScreen` and `-Target Both` require elevation because they update system-level settings. Validate this path on the Windows version and management baseline used by the fleet.
+
+## Slideshows and caching
+
+When the current desktop is a slideshow, PowerBGInfo can render each source and preserve slideshow behavior. Use `-DisableWallpaperSlideshow` for one static result. Keep the default refresh behavior unless a deployment has a specific reason to avoid it; Windows can otherwise reuse a cached wallpaper path after sign-in.
+
+Export JSON configuration when the layout should be versioned separately from the deployment script, then call `Invoke-BGInfo` from the scheduled or RMM workflow.

--- a/Website/content/project-docs/docs/install.md
+++ b/Website/content/project-docs/docs/install.md
@@ -12,7 +12,18 @@ Install PowerBGInfo before trying the curated desktop background examples.
 Install-Module PowerBGInfo -Scope CurrentUser
 ```
 
+Import the module and inspect the exact commands in the installed release:
+
+```powershell
+Import-Module PowerBGInfo
+Get-Command -Module PowerBGInfo
+```
+
+PowerBGInfo supports Windows PowerShell 5.1 and PowerShell 7+ on Windows. Current 2.x packages include the required rendering and desktop-management assemblies; separate installs of ImagePlayground or DesktopManager are not required.
+
 ## Next steps
 
 - Review the [project overview](../overview/)
+- Read [deployment and refresh guidance](../deployment/)
+- Browse the [PowerShell API reference](/projects/powerbginfo/api/)
 - Browse the [curated examples](/projects/powerbginfo/examples/)

--- a/Website/content/project-docs/docs/layouts-and-overlays.md
+++ b/Website/content/project-docs/docs/layouts-and-overlays.md
@@ -1,0 +1,25 @@
+---
+title: "Layouts, charts, and topology"
+description: "Compose PowerBGInfo values, visual-canvas tiles, charts, and topology on Windows backgrounds."
+layout: docs
+---
+
+Start with the information a person needs while looking at the desktop. A useful background answers identity, ownership, purpose, support, or current-state questions at a glance; it does not need to become a full dashboard.
+
+## Text and sections
+
+Use `New-BGInfoValue` for built-in or custom data and `New-BGInfoLabel` for section headings. Parent settings on `New-BGInfo` provide consistent font, color, spacing, and wrapping defaults, while individual values can override them.
+
+## Images and tiles
+
+`New-BGInfoImage` places a reusable image asset. Visual canvas commands arrange exact-value tiles, sections, and compact visual blocks when plain text needs more structure.
+
+## Charts
+
+`New-BGInfoChart` renders ChartForgeX charts as transparent overlays. Small trends, targets, capacity, or service-state summaries work best. Keep labels readable against the selected wallpaper and test the output at the actual monitor resolution.
+
+## Topology
+
+`New-BGInfoTopology` can show a compact service route, lab layout, tenant boundary, or ownership hierarchy. Use it when relationships matter; use text values when the relationship itself adds no information.
+
+All overlays are composed into the final wallpaper, so the deployed desktop does not need a browser or JavaScript runtime.

--- a/Website/content/project-docs/docs/overview.md
+++ b/Website/content/project-docs/docs/overview.md
@@ -4,15 +4,26 @@ description: "PowerBGInfo generates desktop background information from PowerShe
 layout: docs
 ---
 
-Use PowerBGInfo when endpoint background information needs to be generated from repeatable scripts, JSON configuration, or a CLI-driven deployment process.
+PowerBGInfo generates Windows desktop and logon backgrounds from PowerShell data. Use it for lab machines, shared admin workstations, support desktops, build hosts, classrooms, kiosks, and environments where machine identity or operational context should be visible at a glance.
 
 ## Typical use
 
-- desktop wallpaper information panels
-- PowerShell-authored endpoint inventory layouts
-- CLI-friendly background generation workflows
+- show host, user, operating system, CPU, memory, BIOS, disk, and network details
+- add values collected from PowerShell, CIM, registry, Active Directory, APIs, or RMM tools
+- position content by corner, center anchor, or explicit screen coordinates
+- add transparent ChartForgeX charts, topology, images, and visual-canvas tiles
+- preserve wallpaper slideshows or render a solid-color background when no wallpaper file exists
+- apply output to the current user, all users, the logon screen, both targets, or a preview file only
+- export JSON configuration for scheduled tasks, RMM, imaging, or repeatable deployment
+
+PowerBGInfo is the Windows wallpaper product. Image composition and deterministic visuals are provided by [ChartForgeX](/projects/chartforgex/), while [ImagePlayground](/projects/imageplayground/) exposes broader image automation through PowerShell.
 
 ## Related project pages
 
 - [Project overview](/projects/powerbginfo/)
+- [Installation](../install/)
+- [Deployment and refresh](../deployment/)
+- [Layouts, charts, and topology](../layouts-and-overlays/)
+- [Troubleshooting](../troubleshooting/)
+- [PowerShell API](/projects/powerbginfo/api/)
 - [Examples](/projects/powerbginfo/examples/)

--- a/Website/content/project-docs/docs/troubleshooting.md
+++ b/Website/content/project-docs/docs/troubleshooting.md
@@ -1,0 +1,27 @@
+---
+title: "PowerBGInfo troubleshooting"
+description: "Diagnose wallpaper placement, permissions, caching, and PowerShell host issues."
+layout: docs
+---
+
+## Content is outside the visible area
+
+Check the monitor index, resolution, wallpaper fit, text anchor, and whether screen coordinates are enabled. Author the layout with `-Target File` at the target dimensions before applying it.
+
+## The old wallpaper remains visible
+
+Keep the default refresh behavior enabled. Windows may cache a wallpaper path even when the file changed. For a slideshow, verify whether the deployment should preserve the slideshow or use `-DisableWallpaperSlideshow`.
+
+## All-users or logon output fails
+
+Run from an elevated process and confirm that endpoint policy allows the relevant system setting. Current-user and file-only targets do not require the same system-wide writes.
+
+## Text is hard to read
+
+Use a contrasting color, add a visual-canvas panel, or select a less busy part of the wallpaper. Validate at normal desktop scaling instead of only zooming into the generated image.
+
+## Windows PowerShell 5.1 in VS Code
+
+There is a known host-specific issue with the VS Code PowerShell extension on Windows PowerShell 5.1. Use the regular Windows PowerShell console, Windows PowerShell ISE, or PowerShell 7+ for that workflow.
+
+For parameter details and supported values, open the [PowerShell API reference](/projects/powerbginfo/api/).

--- a/WebsiteArtifacts/project-manifest.json
+++ b/WebsiteArtifacts/project-manifest.json
@@ -1,0 +1,28 @@
+{
+  "slug": "powerbginfo",
+  "name": "PowerBGInfo",
+  "description": "Generate support-ready Windows desktop and logon backgrounds from PowerShell data, charts, and topology.",
+  "mode": "hub-full",
+  "contentMode": "hybrid",
+  "status": "active",
+  "listed": true,
+  "sourceRef": "v2-speedygonzales",
+  "links": {
+    "source": "https://github.com/EvotecIT/PowerBGInfo",
+    "powerShellGallery": "https://www.powershellgallery.com/packages/PowerBGInfo",
+    "releases": "https://github.com/EvotecIT/PowerBGInfo/releases"
+  },
+  "surfaces": {
+    "docs": true,
+    "apiPowerShell": true,
+    "apiDotNet": false,
+    "examples": true,
+    "downloads": true,
+    "releases": true,
+    "changelog": true
+  },
+  "artifacts": {
+    "docs": "Website/content/project-docs",
+    "examples": "Website/content/examples"
+  }
+}


### PR DESCRIPTION
## What changed

- add the PowerBGInfo website manifest for its current 2.x development line
- expand installation and product-overview guidance
- add focused deployment, layout/overlay, and troubleshooting documentation
- add curated configuration, chart, topology, and visual-canvas examples
- expose the PowerShell API and examples as distinct website surfaces

The docs keep PowerBGInfo focused on Windows background deployment, placement, caching, and refresh while identifying ChartForgeX as the reusable visual-rendering owner.