### PR TITLE
Consume the RDS-safe DesktopManager wallpaper fallback

### DIFF
--- a/Sources/PowerBGInfo/PowerBGInfo.csproj
+++ b/Sources/PowerBGInfo/PowerBGInfo.csproj
@@ -18,7 +18,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="DesktopManager" Version="3.6.4" />
+        <PackageReference Include="DesktopManager" Version="4.4.0" />
     </ItemGroup>
     <ItemGroup Condition="'$(ChartForgeXProjectPath)' != ''">
         <ProjectReference Include="$(ChartForgeXProjectPath)" />

--- a/Sources/PowerBGInfo/PowerBGInfo.csproj
+++ b/Sources/PowerBGInfo/PowerBGInfo.csproj
@@ -18,7 +18,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="DesktopManager" Version="3.6.3" />
+        <PackageReference Include="DesktopManager" Version="3.6.4" />
     </ItemGroup>
     <ItemGroup Condition="'$(ChartForgeXProjectPath)' != ''">
         <ProjectReference Include="$(ChartForgeXProjectPath)" />


### PR DESCRIPTION
## Summary

- update PowerBGInfo to the published DesktopManager 4.4.0 package
- consume DesktopManager's canonical fallback for RDS sessions that report a monitor without a display device
- keep PowerBGInfo free of package-version probes or a second wallpaper implementation

DesktopManager 4.4.0 is available from [NuGet](https://www.nuget.org/packages/DesktopManager/4.4.0), [PowerShell Gallery](https://www.powershellgallery.com/packages/DesktopManager/4.4.0), and the [GitHub release](https://github.com/EvotecIT/DesktopManager/releases/tag/DesktopManager-PowerShellModule.v4.4.0).

Closes #71
